### PR TITLE
ci: phased pipeline + pre-push quality hook

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -28,9 +28,9 @@ Start work on issue `$ARGUMENTS`. Required arg: the issue number (accepts `42` o
    - Cap at 60 characters (cut on a `-` boundary if possible).
    - Branch name is `<n>-<slug>`. Example: issue 5 titled "Server OAuth: Discord + Google, JWT, refresh tokens, /me" → `5-server-oauth-discord-google-jwt-refresh-tokens-me`.
 
-6. **Create the branch off latest `main`:**
-   - `git fetch origin main`
-   - `git switch -c <n>-<slug> origin/main`
-   - If `git switch -c` fails because the branch already exists, stop and suggest `git switch <n>-<slug>` instead — do not overwrite.
+6. **Create the branch off latest `main`, linked to the issue:**
+   - `gh issue develop <n> --name <n>-<slug> --base main --checkout`
+   - This creates the branch on origin **and** registers it as a linked branch on the GitHub issue (shows up in the "Development" section), then checks it out locally.
+   - If the command fails because a linked/branch already exists, stop and suggest `git switch <n>-<slug>` instead — do not overwrite.
 
 7. **Confirm** with one line: the new branch name and a pointer back to the issue URL (`gh issue view <n> --json url --jq .url`).

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -33,4 +33,8 @@ Start work on issue `$ARGUMENTS`. Required arg: the issue number (accepts `42` o
    - This creates the branch on origin **and** registers it as a linked branch on the GitHub issue (shows up in the "Development" section), then checks it out locally.
    - If the command fails because a linked/branch already exists, stop and suggest `git switch <n>-<slug>` instead — do not overwrite.
 
-7. **Confirm** with one line: the new branch name and a pointer back to the issue URL (`gh issue view <n> --json url --jq .url`).
+7. **Verify the branch tracks itself, not `main`.** If upstream is wrong, `git push` will try to rewrite `main` and get rejected by branch protection. Run:
+   - `git rev-parse --abbrev-ref --symbolic-full-name @{u}` — expected output: `origin/<n>-<slug>`.
+   - If it prints `origin/main` (or errors), fix immediately: `git branch --set-upstream-to=origin/<n>-<slug>`.
+
+8. **Confirm** with one line: the new branch name and a pointer back to the issue URL (`gh issue view <n> --json url --jq .url`).

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -28,13 +28,9 @@ Start work on issue `$ARGUMENTS`. Required arg: the issue number (accepts `42` o
    - Cap at 60 characters (cut on a `-` boundary if possible).
    - Branch name is `<n>-<slug>`. Example: issue 5 titled "Server OAuth: Discord + Google, JWT, refresh tokens, /me" → `5-server-oauth-discord-google-jwt-refresh-tokens-me`.
 
-6. **Create the branch off latest `main`, linked to the issue:**
+6. **Create the branch, linked to the issue:**
    - `gh issue develop <n> --name <n>-<slug> --base main --checkout`
-   - This creates the branch on origin **and** registers it as a linked branch on the GitHub issue (shows up in the "Development" section), then checks it out locally.
-   - If the command fails because a linked/branch already exists, stop and suggest `git switch <n>-<slug>` instead — do not overwrite.
+   - One command: creates the branch on origin, links it to the issue (shows in the issue's "Development" section), and checks it out locally with correct upstream tracking.
+   - If it fails because the branch already exists, stop and suggest `git switch <n>-<slug>` — do not overwrite.
 
-7. **Verify the branch tracks itself, not `main`.** If upstream is wrong, `git push` will try to rewrite `main` and get rejected by branch protection. Run:
-   - `git rev-parse --abbrev-ref --symbolic-full-name @{u}` — expected output: `origin/<n>-<slug>`.
-   - If it prints `origin/main` (or errors), fix immediately: `git branch --set-upstream-to=origin/<n>-<slug>`.
-
-8. **Confirm** with one line: the new branch name and a pointer back to the issue URL (`gh issue view <n> --json url --jq .url`).
+7. **Confirm** with one line: the new branch name and a pointer back to the issue URL (`gh issue view <n> --json url --jq .url`).

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -72,4 +72,9 @@ if [ -n "$touched_web" ]; then
   )
 fi
 
+if command -v graphify >/dev/null 2>&1; then
+  echo "pre-push: refreshing graphify index…"
+  graphify update . || echo "pre-push: graphify update failed, continuing."
+fi
+
 echo "pre-push: all checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -66,7 +66,7 @@ if [ -n "$touched_web" ]; then
     cd web
     bun install --frozen-lockfile
     bun run format:check
-    bun run lint
+    bun run lint:check
     bun run build
     bun run test:unit
   )

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Mirrors CI: runs the checks CI runs, locally, scoped to what changed.
+# Bypass: `PREPUSH_SKIP=1 git push` or `git push --no-verify`.
+
+set -eu
+
+if [ "${PREPUSH_SKIP:-0}" = "1" ]; then
+  echo "pre-push: PREPUSH_SKIP=1 — skipping checks."
+  exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+zero='0000000000000000000000000000000000000000'
+changed_files=''
+
+# stdin: <local_ref> <local_sha> <remote_ref> <remote_sha>
+while read -r _ local_sha _ remote_sha; do
+  [ -z "$local_sha" ] && continue
+  if [ "$local_sha" = "$zero" ]; then
+    # branch deletion — nothing to check
+    continue
+  fi
+  if [ "$remote_sha" = "$zero" ]; then
+    # new branch — diff against the upstream default (origin/main)
+    base=$(git merge-base "$local_sha" origin/main 2>/dev/null || echo "")
+    if [ -z "$base" ]; then
+      range_files=$(git show --name-only --pretty=format: "$local_sha")
+    else
+      range_files=$(git diff --name-only "$base" "$local_sha")
+    fi
+  else
+    range_files=$(git diff --name-only "$remote_sha" "$local_sha")
+  fi
+  changed_files="$changed_files
+$range_files"
+done
+
+if [ -z "$(echo "$changed_files" | tr -d '[:space:]')" ]; then
+  echo "pre-push: no commits to check."
+  exit 0
+fi
+
+touched_server=$(echo "$changed_files" | grep -E '^server/' || true)
+touched_web=$(echo "$changed_files" | grep -E '^web/' || true)
+
+if [ -z "$touched_server" ] && [ -z "$touched_web" ]; then
+  echo "pre-push: no changes under server/ or web/ — skipping."
+  exit 0
+fi
+
+if [ -n "$touched_server" ]; then
+  echo "pre-push: running server checks…"
+  (
+    cd server
+    dotnet build --configuration Release
+    dotnet format --verify-no-changes --no-restore
+    dotnet test --no-build --configuration Release
+  )
+fi
+
+if [ -n "$touched_web" ]; then
+  echo "pre-push: running web checks…"
+  (
+    cd web
+    bun install --frozen-lockfile
+    bun run format:check
+    bun run lint
+    bun run build
+    bun run test:unit
+  )
+fi
+
+echo "pre-push: all checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -26,7 +26,7 @@ while read -r _ local_sha _ remote_sha; do
     # new branch — diff against the upstream default (origin/main)
     base=$(git merge-base "$local_sha" origin/main 2>/dev/null || echo "")
     if [ -z "$base" ]; then
-      range_files=$(git show --name-only --pretty=format: "$local_sha")
+      range_files=$(git log --name-only --pretty=format: "$local_sha")
     else
       range_files=$(git diff --name-only "$base" "$local_sha")
     fi

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -12,6 +12,10 @@ on:
       - 'server/**'
       - '.github/workflows/server.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -26,13 +30,27 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('server/**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore tools
+        run: dotnet tool restore
 
       - name: Restore dependencies
         run: dotnet restore
 
       - name: Build
         run: dotnet build --no-restore --configuration Release
+
+      - name: Format check
+        run: dotnet format --verify-no-changes --no-restore
 
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -17,13 +17,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
-
     defaults:
       run:
         working-directory: server
-
     steps:
       - uses: actions/checkout@v4
 
@@ -49,8 +47,58 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
+  format:
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('server/**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Format check
         run: dotnet format --verify-no-changes --no-restore
 
+  test:
+    needs: format
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('server/**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal
+        run: dotnet test --configuration Release --verbosity normal

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -12,6 +12,10 @@ on:
       - 'web/**'
       - '.github/workflows/web.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -26,19 +30,19 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: web/package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Format check
+        run: bun run format:check
+
       - name: Lint
         run: bun run lint
 
-      - name: Type check
-        run: bun run type-check
+      - name: Build
+        run: bun run build
 
       - name: Test
         run: bun run test:unit
-
-      - name: Build
-        run: bun run build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -39,7 +39,7 @@ jobs:
         run: bun run format:check
 
       - name: Lint
-        run: bun run lint
+        run: bun run lint:check
 
       - name: Build
         run: bun run build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -17,13 +17,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
-
     defaults:
       run:
         working-directory: web
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: web/package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+  format:
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v4
 
@@ -41,8 +59,22 @@ jobs:
       - name: Lint
         run: bun run lint:check
 
-      - name: Build
-        run: bun run build
+  test:
+    needs: format
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: web/package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Test
         run: bun run test:unit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,12 @@ make clean                    # Stop and remove volumes
 make logs                     # View infrastructure logs
 ```
 
+### Git hooks
+```bash
+make hooks                    # One-time: install pre-push hook via core.hooksPath
+```
+Hook lives at `.githooks/pre-push` and mirrors CI, scoped to changed top-level dirs (`server/` or `web/`). Bypass with `PREPUSH_SKIP=1 git push` or `git push --no-verify`.
+
 ### Server (from repository root)
 ```bash
 dotnet build server           # Build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down clean logs server server-build server-test web web-install web-build web-test web-lint dev-all
+.PHONY: up down clean logs server server-build server-test web web-install web-build web-test web-lint dev-all hooks
 
 # Infrastructure
 up:
@@ -44,3 +44,8 @@ dev-all: up
 	@trap 'kill 0' EXIT; \
 	dotnet watch --project server/src/GankedTV.Api & \
 	cd web && bun dev
+
+# Git hooks — point git at the tracked .githooks/ directory.
+hooks:
+	git config core.hooksPath .githooks
+	@echo "pre-push hook active. Bypass with PREPUSH_SKIP=1 or git push --no-verify."

--- a/Makefile
+++ b/Makefile
@@ -47,5 +47,5 @@ dev-all: up
 
 # Git hooks — point git at the tracked .githooks/ directory.
 hooks:
-	git config core.hooksPath .githooks
+	git config --local core.hooksPath .githooks
 	@echo "pre-push hook active. Bypass with PREPUSH_SKIP=1 or git push --no-verify."

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ bun run lint              # Run linter
 bun run test:unit         # Run tests
 ```
 
+### Local quality gate
+
+Run once to install the pre-push git hook:
+
+```bash
+make hooks
+```
+
+This points git at `.githooks/` (via `core.hooksPath`). On `git push`, the hook runs the same checks CI runs, scoped to whichever top-level area changed (`server/` or `web/`). Bypass with `PREPUSH_SKIP=1 git push` or `git push --no-verify` when truly needed.
+
 ## Docker
 
 ### Start Infrastructure

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -29,15 +29,15 @@ builder.Services.AddDbContext<GankedTvDbContext>(opts =>
 
 builder.Services.Configure<MinioOptions>(opts =>
 {
-    opts.Endpoint  = Environment.GetEnvironmentVariable("S3_ENDPOINT")   ?? builder.Configuration["Minio:Endpoint"]  ?? "http://localhost:9000";
+    opts.Endpoint = Environment.GetEnvironmentVariable("S3_ENDPOINT") ?? builder.Configuration["Minio:Endpoint"] ?? "http://localhost:9000";
     opts.AccessKey = Environment.GetEnvironmentVariable("S3_ACCESS_KEY") ?? builder.Configuration["Minio:AccessKey"] ?? "minioadmin";
     opts.SecretKey = Environment.GetEnvironmentVariable("S3_SECRET_KEY") ?? builder.Configuration["Minio:SecretKey"] ?? "minioadmin";
     // .env.example ships `S3_PUBLIC_URL=` (empty); treat empty/whitespace as unset so the config fallback wins.
-    var envPublic  = Environment.GetEnvironmentVariable("S3_PUBLIC_URL");
+    var envPublic = Environment.GetEnvironmentVariable("S3_PUBLIC_URL");
     opts.PublicUrl = !string.IsNullOrWhiteSpace(envPublic) ? envPublic : builder.Configuration["Minio:PublicUrl"];
-    var clips      = builder.Configuration["Minio:ClipsBucket"];
-    var thumbs     = builder.Configuration["Minio:ThumbnailsBucket"];
-    if (!string.IsNullOrWhiteSpace(clips))  opts.ClipsBucket = clips;
+    var clips = builder.Configuration["Minio:ClipsBucket"];
+    var thumbs = builder.Configuration["Minio:ThumbnailsBucket"];
+    if (!string.IsNullOrWhiteSpace(clips)) opts.ClipsBucket = clips;
     if (!string.IsNullOrWhiteSpace(thumbs)) opts.ThumbnailsBucket = thumbs;
 });
 
@@ -59,10 +59,10 @@ builder.Services.AddHostedService<BucketBootstrapHostedService>();
 builder.Services.AddOptions<JwtOptions>()
     .Configure(opts =>
     {
-        opts.Secret   = Environment.GetEnvironmentVariable("JWT_SECRET")   ?? builder.Configuration["Jwt:Secret"]   ?? "";
-        opts.Issuer   = Environment.GetEnvironmentVariable("JWT_ISSUER")   ?? builder.Configuration["Jwt:Issuer"]   ?? "gankedtv";
+        opts.Secret = Environment.GetEnvironmentVariable("JWT_SECRET") ?? builder.Configuration["Jwt:Secret"] ?? "";
+        opts.Issuer = Environment.GetEnvironmentVariable("JWT_ISSUER") ?? builder.Configuration["Jwt:Issuer"] ?? "gankedtv";
         opts.Audience = Environment.GetEnvironmentVariable("JWT_AUDIENCE") ?? builder.Configuration["Jwt:Audience"] ?? "gankedtv-web";
-        var expiry    = Environment.GetEnvironmentVariable("JWT_EXPIRY_MINUTES") ?? builder.Configuration["Jwt:ExpiryMinutes"];
+        var expiry = Environment.GetEnvironmentVariable("JWT_EXPIRY_MINUTES") ?? builder.Configuration["Jwt:ExpiryMinutes"];
         if (int.TryParse(expiry, out var mins) && mins > 0) opts.ExpiryMinutes = mins;
     })
     .Validate(o => Encoding.UTF8.GetByteCount(o.Secret) >= 32,
@@ -85,13 +85,13 @@ builder.Services.AddOptions<OAuthOptions>()
     .Configure(opts =>
     {
         opts.StateSecret = Environment.GetEnvironmentVariable("OAUTH_STATE_SECRET") ?? builder.Configuration["OAuth:StateSecret"] ?? "";
-        opts.WebOrigin   = Environment.GetEnvironmentVariable("WEB_ORIGIN")         ?? builder.Configuration["OAuth:WebOrigin"]   ?? "http://localhost:5173";
-        opts.Discord.ClientId     = Environment.GetEnvironmentVariable("DISCORD_CLIENT_ID")     ?? builder.Configuration["OAuth:Discord:ClientId"]     ?? "";
+        opts.WebOrigin = Environment.GetEnvironmentVariable("WEB_ORIGIN") ?? builder.Configuration["OAuth:WebOrigin"] ?? "http://localhost:5173";
+        opts.Discord.ClientId = Environment.GetEnvironmentVariable("DISCORD_CLIENT_ID") ?? builder.Configuration["OAuth:Discord:ClientId"] ?? "";
         opts.Discord.ClientSecret = Environment.GetEnvironmentVariable("DISCORD_CLIENT_SECRET") ?? builder.Configuration["OAuth:Discord:ClientSecret"] ?? "";
-        opts.Discord.RedirectUri  = Environment.GetEnvironmentVariable("DISCORD_REDIRECT_URI")  ?? builder.Configuration["OAuth:Discord:RedirectUri"]  ?? "";
-        opts.Google.ClientId      = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID")      ?? builder.Configuration["OAuth:Google:ClientId"]      ?? "";
-        opts.Google.ClientSecret  = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET")  ?? builder.Configuration["OAuth:Google:ClientSecret"]  ?? "";
-        opts.Google.RedirectUri   = Environment.GetEnvironmentVariable("GOOGLE_REDIRECT_URI")   ?? builder.Configuration["OAuth:Google:RedirectUri"]   ?? "";
+        opts.Discord.RedirectUri = Environment.GetEnvironmentVariable("DISCORD_REDIRECT_URI") ?? builder.Configuration["OAuth:Discord:RedirectUri"] ?? "";
+        opts.Google.ClientId = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") ?? builder.Configuration["OAuth:Google:ClientId"] ?? "";
+        opts.Google.ClientSecret = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET") ?? builder.Configuration["OAuth:Google:ClientSecret"] ?? "";
+        opts.Google.RedirectUri = Environment.GetEnvironmentVariable("GOOGLE_REDIRECT_URI") ?? builder.Configuration["OAuth:Google:RedirectUri"] ?? "";
     })
     .Validate(o => Encoding.UTF8.GetByteCount(o.StateSecret) >= 32,
         "OAUTH_STATE_SECRET must be at least 32 bytes.")

--- a/web/package.json
+++ b/web/package.json
@@ -11,9 +11,12 @@
     "test:unit": "vitest",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
-    "lint": "run-s lint:*",
+    "lint": "run-s lint:oxlint lint:eslint",
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache",
+    "lint:check": "run-s lint:oxlint:check lint:eslint:check",
+    "lint:oxlint:check": "oxlint .",
+    "lint:eslint:check": "eslint . --cache",
     "format": "prettier --write --experimental-cli src/",
     "format:check": "prettier --check src/"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.12",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -13,7 +14,8 @@
     "lint": "run-s lint:*",
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache",
-    "format": "prettier --write --experimental-cli src/"
+    "format": "prettier --write --experimental-cli src/",
+    "format:check": "prettier --check src/"
   },
   "dependencies": {
     "pinia": "^3.0.4",

--- a/web/src/assets/base.css
+++ b/web/src/assets/base.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
   /* Fonts */
@@ -53,7 +53,6 @@
 html {
   color-scheme: dark;
 }
-
 
 html.light {
   color-scheme: light;

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -34,12 +34,11 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
         GANKED<span class="text-brand-light">.TV</span>
       </RouterLink>
 
-      <nav class="hidden flex-1 items-center justify-center gap-1 sm:flex" aria-label="Main navigation">
-        <RouterLink
-          to="/"
-          :class="navLinkClass"
-          exact-active-class="nav-link--active"
-        >
+      <nav
+        class="hidden flex-1 items-center justify-center gap-1 sm:flex"
+        aria-label="Main navigation"
+      >
+        <RouterLink to="/" :class="navLinkClass" exact-active-class="nav-link--active">
           Home
         </RouterLink>
         <RouterLink
@@ -60,8 +59,19 @@ onUnmounted(() => window.removeEventListener('scroll', onScroll))
           aria-label="Toggle navigation"
           @click="menuOpen = !menuOpen"
         >
-          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path v-if="!menuOpen" stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          <svg
+            class="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path
+              v-if="!menuOpen"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M4 6h16M4 12h16M4 18h16"
+            />
             <path v-else stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>

--- a/web/src/components/ThemeToggle.vue
+++ b/web/src/components/ThemeToggle.vue
@@ -26,7 +26,9 @@ const theme = useThemeStore()
         aria-hidden="true"
       >
         <circle cx="12" cy="12" r="4" />
-        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        <path
+          d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"
+        />
       </svg>
       <svg
         v-else
@@ -52,7 +54,9 @@ const theme = useThemeStore()
 /* Kept only for Vue Transition hooks — cannot be expressed as Tailwind utilities */
 .icon-enter-active,
 .icon-leave-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
 
 .icon-enter-from {

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] gap-3">
-    <h1 class="font-heading text-3xl font-bold uppercase tracking-wide text-text-primary">Sign In</h1>
+    <h1 class="font-heading text-3xl font-bold uppercase tracking-wide text-text-primary">
+      Sign In
+    </h1>
     <p class="font-body text-base text-text-secondary">Connect with Discord or Google</p>
   </div>
 </template>

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] gap-3">
-    <h1 class="font-heading text-3xl font-bold uppercase tracking-wide text-text-primary">Upload Clip</h1>
+    <h1 class="font-heading text-3xl font-bold uppercase tracking-wide text-text-primary">
+      Upload Clip
+    </h1>
     <p class="font-body text-base text-text-secondary">Share your best gaming moments</p>
   </div>
 </template>

--- a/web/src/views/UserView.vue
+++ b/web/src/views/UserView.vue
@@ -5,7 +5,9 @@ const route = useRoute()
 
 <template>
   <div class="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] gap-3">
-    <h1 class="font-heading text-3xl font-bold uppercase tracking-wide text-text-primary">Profile</h1>
+    <h1 class="font-heading text-3xl font-bold uppercase tracking-wide text-text-primary">
+      Profile
+    </h1>
     <p class="font-mono text-sm text-neon">@{{ route.params.username }}</p>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Restructures CI into phased stages (build → format → test, chained via `needs:`) so failures surface at the first relevant phase and runner minutes aren't wasted on downstream phases. Adds a pre-push git hook that mirrors CI locally so contributors catch issues before pushing, and hardens the `/issue` slash command so branches are linked to their GitHub issue with correct upstream tracking.

## What's here

- **CI phased jobs.** Both `server.yml` and `web.yml` now have three jobs: `build`, `format` (`needs: build`), `test` (`needs: format`). Each phase is a separate status check on PRs; a format failure short-circuits the test phase.
- **`.NET` drift fix.** Pinned to `10.0.x` (was `9.0.x` against a `net10.0` project). NuGet cache added.
- **Bun pinned** via `packageManager` + `bun-version-file` so `latest` doesn't drift under us.
- **Per-PR concurrency groups** cancel superseded runs on force-push.
- **New `dotnet format --verify-no-changes` gate** on server.
- **New `prettier --check src/` gate** on web, plus a non-mutating `lint:check` (splits the existing `--fix` lint into a check-only variant so CI and the hook don't silently rewrite files).
- **Pre-push hook** at `.githooks/pre-push` — POSIX, scoped to `server/` vs `web/`, mirrors CI. Activate with `make hooks`. Bypass with `PREPUSH_SKIP=1 git push` or `--no-verify`.
- **`/issue` slash command** now uses `gh issue develop --checkout` — creates the branch on origin, links it to the issue (shows in the "Development" section), sets upstream to the branch itself rather than `main` (the old behavior caused `git push` to target `main` and get rejected by branch protection).
- **Format auto-fixes** (whitespace in `Program.cs`, 6 Vue/CSS files via Prettier) so the new gates land green. No behavior changes.
- **Docs** — `README.md` + `CLAUDE.md` cover the `make hooks` step and bypass options.

## Out of scope (deferred)

- Coverage upload / artifact publishing — issue's optional "cleanup" phase.
- Adding `dotnet-format` to `server/.config/dotnet-tools.json` — `dotnet format` ships in the .NET SDK since .NET 6, no separate install needed.
- Branch protection reconfiguration — the required check names will change (was `build-and-test`, now `build` / `format` / `test` per workflow). Repo admin needs to update required status checks on `main` once this merges.

Closes #21

## How to test manually

1. `make hooks` — installs the pre-push hook via `core.hooksPath`.
2. Introduce a formatting issue under `web/src/` and attempt `git push` — hook fails at `bun run format:check`.
3. Introduce a whitespace issue under `server/` and attempt `git push` — hook fails at `dotnet format`.
4. Touch only `README.md` and `git push` — hook detects no changes under `server/` or `web/`, exits clean.
5. `PREPUSH_SKIP=1 git push` and `git push --no-verify` — both bypass.
6. Watch Actions on this PR: each workflow shows 3 separate job statuses (`build`, `format`, `test`), each runs only after the previous succeeds; concurrency cancels superseded runs.

## Checklist

- [x] Pre-push hook verified locally (simulated invocation + `git push --dry-run`).
- [x] `dotnet format --verify-no-changes --no-restore` passes from `server/`.
- [x] `bun run format:check`, `bun run lint:check`, `bun run build` pass from `web/`.
- [x] CI workflows target `.NET 10.0.x` and pinned Bun.
- [ ] Branch protection on `main` updated to require the new check names (`build`, `format`, `test`) once merged — manual repo admin step.
