### PR TITLE
Server clip create presign complete 3 step upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,12 @@ JWT_AUDIENCE=gankedtv-web
 JWT_EXPIRY_MINUTES=15
 REFRESH_TOKEN_EXPIRY_DAYS=30
 
-# OAuth
-# OAUTH_STATE_SECRET must be >= 32 bytes (generate with: openssl rand -hex 32)
+# OAuth — providers are OPTIONAL in development. Leave Discord/Google credentials empty
+# to run without them (the API will boot, GET /auth/providers will list only configured
+# ones, and the frontend should hide the buttons for the rest). In development you can
+# mint a local JWT via POST /dev/token without any OAuth setup.
+# OAUTH_STATE_SECRET only needs to be >= 32 bytes when at least one provider is configured
+# (generate with: openssl rand -hex 32).
 OAUTH_STATE_SECRET=
 WEB_ORIGIN=http://localhost:5173
 
@@ -37,3 +41,7 @@ DISCORD_REDIRECT_URI=http://localhost:5000/auth/discord/callback
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:5000/auth/google/callback
+
+# Clip upload limits
+MAX_UPLOAD_SIZE_MB=500
+MAX_CLIP_DURATION_SECS=120

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ web/cypress/videos/
 web/cypress/screenshots/
 
 server/postman
+
+# Graphify knowledge graph (regenerated locally via `graphify update .`)
+graphify-out/

--- a/server/src/GankedTV.Api/Auth/OAuthOptions.cs
+++ b/server/src/GankedTV.Api/Auth/OAuthOptions.cs
@@ -2,10 +2,12 @@ namespace GankedTV.Api.Auth;
 
 public sealed class OAuthOptions
 {
-    public required string StateSecret { get; set; }
+    public string StateSecret { get; set; } = "";
     public required string WebOrigin { get; set; }
     public OAuthProviderOptions Discord { get; set; } = new();
     public OAuthProviderOptions Google { get; set; } = new();
+
+    public bool AnyProviderConfigured => Discord.IsConfigured || Google.IsConfigured;
 }
 
 public sealed class OAuthProviderOptions
@@ -13,4 +15,9 @@ public sealed class OAuthProviderOptions
     public string ClientId { get; set; } = "";
     public string ClientSecret { get; set; } = "";
     public string RedirectUri { get; set; } = "";
+
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(ClientId)
+        && !string.IsNullOrWhiteSpace(ClientSecret)
+        && !string.IsNullOrWhiteSpace(RedirectUri);
 }

--- a/server/src/GankedTV.Api/Auth/Providers/OAuthProviderRegistry.cs
+++ b/server/src/GankedTV.Api/Auth/Providers/OAuthProviderRegistry.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Options;
 
 namespace GankedTV.Api.Auth.Providers;
 
@@ -6,11 +7,23 @@ public sealed class OAuthProviderRegistry
 {
     private readonly Dictionary<string, IOAuthProvider> _providers;
 
-    public OAuthProviderRegistry(IEnumerable<IOAuthProvider> providers)
+    public OAuthProviderRegistry(IEnumerable<IOAuthProvider> providers, IOptions<OAuthOptions> options)
     {
-        _providers = providers.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+        var opts = options.Value;
+        _providers = providers
+            .Where(p => IsConfigured(p.Name, opts))
+            .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
     }
 
     public bool TryGet(string name, [NotNullWhen(true)] out IOAuthProvider? provider) =>
         _providers.TryGetValue(name, out provider);
+
+    public IReadOnlyCollection<string> ConfiguredProviderNames => _providers.Keys;
+
+    private static bool IsConfigured(string name, OAuthOptions opts) => name switch
+    {
+        DiscordOAuthProvider.ProviderName => opts.Discord.IsConfigured,
+        GoogleOAuthProvider.ProviderName => opts.Google.IsConfigured,
+        _ => false,
+    };
 }

--- a/server/src/GankedTV.Api/Auth/State/StateCookieService.cs
+++ b/server/src/GankedTV.Api/Auth/State/StateCookieService.cs
@@ -9,20 +9,31 @@ public sealed class StateCookieService : IStateCookieService
     public const string CookieName = "gtv_oauth_state";
     public static readonly TimeSpan CookieTtl = TimeSpan.FromMinutes(5);
 
-    private readonly byte[] _secret;
+    private readonly IOptions<OAuthOptions> _options;
 
+    // Validation moved out of the ctor so DI resolution succeeds when OAuth is fully
+    // optional (no providers configured, no state secret). The `/auth/{provider}/start`
+    // handler takes a hard dependency on this service; throwing here would 500 every
+    // request to an unknown/unconfigured provider before the registry's 404 could fire.
+    // IssueState / ValidateState guard at use-time instead.
     public StateCookieService(IOptions<OAuthOptions> options)
     {
-        var secret = options.Value.StateSecret;
+        _options = options;
+    }
+
+    private byte[] RequireSecret()
+    {
+        var secret = _options.Value.StateSecret;
         if (string.IsNullOrWhiteSpace(secret))
         {
-            throw new InvalidOperationException("OAUTH_STATE_SECRET must be configured.");
+            throw new InvalidOperationException("OAUTH_STATE_SECRET must be configured to use OAuth state cookies.");
         }
-        _secret = Encoding.UTF8.GetBytes(secret);
+        return Encoding.UTF8.GetBytes(secret);
     }
 
     public string IssueState(string? returnTo)
     {
+        var secret = RequireSecret();
         Span<byte> nonceBytes = stackalloc byte[16];
         RandomNumberGenerator.Fill(nonceBytes);
         var nonce = Base64UrlEncode(nonceBytes);
@@ -30,12 +41,13 @@ public sealed class StateCookieService : IStateCookieService
         var returnToBytes = Encoding.UTF8.GetBytes(returnTo ?? "");
         var returnToPart = Base64UrlEncode(returnToBytes);
 
-        var hmac = ComputeHmac(nonce, returnToPart);
+        var hmac = ComputeHmac(secret, nonce, returnToPart);
         return $"{nonce}.{returnToPart}.{hmac}";
     }
 
     public StateValidationResult ValidateState(string stateParam, string? cookieValue)
     {
+        var secret = RequireSecret();
         if (string.IsNullOrEmpty(stateParam) || string.IsNullOrEmpty(cookieValue))
         {
             return StateValidationResult.Invalid;
@@ -52,7 +64,7 @@ public sealed class StateCookieService : IStateCookieService
             return StateValidationResult.Invalid;
         }
 
-        var expected = ComputeHmac(segments[0], segments[1]);
+        var expected = ComputeHmac(secret, segments[0], segments[1]);
         if (!FixedTimeEquals(expected, segments[2]))
         {
             return StateValidationResult.Invalid;
@@ -72,9 +84,9 @@ public sealed class StateCookieService : IStateCookieService
         return StateValidationResult.Valid(returnTo);
     }
 
-    private string ComputeHmac(string nonce, string returnToPart)
+    private static string ComputeHmac(byte[] secret, string nonce, string returnToPart)
     {
-        using var hmac = new HMACSHA256(_secret);
+        using var hmac = new HMACSHA256(secret);
         var payload = Encoding.UTF8.GetBytes($"{nonce}|{returnToPart}");
         var sig = hmac.ComputeHash(payload);
         return Base64UrlEncode(sig);

--- a/server/src/GankedTV.Api/Data/Entities/ClipStatuses.cs
+++ b/server/src/GankedTV.Api/Data/Entities/ClipStatuses.cs
@@ -1,0 +1,18 @@
+namespace GankedTV.Api.Data.Entities;
+
+public static class ClipStatuses
+{
+    public const string Draft = "draft";
+    public const string Processing = "processing";
+    public const string Ready = "ready";
+    public const string Failed = "failed";
+}
+
+public static class ClipVisibilities
+{
+    public const string Public = "public";
+    public const string Unlisted = "unlisted";
+
+    public static bool IsValid(string value) =>
+        value == Public || value == Unlisted;
+}

--- a/server/src/GankedTV.Api/Data/Entities/ClipStatuses.cs
+++ b/server/src/GankedTV.Api/Data/Entities/ClipStatuses.cs
@@ -14,5 +14,10 @@ public static class ClipVisibilities
     public const string Unlisted = "unlisted";
 
     public static bool IsValid(string value) =>
-        value == Public || value == Unlisted;
+        string.Equals(value, Public, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(value, Unlisted, StringComparison.OrdinalIgnoreCase);
+
+    // Callers receive the canonical lowercase form so the DB column stays consistent
+    // regardless of how the client cased the input.
+    public static string Normalize(string value) => value.ToLowerInvariant();
 }

--- a/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
@@ -16,11 +16,15 @@ public static class AuthEndpoints
 
     public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
     {
+        app.MapGet("/auth/providers", ListProviders);
         app.MapGet("/auth/{provider}/start", Start);
         app.MapGet("/auth/{provider}/callback", Callback);
         app.MapPost("/auth/refresh", Refresh);
         return app;
     }
+
+    private static IResult ListProviders(OAuthProviderRegistry registry) =>
+        Results.Ok(new { providers = registry.ConfiguredProviderNames });
 
     private static IResult Start(
         string provider,

--- a/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
@@ -2,11 +2,16 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using GankedTV.Api.Services.Clips;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace GankedTV.Api.Endpoints;
 
 public static class ClipsUploadEndpoints
 {
+    // Category used when logging unmapped enum values so the failure is traceable
+    // if a new ClipUploadError case is added without updating MapError.
+    private static readonly string LogCategory = typeof(ClipsUploadEndpoints).FullName!;
+
     public sealed record CreateClipRequest(
         string? Title,
         string? Description,
@@ -30,6 +35,7 @@ public static class ClipsUploadEndpoints
         [FromBody] CreateClipRequest? req,
         ClaimsPrincipal principal,
         IClipUploadService clips,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -51,13 +57,14 @@ public static class ClipsUploadEndpoints
 
         return result.IsSuccess
             ? Results.Ok(new CreateClipResponse(result.Value!.ClipId))
-            : MapError(result.Error!.Value);
+            : MapError(result.Error!.Value, loggerFactory);
     }
 
     private static async Task<IResult> GetUploadUrl(
         Guid id,
         ClaimsPrincipal principal,
         IClipUploadService clips,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -68,13 +75,14 @@ public static class ClipsUploadEndpoints
         var result = await clips.GetUploadUrlAsync(userId, id, ct);
         return result.IsSuccess
             ? Results.Ok(new UploadUrlResponse(result.Value!.Url, result.Value.ExpiresAt))
-            : MapError(result.Error!.Value);
+            : MapError(result.Error!.Value, loggerFactory);
     }
 
     private static async Task<IResult> CompleteClip(
         Guid id,
         ClaimsPrincipal principal,
         IClipUploadService clips,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -85,10 +93,10 @@ public static class ClipsUploadEndpoints
         var result = await clips.CompleteAsync(userId, id, ct);
         return result.IsSuccess
             ? Results.Ok(new CompleteClipResponse(result.Value!.ClipId, result.Value.FileSizeBytes))
-            : MapError(result.Error!.Value);
+            : MapError(result.Error!.Value, loggerFactory);
     }
 
-    private static IResult MapError(ClipUploadError error) => error switch
+    private static IResult MapError(ClipUploadError error, ILoggerFactory loggerFactory) => error switch
     {
         ClipUploadError.InvalidTitle => Results.BadRequest(new { error = "invalid_title" }),
         ClipUploadError.InvalidDescription => Results.BadRequest(new { error = "invalid_description" }),
@@ -98,8 +106,18 @@ public static class ClipsUploadEndpoints
         ClipUploadError.ObjectNotUploaded => Results.BadRequest(new { error = "object_not_uploaded" }),
         ClipUploadError.FileTooLarge => Results.BadRequest(new { error = "file_too_large" }),
         ClipUploadError.UnsupportedContentType => Results.BadRequest(new { error = "unsupported_content_type" }),
-        _ => Results.Problem(statusCode: 500),
+        _ => UnmappedError(error, loggerFactory),
     };
+
+    private static IResult UnmappedError(ClipUploadError error, ILoggerFactory loggerFactory)
+    {
+        loggerFactory.CreateLogger(LogCategory)
+            .LogError("Unmapped ClipUploadError value {Error}; add a case to MapError.", error);
+        return Results.Problem(
+            title: "unmapped_error",
+            detail: $"Unhandled error: {error}",
+            statusCode: StatusCodes.Status500InternalServerError);
+    }
 
     private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
     {

--- a/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
@@ -27,7 +27,7 @@ public static class ClipsUploadEndpoints
     }
 
     private static async Task<IResult> CreateClip(
-        [FromBody] CreateClipRequest req,
+        [FromBody] CreateClipRequest? req,
         ClaimsPrincipal principal,
         IClipUploadService clips,
         CancellationToken ct)
@@ -35,6 +35,13 @@ public static class ClipsUploadEndpoints
         if (!TryGetUserId(principal, out var userId))
         {
             return Results.Unauthorized();
+        }
+
+        // A literal JSON `null` body deserializes to a null reference even though the
+        // parameter type is non-nullable, so guard explicitly before dereferencing.
+        if (req is null)
+        {
+            return Results.BadRequest(new { error = "invalid_body" });
         }
 
         var result = await clips.CreateAsync(

--- a/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
@@ -1,0 +1,104 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using GankedTV.Api.Services.Clips;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class ClipsUploadEndpoints
+{
+    public sealed record CreateClipRequest(
+        string? Title,
+        string? Description,
+        int? GameId,
+        string? Visibility);
+
+    public sealed record CreateClipResponse(Guid Id);
+    public sealed record UploadUrlResponse(string Url, DateTimeOffset ExpiresAt);
+    public sealed record CompleteClipResponse(Guid Id, long FileSizeBytes);
+
+    public static IEndpointRouteBuilder MapClipsUploadEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/clips").RequireAuthorization();
+        group.MapPost("/", CreateClip);
+        group.MapPost("/{id:guid}/upload-url", GetUploadUrl);
+        group.MapPost("/{id:guid}/complete", CompleteClip);
+        return app;
+    }
+
+    private static async Task<IResult> CreateClip(
+        [FromBody] CreateClipRequest req,
+        ClaimsPrincipal principal,
+        IClipUploadService clips,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        var result = await clips.CreateAsync(
+            userId,
+            new CreateClipInput(req.Title, req.Description, req.GameId, req.Visibility),
+            ct);
+
+        return result.IsSuccess
+            ? Results.Ok(new CreateClipResponse(result.Value!.ClipId))
+            : MapError(result.Error!.Value);
+    }
+
+    private static async Task<IResult> GetUploadUrl(
+        Guid id,
+        ClaimsPrincipal principal,
+        IClipUploadService clips,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        var result = await clips.GetUploadUrlAsync(userId, id, ct);
+        return result.IsSuccess
+            ? Results.Ok(new UploadUrlResponse(result.Value!.Url, result.Value.ExpiresAt))
+            : MapError(result.Error!.Value);
+    }
+
+    private static async Task<IResult> CompleteClip(
+        Guid id,
+        ClaimsPrincipal principal,
+        IClipUploadService clips,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        var result = await clips.CompleteAsync(userId, id, ct);
+        return result.IsSuccess
+            ? Results.Ok(new CompleteClipResponse(result.Value!.ClipId, result.Value.FileSizeBytes))
+            : MapError(result.Error!.Value);
+    }
+
+    private static IResult MapError(ClipUploadError error) => error switch
+    {
+        ClipUploadError.InvalidTitle => Results.BadRequest(new { error = "invalid_title" }),
+        ClipUploadError.InvalidDescription => Results.BadRequest(new { error = "invalid_description" }),
+        ClipUploadError.InvalidVisibility => Results.BadRequest(new { error = "invalid_visibility" }),
+        ClipUploadError.NotFound => Results.NotFound(new { error = "not_found" }),
+        ClipUploadError.InvalidState => Results.BadRequest(new { error = "invalid_state" }),
+        ClipUploadError.ObjectNotUploaded => Results.BadRequest(new { error = "object_not_uploaded" }),
+        ClipUploadError.FileTooLarge => Results.BadRequest(new { error = "file_too_large" }),
+        ClipUploadError.UnsupportedContentType => Results.BadRequest(new { error = "unsupported_content_type" }),
+        _ => Results.Problem(statusCode: 500),
+    };
+
+    private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
+    {
+        userId = default;
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out userId);
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/DevAuthEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/DevAuthEndpoints.cs
@@ -1,0 +1,53 @@
+using GankedTV.Api.Auth;
+using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Endpoints;
+
+/// <summary>
+/// Dev-only helpers for local testing without OAuth credentials. These endpoints are
+/// only mapped when <see cref="IHostEnvironment.IsDevelopment"/> is true, so they are
+/// never exposed in Staging/Production regardless of how the host is configured.
+/// </summary>
+public static class DevAuthEndpoints
+{
+    public sealed record DevTokenRequest(string? Username);
+    public sealed record DevTokenResponse(string Token, Guid UserId, string Username);
+
+    public static IEndpointRouteBuilder MapDevAuthEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/dev/token", IssueDevToken);
+        return app;
+    }
+
+    private static async Task<IResult> IssueDevToken(
+        [FromBody] DevTokenRequest? req,
+        GankedTvDbContext db,
+        IJwtService jwt,
+        CancellationToken ct)
+    {
+        var raw = req?.Username ?? "dev-user";
+        var username = UsernameGenerator.Slugify(raw);
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Username == username, ct);
+        if (user is null)
+        {
+            var now = DateTimeOffset.UtcNow;
+            user = new User
+            {
+                Username = username,
+                Email = $"{username}@dev.local",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync(ct);
+        }
+
+        var token = jwt.Issue(user);
+        return Results.Ok(new DevTokenResponse(token, user.Id, user.Username));
+    }
+}

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -6,7 +6,9 @@ using GankedTV.Api.Auth.State;
 using GankedTV.Api.Auth.Tokens;
 using GankedTV.Api.Data;
 using GankedTV.Api.Endpoints;
+using GankedTV.Api.Services.Clips;
 using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -44,15 +46,38 @@ builder.Services.Configure<MinioOptions>(opts =>
 builder.Services.AddSingleton<IAmazonS3>(sp =>
 {
     var o = sp.GetRequiredService<IOptions<MinioOptions>>().Value;
+    // GetPreSignedURL in the AWS SDK defaults to https:// regardless of ServiceURL scheme
+    // unless UseHttp is set. MinIO in dev runs plain HTTP, so presigned PUTs fail TLS
+    // negotiation without this flag.
+    var useHttp = o.Endpoint.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
     return new AmazonS3Client(o.AccessKey, o.SecretKey, new AmazonS3Config
     {
         ServiceURL = o.Endpoint,
         ForcePathStyle = true,
+        UseHttp = useHttp,
     });
 });
 
 builder.Services.AddSingleton<IObjectStorageService, MinioObjectStorageService>();
 builder.Services.AddHostedService<BucketBootstrapHostedService>();
+
+builder.Services.AddOptions<ClipValidationOptions>()
+    .Configure(opts =>
+    {
+        var size = Environment.GetEnvironmentVariable("MAX_UPLOAD_SIZE_MB")
+            ?? builder.Configuration["Clips:MaxUploadSizeMb"];
+        if (int.TryParse(size, out var mb) && mb > 0) opts.MaxUploadSizeMb = mb;
+        var dur = Environment.GetEnvironmentVariable("MAX_CLIP_DURATION_SECS")
+            ?? builder.Configuration["Clips:MaxClipDurationSecs"];
+        if (int.TryParse(dur, out var secs) && secs > 0) opts.MaxClipDurationSecs = secs;
+    })
+    .Validate(o => o.MaxUploadSizeMb is > 0 and <= 5000,
+        "MAX_UPLOAD_SIZE_MB must be in [1, 5000].")
+    .Validate(o => o.MaxClipDurationSecs is > 0 and <= 3600,
+        "MAX_CLIP_DURATION_SECS must be in [1, 3600].")
+    .ValidateOnStart();
+
+builder.Services.AddScoped<IClipUploadService, ClipUploadService>();
 
 // ---- Auth configuration ----
 
@@ -93,8 +118,8 @@ builder.Services.AddOptions<OAuthOptions>()
         opts.Google.ClientSecret = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET") ?? builder.Configuration["OAuth:Google:ClientSecret"] ?? "";
         opts.Google.RedirectUri = Environment.GetEnvironmentVariable("GOOGLE_REDIRECT_URI") ?? builder.Configuration["OAuth:Google:RedirectUri"] ?? "";
     })
-    .Validate(o => Encoding.UTF8.GetByteCount(o.StateSecret) >= 32,
-        "OAUTH_STATE_SECRET must be at least 32 bytes.")
+    .Validate(o => !o.AnyProviderConfigured || Encoding.UTF8.GetByteCount(o.StateSecret) >= 32,
+        "OAUTH_STATE_SECRET must be at least 32 bytes when any OAuth provider is configured.")
     .Validate(o => !string.IsNullOrWhiteSpace(o.WebOrigin),
         "WEB_ORIGIN must be set.")
     .ValidateOnStart();
@@ -172,6 +197,12 @@ app.UseAuthorization();
 
 app.MapAuthEndpoints();
 app.MapMeEndpoints();
+app.MapClipsUploadEndpoints();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapDevAuthEndpoints();
+}
 
 app.Run();
 

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -46,15 +46,10 @@ builder.Services.Configure<MinioOptions>(opts =>
 builder.Services.AddSingleton<IAmazonS3>(sp =>
 {
     var o = sp.GetRequiredService<IOptions<MinioOptions>>().Value;
-    // GetPreSignedURL in the AWS SDK defaults to https:// regardless of ServiceURL scheme
-    // unless UseHttp is set. MinIO in dev runs plain HTTP, so presigned PUTs fail TLS
-    // negotiation without this flag.
-    var useHttp = o.Endpoint.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
     return new AmazonS3Client(o.AccessKey, o.SecretKey, new AmazonS3Config
     {
         ServiceURL = o.Endpoint,
         ForcePathStyle = true,
-        UseHttp = useHttp,
     });
 });
 
@@ -202,6 +197,9 @@ app.MapClipsUploadEndpoints();
 if (app.Environment.IsDevelopment())
 {
     app.MapDevAuthEndpoints();
+    app.Logger.LogWarning(
+        "Development mode: POST /dev/token is mapped and will mint JWTs without authentication. "
+        + "Ensure ASPNETCORE_ENVIRONMENT is NOT 'Development' in any internet-exposed deployment.");
 }
 
 app.Run();

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -59,11 +59,13 @@ builder.Services.AddHostedService<BucketBootstrapHostedService>();
 builder.Services.AddOptions<ClipValidationOptions>()
     .Configure(opts =>
     {
-        var size = Environment.GetEnvironmentVariable("MAX_UPLOAD_SIZE_MB")
-            ?? builder.Configuration["Clips:MaxUploadSizeMb"];
+        // Bind the full Clips section first so appsettings can configure
+        // AllowedContentTypes / MaxTitleLength / MaxDescriptionLength alongside the two
+        // env-var-only settings below.
+        builder.Configuration.GetSection("Clips").Bind(opts);
+        var size = Environment.GetEnvironmentVariable("MAX_UPLOAD_SIZE_MB");
         if (int.TryParse(size, out var mb) && mb > 0) opts.MaxUploadSizeMb = mb;
-        var dur = Environment.GetEnvironmentVariable("MAX_CLIP_DURATION_SECS")
-            ?? builder.Configuration["Clips:MaxClipDurationSecs"];
+        var dur = Environment.GetEnvironmentVariable("MAX_CLIP_DURATION_SECS");
         if (int.TryParse(dur, out var secs) && secs > 0) opts.MaxClipDurationSecs = secs;
     })
     .Validate(o => o.MaxUploadSizeMb is > 0 and <= 5000,

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -31,6 +31,11 @@ public sealed class ClipUploadService : IClipUploadService
         _clock = clock;
     }
 
+    // Shared content-type used both for signing the presigned PUT and for validating
+    // the uploaded object — keeps the two sides from drifting.
+    private string PrimaryContentType =>
+        _validation.AllowedContentTypes.FirstOrDefault() ?? "video/mp4";
+
     public async Task<ClipResult<CreateClipResult>> CreateAsync(
         Guid userId,
         CreateClipInput input,
@@ -98,7 +103,7 @@ public sealed class ClipUploadService : IClipUploadService
         var url = _storage.GetPresignedPutUrl(
             _minio.ClipsBucket,
             clip.VideoKey,
-            "video/mp4",
+            PrimaryContentType,
             UploadUrlExpiry);
         var expiresAt = _clock.GetUtcNow().Add(UploadUrlExpiry);
 
@@ -127,8 +132,10 @@ public sealed class ClipUploadService : IClipUploadService
         }
 
         var meta = await _storage.GetObjectMetadataAsync(_minio.ClipsBucket, clip.VideoKey, ct);
-        if (meta is null)
+        if (meta is null || meta.SizeBytes <= 0)
         {
+            // Treat a zero-byte object the same as missing — MinIO can accept an empty PUT,
+            // and a zero-length clip has no meaningful content to serve later.
             return ClipResult<CompleteClipResult>.Fail(ClipUploadError.ObjectNotUploaded);
         }
 

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -1,0 +1,179 @@
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Validation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Services.Clips;
+
+public sealed class ClipUploadService : IClipUploadService
+{
+    private static readonly TimeSpan UploadUrlExpiry = TimeSpan.FromMinutes(15);
+
+    private readonly GankedTvDbContext _db;
+    private readonly IObjectStorageService _storage;
+    private readonly ClipValidationOptions _validation;
+    private readonly MinioOptions _minio;
+    private readonly TimeProvider _clock;
+
+    public ClipUploadService(
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<ClipValidationOptions> validation,
+        IOptions<MinioOptions> minio,
+        TimeProvider clock)
+    {
+        _db = db;
+        _storage = storage;
+        _validation = validation.Value;
+        _minio = minio.Value;
+        _clock = clock;
+    }
+
+    public async Task<ClipResult<CreateClipResult>> CreateAsync(
+        Guid userId,
+        CreateClipInput input,
+        CancellationToken ct)
+    {
+        var title = input.Title?.Trim();
+        if (string.IsNullOrEmpty(title) || title.Length > _validation.MaxTitleLength)
+        {
+            return ClipResult<CreateClipResult>.Fail(ClipUploadError.InvalidTitle);
+        }
+
+        if (input.Description is { Length: var descLen } && descLen > _validation.MaxDescriptionLength)
+        {
+            return ClipResult<CreateClipResult>.Fail(ClipUploadError.InvalidDescription);
+        }
+
+        var visibility = input.Visibility ?? ClipVisibilities.Public;
+        if (!ClipVisibilities.IsValid(visibility))
+        {
+            return ClipResult<CreateClipResult>.Fail(ClipUploadError.InvalidVisibility);
+        }
+
+        var id = Guid.NewGuid();
+        var now = _clock.GetUtcNow();
+        var clip = new Clip
+        {
+            Id = id,
+            UserId = userId,
+            GameId = input.GameId,
+            Title = title,
+            Description = string.IsNullOrEmpty(input.Description) ? null : input.Description,
+            VideoKey = $"clips/{id}.mp4",
+            Status = ClipStatuses.Draft,
+            Visibility = visibility,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        _db.Clips.Add(clip);
+        await _db.SaveChangesAsync(ct);
+
+        return ClipResult<CreateClipResult>.Ok(new CreateClipResult(id));
+    }
+
+    public async Task<ClipResult<UploadUrlResult>> GetUploadUrlAsync(
+        Guid userId,
+        Guid clipId,
+        CancellationToken ct)
+    {
+        var clip = await _db.Clips
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == clipId && c.UserId == userId, ct);
+
+        if (clip is null)
+        {
+            return ClipResult<UploadUrlResult>.Fail(ClipUploadError.NotFound);
+        }
+
+        if (clip.Status != ClipStatuses.Draft)
+        {
+            return ClipResult<UploadUrlResult>.Fail(ClipUploadError.InvalidState);
+        }
+
+        var url = _storage.GetPresignedPutUrl(
+            _minio.ClipsBucket,
+            clip.VideoKey,
+            "video/mp4",
+            UploadUrlExpiry);
+        var expiresAt = _clock.GetUtcNow().Add(UploadUrlExpiry);
+
+        return ClipResult<UploadUrlResult>.Ok(new UploadUrlResult(url, expiresAt));
+    }
+
+    public async Task<ClipResult<CompleteClipResult>> CompleteAsync(
+        Guid userId,
+        Guid clipId,
+        CancellationToken ct)
+    {
+        var clip = await _db.Clips
+            .FirstOrDefaultAsync(c => c.Id == clipId && c.UserId == userId, ct);
+
+        if (clip is null)
+        {
+            return ClipResult<CompleteClipResult>.Fail(ClipUploadError.NotFound);
+        }
+
+        if (clip.Status != ClipStatuses.Draft)
+        {
+            return ClipResult<CompleteClipResult>.Fail(ClipUploadError.InvalidState);
+        }
+
+        var meta = await _storage.GetObjectMetadataAsync(_minio.ClipsBucket, clip.VideoKey, ct);
+        if (meta is null)
+        {
+            return ClipResult<CompleteClipResult>.Fail(ClipUploadError.ObjectNotUploaded);
+        }
+
+        if (meta.SizeBytes > _validation.MaxUploadSizeBytes)
+        {
+            return ClipResult<CompleteClipResult>.Fail(ClipUploadError.FileTooLarge);
+        }
+
+        if (!IsAllowedContentType(meta.ContentType))
+        {
+            return ClipResult<CompleteClipResult>.Fail(ClipUploadError.UnsupportedContentType);
+        }
+
+        // Conditional atomic update guards against two concurrent completes racing past
+        // the status check above and both flipping the row to ready.
+        var now = _clock.GetUtcNow();
+        var rowsAffected = await _db.Clips
+            .Where(c => c.Id == clipId && c.Status == ClipStatuses.Draft)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(c => c.Status, ClipStatuses.Ready)
+                    .SetProperty(c => c.FileSizeBytes, meta.SizeBytes)
+                    .SetProperty(c => c.UpdatedAt, now),
+                ct);
+
+        if (rowsAffected == 0)
+        {
+            return ClipResult<CompleteClipResult>.Fail(ClipUploadError.InvalidState);
+        }
+
+        return ClipResult<CompleteClipResult>.Ok(new CompleteClipResult(clipId, meta.SizeBytes));
+    }
+
+    private bool IsAllowedContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return false;
+        }
+
+        var semicolon = contentType.IndexOf(';');
+        var mediaType = (semicolon >= 0 ? contentType[..semicolon] : contentType).Trim();
+        foreach (var allowed in _validation.AllowedContentTypes)
+        {
+            if (string.Equals(allowed, mediaType, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -47,11 +47,12 @@ public sealed class ClipUploadService : IClipUploadService
             return ClipResult<CreateClipResult>.Fail(ClipUploadError.InvalidDescription);
         }
 
-        var visibility = input.Visibility ?? ClipVisibilities.Public;
-        if (!ClipVisibilities.IsValid(visibility))
+        var rawVisibility = input.Visibility ?? ClipVisibilities.Public;
+        if (!ClipVisibilities.IsValid(rawVisibility))
         {
             return ClipResult<CreateClipResult>.Fail(ClipUploadError.InvalidVisibility);
         }
+        var visibility = ClipVisibilities.Normalize(rawVisibility);
 
         var id = Guid.NewGuid();
         var now = _clock.GetUtcNow();
@@ -109,7 +110,10 @@ public sealed class ClipUploadService : IClipUploadService
         Guid clipId,
         CancellationToken ct)
     {
+        // AsNoTracking: the final mutation goes through ExecuteUpdateAsync, which bypasses
+        // the change tracker. Keeping the entity untracked avoids a wasted tracker entry.
         var clip = await _db.Clips
+            .AsNoTracking()
             .FirstOrDefaultAsync(c => c.Id == clipId && c.UserId == userId, ct);
 
         if (clip is null)

--- a/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
@@ -1,0 +1,38 @@
+namespace GankedTV.Api.Services.Clips;
+
+public interface IClipUploadService
+{
+    Task<ClipResult<CreateClipResult>> CreateAsync(Guid userId, CreateClipInput input, CancellationToken ct);
+    Task<ClipResult<UploadUrlResult>> GetUploadUrlAsync(Guid userId, Guid clipId, CancellationToken ct);
+    Task<ClipResult<CompleteClipResult>> CompleteAsync(Guid userId, Guid clipId, CancellationToken ct);
+}
+
+public sealed record CreateClipInput(
+    string? Title,
+    string? Description,
+    int? GameId,
+    string? Visibility);
+
+public sealed record CreateClipResult(Guid ClipId);
+public sealed record UploadUrlResult(string Url, DateTimeOffset ExpiresAt);
+public sealed record CompleteClipResult(Guid ClipId, long FileSizeBytes);
+
+public enum ClipUploadError
+{
+    InvalidTitle,
+    InvalidDescription,
+    InvalidVisibility,
+    NotFound,
+    InvalidState,
+    ObjectNotUploaded,
+    FileTooLarge,
+    UnsupportedContentType,
+}
+
+public readonly record struct ClipResult<T>(T? Value, ClipUploadError? Error)
+{
+    public bool IsSuccess => Error is null;
+
+    public static ClipResult<T> Ok(T value) => new(value, null);
+    public static ClipResult<T> Fail(ClipUploadError error) => new(default, error);
+}

--- a/server/src/GankedTV.Api/Services/ObjectStorage/IObjectStorageService.cs
+++ b/server/src/GankedTV.Api/Services/ObjectStorage/IObjectStorageService.cs
@@ -1,5 +1,7 @@
 namespace GankedTV.Api.Services.ObjectStorage;
 
+public sealed record ObjectMetadata(long SizeBytes, string? ContentType);
+
 public interface IObjectStorageService
 {
     Task EnsureBucketsAsync(CancellationToken ct = default);
@@ -16,4 +18,9 @@ public interface IObjectStorageService
         TimeSpan? expiry = null);
 
     Task DeleteObjectAsync(string bucket, string key, CancellationToken ct = default);
+
+    Task<ObjectMetadata?> GetObjectMetadataAsync(
+        string bucket,
+        string key,
+        CancellationToken ct = default);
 }

--- a/server/src/GankedTV.Api/Services/ObjectStorage/MinioObjectStorageService.cs
+++ b/server/src/GankedTV.Api/Services/ObjectStorage/MinioObjectStorageService.cs
@@ -56,6 +56,7 @@ public sealed class MinioObjectStorageService : IObjectStorageService
             Verb = HttpVerb.PUT,
             ContentType = contentType,
             Expires = DateTime.UtcNow.Add(expiry ?? DefaultExpiry),
+            Protocol = ResolveProtocol(_options.Endpoint),
         };
 
         return RewriteHost(_s3.GetPreSignedURL(request), _options.PublicUrl);
@@ -72,10 +73,19 @@ public sealed class MinioObjectStorageService : IObjectStorageService
             Key = key,
             Verb = HttpVerb.GET,
             Expires = DateTime.UtcNow.Add(expiry ?? DefaultExpiry),
+            Protocol = ResolveProtocol(_options.Endpoint),
         };
 
         return RewriteHost(_s3.GetPreSignedURL(request), _options.PublicUrl);
     }
+
+    // GetPreSignedURL defaults to https:// regardless of the ServiceURL scheme. For MinIO dev
+    // on plain HTTP we have to set Protocol.HTTP explicitly or the presigned URL won't match
+    // MinIO's listener.
+    private static Protocol ResolveProtocol(string endpoint) =>
+        endpoint.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            ? Protocol.HTTP
+            : Protocol.HTTPS;
 
     public async Task DeleteObjectAsync(string bucket, string key, CancellationToken ct = default)
     {
@@ -84,6 +94,26 @@ public sealed class MinioObjectStorageService : IObjectStorageService
             BucketName = bucket,
             Key = key,
         }, ct);
+    }
+
+    public async Task<ObjectMetadata?> GetObjectMetadataAsync(
+        string bucket,
+        string key,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _s3.GetObjectMetadataAsync(new GetObjectMetadataRequest
+            {
+                BucketName = bucket,
+                Key = key,
+            }, ct);
+            return new ObjectMetadata(response.ContentLength, response.Headers?.ContentType);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
     }
 
     // MinIO signs with the container-internal endpoint (http://minio:9000) but browsers

--- a/server/src/GankedTV.Api/Validation/ClipValidationOptions.cs
+++ b/server/src/GankedTV.Api/Validation/ClipValidationOptions.cs
@@ -1,0 +1,12 @@
+namespace GankedTV.Api.Validation;
+
+public sealed class ClipValidationOptions
+{
+    public int MaxUploadSizeMb { get; set; } = 500;
+    public int MaxClipDurationSecs { get; set; } = 120;
+    public int MaxTitleLength { get; set; } = 255;
+    public int MaxDescriptionLength { get; set; } = 5000;
+    public IReadOnlyList<string> AllowedContentTypes { get; set; } = new[] { "video/mp4" };
+
+    public long MaxUploadSizeBytes => (long)MaxUploadSizeMb * 1024 * 1024;
+}

--- a/server/tests/GankedTV.Api.Tests/Auth/Providers/OAuthProviderRegistryTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Auth/Providers/OAuthProviderRegistryTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using GankedTV.Api.Auth;
+using GankedTV.Api.Auth.Providers;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Auth.Providers;
+
+public class OAuthProviderRegistryTests
+{
+    private static IOAuthProvider FakeProvider(string name)
+    {
+        var p = Substitute.For<IOAuthProvider>();
+        p.Name.Returns(name);
+        return p;
+    }
+
+    private static OAuthProviderRegistry Build(OAuthOptions opts, params IOAuthProvider[] providers) =>
+        new(providers, Options.Create(opts));
+
+    [Fact]
+    public void NothingConfigured_RegistryIsEmpty()
+    {
+        var registry = Build(
+            new OAuthOptions { WebOrigin = "http://localhost:5173" },
+            FakeProvider(DiscordOAuthProvider.ProviderName),
+            FakeProvider(GoogleOAuthProvider.ProviderName));
+
+        registry.ConfiguredProviderNames.Should().BeEmpty();
+        registry.TryGet(DiscordOAuthProvider.ProviderName, out _).Should().BeFalse();
+        registry.TryGet(GoogleOAuthProvider.ProviderName, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OnlyDiscordConfigured_GoogleFilteredOut()
+    {
+        var opts = new OAuthOptions
+        {
+            WebOrigin = "http://localhost:5173",
+            Discord = new OAuthProviderOptions
+            {
+                ClientId = "did",
+                ClientSecret = "secret",
+                RedirectUri = "http://localhost/callback",
+            },
+        };
+
+        var registry = Build(opts,
+            FakeProvider(DiscordOAuthProvider.ProviderName),
+            FakeProvider(GoogleOAuthProvider.ProviderName));
+
+        registry.ConfiguredProviderNames.Should().ContainSingle().Which.Should().Be(DiscordOAuthProvider.ProviderName);
+        registry.TryGet(DiscordOAuthProvider.ProviderName, out _).Should().BeTrue();
+        registry.TryGet(GoogleOAuthProvider.ProviderName, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void BothConfigured_BothReturned()
+    {
+        var configured = new OAuthProviderOptions
+        {
+            ClientId = "id",
+            ClientSecret = "secret",
+            RedirectUri = "http://localhost/cb",
+        };
+        var opts = new OAuthOptions
+        {
+            WebOrigin = "http://localhost:5173",
+            Discord = configured,
+            Google = new OAuthProviderOptions
+            {
+                ClientId = "gid",
+                ClientSecret = "gsecret",
+                RedirectUri = "http://localhost/gcb",
+            },
+        };
+
+        var registry = Build(opts,
+            FakeProvider(DiscordOAuthProvider.ProviderName),
+            FakeProvider(GoogleOAuthProvider.ProviderName));
+
+        registry.ConfiguredProviderNames.Should().BeEquivalentTo(
+            new[] { DiscordOAuthProvider.ProviderName, GoogleOAuthProvider.ProviderName });
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Auth/Providers/OAuthProviderRegistryTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Auth/Providers/OAuthProviderRegistryTests.cs
@@ -55,6 +55,31 @@ public class OAuthProviderRegistryTests
     }
 
     [Fact]
+    public void UnknownProviderName_IsFilteredOut()
+    {
+        // Even if a third-party IOAuthProvider is registered in DI, the registry only
+        // surfaces the names it explicitly whitelists in IsConfigured.
+        var opts = new OAuthOptions
+        {
+            WebOrigin = "http://localhost:5173",
+            Discord = new OAuthProviderOptions
+            {
+                ClientId = "id",
+                ClientSecret = "secret",
+                RedirectUri = "http://localhost/cb",
+            },
+        };
+
+        var registry = Build(opts,
+            FakeProvider(DiscordOAuthProvider.ProviderName),
+            FakeProvider("twitter"));
+
+        registry.ConfiguredProviderNames.Should().ContainSingle()
+            .Which.Should().Be(DiscordOAuthProvider.ProviderName);
+        registry.TryGet("twitter", out _).Should().BeFalse();
+    }
+
+    [Fact]
     public void BothConfigured_BothReturned()
     {
         var configured = new OAuthProviderOptions

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsSmokeTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsSmokeTests.cs
@@ -42,6 +42,21 @@ public class AuthEndpointsSmokeTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ListProviders_ReturnsConfiguredProviders()
+    {
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/auth/providers");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var providers = body.GetProperty("providers").EnumerateArray()
+            .Select(e => e.GetString())
+            .ToArray();
+        providers.Should().BeEquivalentTo(new[] { "discord", "google" });
+    }
+
+    [Fact]
     public async Task Refresh_UnknownToken_Returns401()
     {
         using var client = _factory!.CreateClient();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
@@ -1,0 +1,497 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class ClipsUploadEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public ClipsUploadEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private async Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "uploader")
+    {
+        var now = DateTimeOffset.UtcNow;
+        Guid id;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = username,
+                Email = $"{username}@example.com",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            id = user.Id;
+        }
+
+        using var scope = _factory!.Services.CreateScope();
+        var jwt = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var token = jwt.Issue(new User { Id = id, Username = username, Email = $"{username}@example.com" });
+        return (id, token);
+    }
+
+    private HttpClient ClientWithBearer(string token)
+    {
+        var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task<Guid> SeedClipAsync(Guid userId, string status = "draft", long? fileSizeBytes = null)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = "seed",
+            VideoKey = $"clips/{id}.mp4",
+            Status = status,
+            Visibility = "public",
+            FileSizeBytes = fileSizeBytes,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    // ---- POST /clips ----
+
+    [Fact]
+    public async Task Create_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/clips", new { title = "test" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Create_ValidPayload_Returns200AndPersistsDraft()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new
+        {
+            title = "My first clip",
+            description = "did a thing",
+            visibility = "unlisted",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var id = body.GetProperty("id").GetGuid();
+
+        await using var db = _fx.CreateContext();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == id);
+        clip.UserId.Should().Be(userId);
+        clip.Status.Should().Be("draft");
+        clip.VideoKey.Should().Be($"clips/{id}.mp4");
+        clip.Visibility.Should().Be("unlisted");
+        clip.Title.Should().Be("My first clip");
+        clip.Description.Should().Be("did a thing");
+    }
+
+    [Fact]
+    public async Task Create_DefaultsVisibilityToPublic()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new { title = "no vis" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var id = body.GetProperty("id").GetGuid();
+
+        await using var db = _fx.CreateContext();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == id);
+        clip.Visibility.Should().Be("public");
+    }
+
+    [Fact]
+    public async Task Create_WhitespaceTitle_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new { title = "   " });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_title");
+    }
+
+    [Fact]
+    public async Task Create_TitleTooLong_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new { title = new string('x', 256) });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_title");
+    }
+
+    [Fact]
+    public async Task Create_InvalidVisibility_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new { title = "x", visibility = "private" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_visibility");
+    }
+
+    [Fact]
+    public async Task Create_DescriptionTooLong_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new
+        {
+            title = "ok",
+            description = new string('x', 5001),
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_description");
+    }
+
+    // ---- POST /clips/{id}/upload-url ----
+
+    [Fact]
+    public async Task UploadUrl_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsync($"/clips/{Guid.NewGuid()}/upload-url", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UploadUrl_NotOwned_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("me");
+        var (otherId, _) = await SeedUserAndIssueTokenAsync("other");
+        var otherClip = await SeedClipAsync(otherId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{otherClip}/upload-url", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("not_found");
+    }
+
+    [Fact]
+    public async Task UploadUrl_NonExistent_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsync($"/clips/{Guid.NewGuid()}/upload-url", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UploadUrl_ClipAlreadyReady_Returns400InvalidState()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId, status: "ready");
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/upload-url", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_state");
+    }
+
+    [Fact]
+    public async Task UploadUrl_Happy_CallsPresignWithExpectedArgs()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        _storage.GetPresignedPutUrl(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("http://localhost:9000/clips/signed?sig=abc");
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/upload-url", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("url").GetString().Should().Be("http://localhost:9000/clips/signed?sig=abc");
+        body.GetProperty("expiresAt").GetDateTimeOffset()
+            .Should().BeCloseTo(DateTimeOffset.UtcNow.AddMinutes(15), TimeSpan.FromMinutes(1));
+
+        _storage.Received(1).GetPresignedPutUrl(
+            "clips",
+            $"clips/{clipId}.mp4",
+            "video/mp4",
+            TimeSpan.FromMinutes(15));
+    }
+
+    // ---- POST /clips/{id}/complete ----
+
+    [Fact]
+    public async Task Complete_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsync($"/clips/{Guid.NewGuid()}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Complete_NonExistentId_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsync($"/clips/{Guid.NewGuid()}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Complete_NotOwned_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("me");
+        var (otherId, _) = await SeedUserAndIssueTokenAsync("other");
+        var otherClip = await SeedClipAsync(otherId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{otherClip}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Complete_NotInDraft_Returns400InvalidState()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId, status: "ready");
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_state");
+    }
+
+    [Fact]
+    public async Task Complete_ObjectMissing_Returns400ObjectNotUploaded()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((ObjectMetadata?)null);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("object_not_uploaded");
+    }
+
+    [Fact]
+    public async Task Complete_FileTooLarge_Returns400AndLeavesDraft()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        var oversized = (long)501 * 1024 * 1024;
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ObjectMetadata(oversized, "video/mp4"));
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("file_too_large");
+
+        await using var db = _fx.CreateContext();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == clipId);
+        clip.Status.Should().Be("draft");
+        clip.FileSizeBytes.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Complete_UnsupportedContentType_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ObjectMetadata(1024, "video/quicktime"));
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("unsupported_content_type");
+    }
+
+    [Fact]
+    public async Task Complete_NullContentType_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ObjectMetadata(1024, null));
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("unsupported_content_type");
+    }
+
+    [Fact]
+    public async Task Complete_ContentTypeMixedCase_IsAccepted()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ObjectMetadata(1024, "VIDEO/MP4"));
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Complete_ContentTypeWithCharset_IsAccepted()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ObjectMetadata(12345, "video/mp4; charset=binary"));
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Complete_Happy_UpdatesRowAndReturnsFileSize()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        DateTimeOffset originalUpdated;
+        await using (var db = _fx.CreateContext())
+        {
+            originalUpdated = (await db.Clips.AsNoTracking().SingleAsync(c => c.Id == clipId)).UpdatedAt;
+        }
+        await Task.Delay(20);
+
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ObjectMetadata(98765, "video/mp4"));
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(clipId);
+        body.GetProperty("fileSizeBytes").GetInt64().Should().Be(98765);
+
+        await using var db2 = _fx.CreateContext();
+        var clip = await db2.Clips.AsNoTracking().SingleAsync(c => c.Id == clipId);
+        clip.Status.Should().Be("ready");
+        clip.FileSizeBytes.Should().Be(98765);
+        clip.UpdatedAt.Should().BeAfter(originalUpdated);
+    }
+
+    [Fact]
+    public async Task Complete_Duplicate_SecondCallReturns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+
+        _storage.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ObjectMetadata(1024, "video/mp4"));
+
+        using var client = ClientWithBearer(token);
+        var first = await client.PostAsync($"/clips/{clipId}/complete", null);
+        var second = await client.PostAsync($"/clips/{clipId}/complete", null);
+
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await second.Content.ReadAsStringAsync()).Should().Contain("invalid_state");
+
+        // HEAD is skipped on the second call because the state check short-circuits.
+        await _storage.Received(1).GetObjectMetadataAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
@@ -185,6 +185,41 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Create_MixedCaseVisibility_IsNormalized()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new
+        {
+            title = "vis test",
+            visibility = "Unlisted",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var id = (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetGuid();
+
+        await using var db = _fx.CreateContext();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == id);
+        clip.Visibility.Should().Be("unlisted");
+    }
+
+    [Fact]
+    public async Task Create_NullBody_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        using var content = new StringContent("null", System.Text.Encoding.UTF8, "application/json");
+        var resp = await client.PostAsync("/clips", content);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_body");
+    }
+
+    [Fact]
     public async Task Create_DescriptionTooLong_Returns400()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/DevAuthEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/DevAuthEndpointsTests.cs
@@ -81,6 +81,17 @@ public class DevAuthEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DevToken_NotMappedInProduction()
+    {
+        await using var prodFactory = new AuthApiFactory(_fx.ConnectionString, environment: "Production");
+        using var client = prodFactory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/dev/token", new { username = "prod" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
     public async Task DevToken_IssuesJwtAcceptedByMeEndpoint()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/DevAuthEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/DevAuthEndpointsTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class DevAuthEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+
+    public DevAuthEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DevToken_CreatesUserAndReturnsJwt()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/dev/token", new { username = "alice" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("token").GetString().Should().NotBeNullOrEmpty();
+        body.GetProperty("username").GetString().Should().Be("alice");
+        body.GetProperty("userId").GetGuid().Should().NotBeEmpty();
+
+        await using var db = _fx.CreateContext();
+        var user = await db.Users.SingleAsync(u => u.Username == "alice");
+        user.Email.Should().Be("alice@dev.local");
+    }
+
+    [Fact]
+    public async Task DevToken_ReusesExistingUserByUsername()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var first = await client.PostAsJsonAsync("/dev/token", new { username = "bob" });
+        var second = await client.PostAsJsonAsync("/dev/token", new { username = "bob" });
+
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        firstBody.GetProperty("userId").GetGuid()
+            .Should().Be(secondBody.GetProperty("userId").GetGuid());
+
+        await using var db = _fx.CreateContext();
+        var count = await db.Users.CountAsync(u => u.Username == "bob");
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DevToken_DefaultsUsernameWhenOmitted()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/dev/token", new { });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("username").GetString().Should().Be("dev-user");
+    }
+
+    [Fact]
+    public async Task DevToken_IssuesJwtAcceptedByMeEndpoint()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var token = (await (await client.PostAsJsonAsync("/dev/token", new { username = "carol" }))
+            .Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("token").GetString();
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        var meResp = await client.GetAsync("/me");
+
+        meResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await meResp.Content.ReadAsStringAsync()).Should().Contain("carol");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/ObjectStorageTests.cs
+++ b/server/tests/GankedTV.Api.Tests/ObjectStorageTests.cs
@@ -200,4 +200,55 @@ public class ObjectStorageTests
             Arg.Is<DeleteObjectRequest>(r => r.BucketName == "clips" && r.Key == "some/key"),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task GetObjectMetadataAsync_ReturnsSizeAndContentType()
+    {
+        var s3 = Substitute.For<IAmazonS3>();
+        var response = new GetObjectMetadataResponse
+        {
+            ContentLength = 12345L,
+        };
+        response.Headers.ContentType = "video/mp4";
+        s3.GetObjectMetadataAsync(
+                Arg.Is<GetObjectMetadataRequest>(r => r.BucketName == "clips" && r.Key == "clips/abc.mp4"),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var meta = await BuildService(s3).GetObjectMetadataAsync("clips", "clips/abc.mp4");
+
+        meta.Should().NotBeNull();
+        meta!.SizeBytes.Should().Be(12345L);
+        meta.ContentType.Should().Be("video/mp4");
+    }
+
+    [Fact]
+    public async Task GetObjectMetadataAsync_ReturnsNullWhenObjectMissing()
+    {
+        var s3 = Substitute.For<IAmazonS3>();
+        s3.GetObjectMetadataAsync(Arg.Any<GetObjectMetadataRequest>(), Arg.Any<CancellationToken>())
+            .Returns<GetObjectMetadataResponse>(_ => throw new AmazonS3Exception("not found")
+            {
+                StatusCode = System.Net.HttpStatusCode.NotFound,
+            });
+
+        var meta = await BuildService(s3).GetObjectMetadataAsync("clips", "missing.mp4");
+
+        meta.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetObjectMetadataAsync_PropagatesNonNotFoundErrors()
+    {
+        var s3 = Substitute.For<IAmazonS3>();
+        s3.GetObjectMetadataAsync(Arg.Any<GetObjectMetadataRequest>(), Arg.Any<CancellationToken>())
+            .Returns<GetObjectMetadataResponse>(_ => throw new AmazonS3Exception("boom")
+            {
+                StatusCode = System.Net.HttpStatusCode.InternalServerError,
+            });
+
+        var act = async () => await BuildService(s3).GetObjectMetadataAsync("clips", "x.mp4");
+
+        await act.Should().ThrowAsync<AmazonS3Exception>();
+    }
 }

--- a/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
@@ -13,11 +13,16 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
 {
     private readonly string _connectionString;
     private readonly IObjectStorageService? _storageOverride;
+    private readonly string _environment;
 
-    public AuthApiFactory(string connectionString, IObjectStorageService? storageOverride = null)
+    public AuthApiFactory(
+        string connectionString,
+        IObjectStorageService? storageOverride = null,
+        string environment = "Development")
     {
         _connectionString = connectionString;
         _storageOverride = storageOverride;
+        _environment = environment;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -33,7 +38,7 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("GOOGLE_CLIENT_SECRET", "test-google-secret");
         Environment.SetEnvironmentVariable("GOOGLE_REDIRECT_URI", "http://localhost:5000/auth/google/callback");
 
-        builder.UseEnvironment("Development");
+        builder.UseEnvironment(_environment);
         builder.ConfigureServices(services =>
         {
             // Replace the hosted bucket-bootstrap service so we don't need MinIO running.

--- a/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
@@ -1,4 +1,5 @@
 using GankedTV.Api.Data;
+using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -11,10 +12,12 @@ namespace GankedTV.Api.Tests.TestSupport;
 public sealed class AuthApiFactory : WebApplicationFactory<Program>
 {
     private readonly string _connectionString;
+    private readonly IObjectStorageService? _storageOverride;
 
-    public AuthApiFactory(string connectionString)
+    public AuthApiFactory(string connectionString, IObjectStorageService? storageOverride = null)
     {
         _connectionString = connectionString;
+        _storageOverride = storageOverride;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -41,6 +44,12 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
             services.RemoveAll<DbContextOptions<GankedTvDbContext>>();
             services.AddDbContext<GankedTvDbContext>(opts =>
                 opts.UseNpgsql(_connectionString).UseSnakeCaseNamingConvention());
+
+            if (_storageOverride is not null)
+            {
+                services.RemoveAll<IObjectStorageService>();
+                services.AddSingleton(_storageOverride);
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
Implements issue #6's 3-step clip upload flow (`POST /clips` → presigned PUT URL → `POST /complete`) against MinIO, with EF Core persisting the draft→ready transition. Two dev-experience improvements surfaced during manual verification are bundled in: OAuth providers are now optional per-instance (so new contributors can boot the API without Discord/Google credentials) and a Development-only `POST /dev/token` endpoint mints JWTs for local testing.

## What's here
- **Clip upload endpoints** in [`ClipsUploadEndpoints`](server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs): `POST /clips` (draft), `POST /clips/{id}/upload-url` (15-min presigned PUT), `POST /clips/{id}/complete` (HEAD validation → `ready`). Atomic conditional UPDATE in `CompleteAsync` closes the concurrent-complete race.
- **HEAD support on object storage** — new `GetObjectMetadataAsync` on [`IObjectStorageService`](server/src/GankedTV.Api/Services/ObjectStorage/IObjectStorageService.cs) lets the server validate size and content-type before finalizing a clip.
- **OAuth optional** — [`OAuthProviderRegistry`](server/src/GankedTV.Api/Auth/Providers/OAuthProviderRegistry.cs) filters unconfigured providers; `OAUTH_STATE_SECRET` only validated when at least one provider is configured. `StateCookieService` deferred validation to usage sites so DI resolution doesn't 500 on unconfigured providers. New `GET /auth/providers` lists configured provider names for the frontend.
- **`POST /dev/token`** — Development-only JWT mint endpoint (guarded by `IsDevelopment()`, never mapped in Staging/Production, with a startup WARN log).
- **MinIO protocol fix** — `GetPreSignedURL` defaults to `https://` regardless of `ServiceURL`; now `Protocol.HTTP` is set explicitly when the endpoint is HTTP, unblocking local MinIO presigned PUTs.
- **Configurable upload limits** — `MAX_UPLOAD_SIZE_MB` (default 500) and `MAX_CLIP_DURATION_SECS` (default 120). Full `Clips:*` config section is bound so title / description / content-type limits are tunable too.
- **127 tests passing** — 31 new (xUnit + NSubstitute, integration tests against a Postgres testcontainer with the storage layer faked).

Closes #6

## How to test manually
```bash
# 1. Start infra + API
make up
export JWT_SECRET=$(openssl rand -hex 32)
dotnet watch --project server/src/GankedTV.Api

# 2. Mint a local JWT (no OAuth required)
TOKEN=$(curl -s -X POST http://localhost:5293/dev/token \
  -H "Content-Type: application/json" -d '{"username":"you"}' | jq -r .token)

# 3. Run the 3-step upload
CLIP=$(curl -s -X POST http://localhost:5293/clips \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"title":"smoke test","visibility":"public"}' | jq -r .id)

URL=$(curl -s -X POST http://localhost:5293/clips/$CLIP/upload-url \
  -H "Authorization: Bearer $TOKEN" | jq -r .url)

curl -X PUT -H "Content-Type: video/mp4" --data-binary "@/path/to/clip.mp4" "$URL"

curl -X POST http://localhost:5293/clips/$CLIP/complete \
  -H "Authorization: Bearer $TOKEN"
# → { "id": "...", "fileSizeBytes": ... }

# 4. Second complete → 400 invalid_state (idempotency)
curl -X POST http://localhost:5293/clips/$CLIP/complete -H "Authorization: Bearer $TOKEN"
```

Verify the file lands in the MinIO console at http://localhost:9001 under `clips/<id>.mp4`, and Postgres shows `status=ready` with the correct `file_size_bytes`.

## Follow-ups
- Presigned PUT URLs remain valid for 15 min after issuance, so a clip's owner could technically overwrite their own file after `/complete`. Fix would be a staging-key + server-side move — out of scope for #6, worth its own issue.

## Checklist
- [x] Verified manually end-to-end against real MinIO + Postgres
- [x] All tests pass (`dotnet test server` — 127/127)
