### PR TITLE
Server Clip GET endpoints

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -417,6 +417,12 @@ ffmpeg -i input.mp4 -ss 00:00:01 -frames:v 1 -q:v 2 thumbnail.jpg
 - Use `WHERE created_at < @cursor ORDER BY created_at DESC LIMIT 20`
 - Return the last item's `created_at` as the next cursor
 
+**DTO layout & mappers (.NET convention):**
+- DTOs live in `server/src/GankedTV.Api/Contracts/<Area>/` — one `public sealed record` per file. Namespace: `GankedTV.Api.Contracts.<Area>`.
+- Entity → DTO projection happens via **hand-written static extension methods** in a `*Mappings.cs` file next to the DTOs (e.g. `Contracts/Clips/ClipMappings.cs` with `ToFeedItem(this Clip, ...)`). Avoid reflection-based libraries like AutoMapper — modern .NET convention is explicit mappers (compile-time checked, no runtime surprises).
+- Endpoint handlers should not construct DTOs inline; call the mapper.
+- Caller-scoped values (e.g. `likedByMe`, presigned URLs) are passed into the mapper as parameters — the entity stays ignorant of the caller.
+
 **Discord Embeds (OG Tags):**
 ```html
 <meta property="og:title" content="Insane Valorant Ace — by username" />

--- a/server/src/GankedTV.Api/Contracts/Clips/AuthorSummary.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/AuthorSummary.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record AuthorSummary(Guid Id, string Username, string? AvatarUrl);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
@@ -1,0 +1,17 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record ClipDetailResponse(
+    Guid Id,
+    string Title,
+    string? Description,
+    string VideoUrl,
+    DateTimeOffset VideoUrlExpiresAt,
+    string? ThumbnailKey,
+    short? DurationSecs,
+    short? Width,
+    short? Height,
+    int ViewCount,
+    int LikeCount,
+    DateTimeOffset CreatedAt,
+    AuthorSummary Author,
+    bool LikedByMe);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipFeedItem.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipFeedItem.cs
@@ -1,0 +1,13 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record ClipFeedItem(
+    Guid Id,
+    string Title,
+    string? Description,
+    string? ThumbnailKey,
+    short? DurationSecs,
+    int ViewCount,
+    int LikeCount,
+    DateTimeOffset CreatedAt,
+    AuthorSummary Author,
+    bool LikedByMe);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipFeedResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipFeedResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record ClipFeedResponse(IReadOnlyList<ClipFeedItem> Items, string? NextCursor);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
@@ -1,0 +1,43 @@
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Contracts.Clips;
+
+public static class ClipMappings
+{
+    public static AuthorSummary ToAuthorSummary(this User user) =>
+        new(user.Id, user.Username, user.AvatarUrl);
+
+    public static ClipFeedItem ToFeedItem(this Clip clip, bool likedByMe) =>
+        new(
+            clip.Id,
+            clip.Title,
+            clip.Description,
+            clip.ThumbnailKey,
+            clip.DurationSecs,
+            clip.ViewCount,
+            clip.LikeCount,
+            clip.CreatedAt,
+            clip.User.ToAuthorSummary(),
+            likedByMe);
+
+    public static ClipDetailResponse ToDetail(
+        this Clip clip,
+        string videoUrl,
+        DateTimeOffset videoUrlExpiresAt,
+        bool likedByMe) =>
+        new(
+            clip.Id,
+            clip.Title,
+            clip.Description,
+            videoUrl,
+            videoUrlExpiresAt,
+            clip.ThumbnailKey,
+            clip.DurationSecs,
+            clip.Width,
+            clip.Height,
+            clip.ViewCount,
+            clip.LikeCount,
+            clip.CreatedAt,
+            clip.User.ToAuthorSummary(),
+            likedByMe);
+}

--- a/server/src/GankedTV.Api/Contracts/Users/UserMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/UserMappings.cs
@@ -1,0 +1,10 @@
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Contracts.Users;
+
+public static class UserMappings
+{
+    public static UserProfileResponse ToProfile(this User user, IReadOnlyList<ClipFeedItem> clips) =>
+        new(user.Id, user.Username, user.Bio, user.AvatarUrl, user.CreatedAt, clips);
+}

--- a/server/src/GankedTV.Api/Contracts/Users/UserProfileResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/UserProfileResponse.cs
@@ -1,0 +1,11 @@
+using GankedTV.Api.Contracts.Clips;
+
+namespace GankedTV.Api.Contracts.Users;
+
+public sealed record UserProfileResponse(
+    Guid Id,
+    string Username,
+    string? Bio,
+    string? AvatarUrl,
+    DateTimeOffset CreatedAt,
+    IReadOnlyList<ClipFeedItem> Clips);

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -1,0 +1,134 @@
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Data;
+using GankedTV.Api.Services.ObjectStorage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class ClipsReadEndpoints
+{
+    private const int DefaultLimit = 20;
+    private const int MaxLimit = 100;
+    private static readonly TimeSpan VideoUrlLifetime = TimeSpan.FromHours(1);
+
+    public static IEndpointRouteBuilder MapClipsReadEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/clips");
+        group.MapGet("/feed", GetFeed);
+        group.MapGet("/{id:guid}", GetDetail);
+        return app;
+    }
+
+    private static async Task<IResult> GetFeed(
+        string? cursor,
+        int? limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+
+        // Invalid cursor values silently fall back to "no cursor" rather than 400-ing; the
+        // client's next-page fetch shouldn't be broken by a corrupted query string.
+        DateTimeOffset? cursorValue = null;
+        if (!string.IsNullOrWhiteSpace(cursor)
+            && DateTimeOffset.TryParse(cursor, CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out var parsed))
+        {
+            cursorValue = parsed;
+        }
+
+        var query = db.Clips.AsNoTracking()
+            .Where(c => c.Visibility == "public" && c.Status == "ready");
+        if (cursorValue is DateTimeOffset cv)
+        {
+            query = query.Where(c => c.CreatedAt < cv);
+        }
+
+        // Fetch limit+1 so we can detect whether another page exists without a second round trip.
+        var rows = await query
+            .OrderByDescending(c => c.CreatedAt)
+            .Include(c => c.User)
+            .Take(clampedLimit + 1)
+            .ToListAsync(ct);
+
+        var hasMore = rows.Count > clampedLimit;
+        var page = hasMore ? rows.GetRange(0, clampedLimit) : rows;
+
+        var likedIds = await LoadLikedClipIdsAsync(db, principal, page.Select(c => c.Id), ct);
+
+        var items = page.Select(c => c.ToFeedItem(likedIds.Contains(c.Id))).ToList();
+        var nextCursor = hasMore ? page[^1].CreatedAt.ToString("O", CultureInfo.InvariantCulture) : null;
+
+        return Results.Ok(new ClipFeedResponse(items, nextCursor));
+    }
+
+    private static async Task<IResult> GetDetail(
+        Guid id,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<MinioOptions> minio,
+        CancellationToken ct)
+    {
+        var clip = await db.Clips.AsNoTracking()
+            .Include(c => c.User)
+            .FirstOrDefaultAsync(
+                c => c.Id == id && c.Visibility == "public" && c.Status == "ready",
+                ct);
+
+        if (clip is null)
+        {
+            return Results.NotFound();
+        }
+
+        var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
+        var videoUrl = storage.GetPresignedGetUrl(minio.Value.ClipsBucket, clip.VideoKey, VideoUrlLifetime);
+
+        var likedByMe = false;
+        if (TryGetUserId(principal, out var userId))
+        {
+            likedByMe = await db.Likes.AsNoTracking()
+                .AnyAsync(l => l.ClipId == clip.Id && l.UserId == userId, ct);
+        }
+
+        return Results.Ok(clip.ToDetail(videoUrl, expiresAt, likedByMe));
+    }
+
+    internal static async Task<HashSet<Guid>> LoadLikedClipIdsAsync(
+        GankedTvDbContext db,
+        ClaimsPrincipal principal,
+        IEnumerable<Guid> clipIds,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return [];
+        }
+
+        var ids = clipIds as IReadOnlyCollection<Guid> ?? clipIds.ToList();
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        var liked = await db.Likes.AsNoTracking()
+            .Where(l => l.UserId == userId && ids.Contains(l.ClipId))
+            .Select(l => l.ClipId)
+            .ToListAsync(ct);
+
+        return [.. liked];
+    }
+
+    internal static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
+    {
+        userId = default;
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out userId);
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -1,6 +1,8 @@
+using System.Buffers.Text;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Text;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Services.ObjectStorage;
@@ -69,8 +71,14 @@ public static class ClipsReadEndpoints
 
     private const char CursorSeparator = '_';
 
-    private static string BuildCursor(DateTimeOffset createdAt, Guid id) =>
-        $"{createdAt.ToString("O", CultureInfo.InvariantCulture)}{CursorSeparator}{id:D}";
+    // Cursor is Base64Url-encoded so the raw token is safe to drop into a query string without
+    // client-side escaping. DateTimeOffset.ToString("O") includes `+` (which URL decoders turn
+    // into space) and `:` — encoding keeps the token opaque and URL-transport-safe.
+    private static string BuildCursor(DateTimeOffset createdAt, Guid id)
+    {
+        var payload = $"{createdAt.ToString("O", CultureInfo.InvariantCulture)}{CursorSeparator}{id:D}";
+        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
+    }
 
     private static bool TryParseCursor(string? raw, out DateTimeOffset createdAt, out Guid id)
     {
@@ -78,12 +86,23 @@ public static class ClipsReadEndpoints
         id = default;
         if (string.IsNullOrWhiteSpace(raw)) return false;
 
-        var sep = raw.IndexOf(CursorSeparator);
-        if (sep <= 0 || sep == raw.Length - 1) return false;
+        byte[] bytes;
+        try
+        {
+            bytes = Base64Url.DecodeFromChars(raw);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        var decoded = Encoding.UTF8.GetString(bytes);
+        var sep = decoded.IndexOf(CursorSeparator);
+        if (sep <= 0 || sep == decoded.Length - 1) return false;
 
         return DateTimeOffset.TryParse(
-                raw[..sep], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out createdAt)
-            && Guid.TryParse(raw[(sep + 1)..], out id);
+                decoded[..sep], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out createdAt)
+            && Guid.TryParse(decoded[(sep + 1)..], out id);
     }
 
     private static async Task<IResult> GetDetail(

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -83,7 +83,7 @@ public static class ClipsReadEndpoints
 
         if (clip is null)
         {
-            return Results.NotFound();
+            return Results.NotFound(new { error = "not_found" });
         }
 
         var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -34,24 +34,24 @@ public static class ClipsReadEndpoints
 
         // Invalid cursor values silently fall back to "no cursor" rather than 400-ing; the
         // client's next-page fetch shouldn't be broken by a corrupted query string.
-        DateTimeOffset? cursorValue = null;
-        if (!string.IsNullOrWhiteSpace(cursor)
-            && DateTimeOffset.TryParse(cursor, CultureInfo.InvariantCulture,
-                DateTimeStyles.RoundtripKind, out var parsed))
-        {
-            cursorValue = parsed;
-        }
+        var hasCursor = TryParseCursor(cursor, out var cursorCreatedAt, out var cursorId);
 
         var query = db.Clips.AsNoTracking()
             .Where(c => c.Visibility == "public" && c.Status == "ready");
-        if (cursorValue is DateTimeOffset cv)
+        if (hasCursor)
         {
-            query = query.Where(c => c.CreatedAt < cv);
+            // Composite (CreatedAt, Id) keyset: two clips sharing the same created_at (bulk imports,
+            // seed scripts, same-microsecond uploads) would otherwise cause the second one to be
+            // skipped with a strict `CreatedAt < @cursor` filter.
+            query = query.Where(c =>
+                c.CreatedAt < cursorCreatedAt
+                || (c.CreatedAt == cursorCreatedAt && c.Id.CompareTo(cursorId) < 0));
         }
 
         // Fetch limit+1 so we can detect whether another page exists without a second round trip.
         var rows = await query
             .OrderByDescending(c => c.CreatedAt)
+            .ThenByDescending(c => c.Id)
             .Include(c => c.User)
             .Take(clampedLimit + 1)
             .ToListAsync(ct);
@@ -62,9 +62,28 @@ public static class ClipsReadEndpoints
         var likedIds = await LoadLikedClipIdsAsync(db, principal, page.Select(c => c.Id), ct);
 
         var items = page.Select(c => c.ToFeedItem(likedIds.Contains(c.Id))).ToList();
-        var nextCursor = hasMore ? page[^1].CreatedAt.ToString("O", CultureInfo.InvariantCulture) : null;
+        var nextCursor = hasMore ? BuildCursor(page[^1].CreatedAt, page[^1].Id) : null;
 
         return Results.Ok(new ClipFeedResponse(items, nextCursor));
+    }
+
+    private const char CursorSeparator = '_';
+
+    private static string BuildCursor(DateTimeOffset createdAt, Guid id) =>
+        $"{createdAt.ToString("O", CultureInfo.InvariantCulture)}{CursorSeparator}{id:D}";
+
+    private static bool TryParseCursor(string? raw, out DateTimeOffset createdAt, out Guid id)
+    {
+        createdAt = default;
+        id = default;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+
+        var sep = raw.IndexOf(CursorSeparator);
+        if (sep <= 0 || sep == raw.Length - 1) return false;
+
+        return DateTimeOffset.TryParse(
+                raw[..sep], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out createdAt)
+            && Guid.TryParse(raw[(sep + 1)..], out id);
     }
 
     private static async Task<IResult> GetDetail(

--- a/server/src/GankedTV.Api/Endpoints/UsersEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/UsersEndpoints.cs
@@ -25,17 +25,19 @@ public static class UsersEndpoints
     {
         if (string.IsNullOrWhiteSpace(username))
         {
-            return Results.NotFound();
+            return Results.NotFound(new { error = "not_found" });
         }
 
-        // Username index is unique but case-sensitive; match case-insensitively so `/users/AliCe`
-        // works whether the OAuth-assigned slug is "alice" or "Alice".
+        // Case-insensitive equality via LOWER(...). Avoid EF.Functions.ILike here — `%` and `_`
+        // would be interpreted as PG wildcards, letting `/users/a%` match any name starting with a
+        // and legitimate `_` in a username become a wildcard.
+        var usernameLower = username.ToLowerInvariant();
         var user = await db.Users.AsNoTracking()
-            .FirstOrDefaultAsync(u => EF.Functions.ILike(u.Username, username), ct);
+            .FirstOrDefaultAsync(u => u.Username.ToLower() == usernameLower, ct);
 
         if (user is null)
         {
-            return Results.NotFound();
+            return Results.NotFound(new { error = "not_found" });
         }
 
         var clips = await db.Clips.AsNoTracking()

--- a/server/src/GankedTV.Api/Endpoints/UsersEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/UsersEndpoints.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Contracts.Users;
+using GankedTV.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class UsersEndpoints
+{
+    private const int UserClipsPageSize = 20;
+
+    public static IEndpointRouteBuilder MapUsersEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/users");
+        group.MapGet("/{username}", GetByUsername);
+        return app;
+    }
+
+    private static async Task<IResult> GetByUsername(
+        string username,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            return Results.NotFound();
+        }
+
+        // Username index is unique but case-sensitive; match case-insensitively so `/users/AliCe`
+        // works whether the OAuth-assigned slug is "alice" or "Alice".
+        var user = await db.Users.AsNoTracking()
+            .FirstOrDefaultAsync(u => EF.Functions.ILike(u.Username, username), ct);
+
+        if (user is null)
+        {
+            return Results.NotFound();
+        }
+
+        var clips = await db.Clips.AsNoTracking()
+            .Where(c => c.UserId == user.Id && c.Visibility == "public" && c.Status == "ready")
+            .OrderByDescending(c => c.CreatedAt)
+            .Include(c => c.User)
+            .Take(UserClipsPageSize)
+            .ToListAsync(ct);
+
+        var likedIds = await ClipsReadEndpoints.LoadLikedClipIdsAsync(
+            db, principal, clips.Select(c => c.Id), ct);
+
+        var clipDtos = clips.Select(c => c.ToFeedItem(likedIds.Contains(c.Id))).ToList();
+
+        return Results.Ok(user.ToProfile(clipDtos));
+    }
+}

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -195,6 +195,8 @@ app.UseAuthorization();
 app.MapAuthEndpoints();
 app.MapMeEndpoints();
 app.MapClipsUploadEndpoints();
+app.MapClipsReadEndpoints();
+app.MapUsersEndpoints();
 
 if (app.Environment.IsDevelopment())
 {

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -211,6 +211,35 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Feed_Cursor_IsUrlSafeRawWithoutEscaping()
+    {
+        // The cursor must survive being dropped into a query string without Uri.EscapeDataString.
+        // DateTimeOffset.ToString("O") contains `+` and `:` which URL decoders mishandle; the cursor
+        // is Base64Url-encoded to stay opaque and transport-safe.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 3; i++)
+        {
+            await SeedClipAsync(userId, now.AddSeconds(-i), title: $"clip-{i}");
+        }
+
+        using var client = _factory!.CreateClient();
+        var first = await client.GetAsync("/clips/feed?limit=2");
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        var cursor = firstBody.GetProperty("nextCursor").GetString();
+        cursor.Should().NotBeNullOrEmpty();
+        cursor!.Should().NotContainAny("+", "/", "=", ":");
+
+        // Deliberately pass the cursor raw — no Uri.EscapeDataString. If the token contained `+`
+        // the server would see it as a space and drop the filter, returning all 3 items instead of 1.
+        var second = await client.GetAsync($"/clips/feed?limit=2&cursor={cursor}");
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        secondBody.GetProperty("items").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
     public async Task Feed_IdenticalCreatedAt_PaginatesDeterministicallyWithoutSkips()
     {
         // Composite (CreatedAt, Id) cursor: two clips sharing a microsecond timestamp must not

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -166,6 +166,26 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Feed_ExactlyAtLimit_ReturnsNullCursor()
+    {
+        // Boundary between "full page" and "has more". With limit=2 and exactly 2 ready clips,
+        // the limit+1 fetch returns 2 rows, hasMore is false, and nextCursor must be null.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        await SeedClipAsync(userId, now.AddSeconds(-1), title: "clip-1");
+        await SeedClipAsync(userId, now.AddSeconds(-2), title: "clip-2");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?limit=2");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
     public async Task Feed_LimitClampedToBounds()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -211,6 +211,40 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Feed_IdenticalCreatedAt_PaginatesDeterministicallyWithoutSkips()
+    {
+        // Composite (CreatedAt, Id) cursor: two clips sharing a microsecond timestamp must not
+        // cause one of them to be skipped across page boundaries. The previous CreatedAt-only
+        // cursor would drop the second row at each collision point.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var shared = DateTimeOffset.UtcNow;
+        var seeded = new[]
+        {
+            await SeedClipAsync(userId, shared, title: "tie-1"),
+            await SeedClipAsync(userId, shared, title: "tie-2"),
+            await SeedClipAsync(userId, shared, title: "tie-3"),
+        };
+
+        using var client = _factory!.CreateClient();
+        var first = await client.GetAsync("/clips/feed?limit=2");
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        var nextCursor = firstBody.GetProperty("nextCursor").GetString();
+        nextCursor.Should().NotBeNullOrEmpty();
+
+        var second = await client.GetAsync($"/clips/feed?limit=2&cursor={Uri.EscapeDataString(nextCursor!)}");
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        secondBody.GetProperty("items").GetArrayLength().Should().Be(1);
+        secondBody.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+
+        var returned = firstBody.GetProperty("items").EnumerateArray()
+            .Concat(secondBody.GetProperty("items").EnumerateArray())
+            .Select(e => e.GetProperty("id").GetGuid())
+            .ToList();
+        returned.Should().BeEquivalentTo(seeded);
+    }
+
+    [Fact]
     public async Task Feed_InvalidCursor_SilentlyFallsBackToFirstPage()
     {
         // Contract: a corrupted cursor query string shouldn't break pagination — the client

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -211,6 +211,60 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Feed_InvalidCursor_SilentlyFallsBackToFirstPage()
+    {
+        // Contract: a corrupted cursor query string shouldn't break pagination — the client
+        // should still get a first page rather than a 400. Guards against accidentally strict
+        // parsing if someone later swaps TryParse for Parse.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?cursor=not-a-date");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Feed_NegativeLimit_ClampsToOne()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        await SeedClipAsync(userId, now.AddSeconds(-1));
+        await SeedClipAsync(userId, now.AddSeconds(-2));
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?limit=-5");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Feed_ExcludesFailedStatusClips()
+    {
+        // Only "ready" should appear. If the filter ever drifted to `status != "draft"` or
+        // similar, "failed" clips would leak.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var ready = await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddSeconds(-1), title: "ready");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, status: "failed", title: "failed");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(ready);
+    }
+
+    [Fact]
     public async Task Feed_Anonymous_LikedByMeFalseForAllItems()
     {
         await _fx.ResetAsync();
@@ -225,6 +279,31 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         using var client = _factory!.CreateClient();
         var resp = await client.GetAsync("/clips/feed");
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var liked = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("likedByMe").GetBoolean());
+        liked.Should().OnlyContain(l => l == false);
+    }
+
+    [Fact]
+    public async Task Feed_WithJwt_LikedByMeIgnoresOtherUsersLikes()
+    {
+        // Cross-user isolation: viewer should see likedByMe=false on a clip liked by someone else.
+        await _fx.ResetAsync();
+        var (_, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (strangerId, _) = await SeedUserAndIssueTokenAsync("stranger");
+        var clipId = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = strangerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = ClientWithBearer(viewerToken);
+        var resp = await client.GetAsync("/clips/feed");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
         var liked = body.GetProperty("items").EnumerateArray()
             .Select(e => e.GetProperty("likedByMe").GetBoolean());
         liked.Should().OnlyContain(l => l == false);
@@ -346,6 +425,25 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             Arg.Any<string>(),
             $"clips/{clipId}.mp4",
             Arg.Is<TimeSpan?>(ts => ts.HasValue && ts.Value == TimeSpan.FromHours(1)));
+    }
+
+    [Fact]
+    public async Task Detail_WithJwt_LikedByMeFalseWhenNoLike()
+    {
+        // Exercises the authed code path specifically — anonymous false is covered above, but
+        // JWT-present-without-like is a distinct branch (TryGetUserId returns true, AnyAsync false).
+        await _fx.ResetAsync();
+        var (_, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var clipId = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://example/url");
+
+        using var client = ClientWithBearer(viewerToken);
+        var resp = await client.GetAsync($"/clips/{clipId}");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likedByMe").GetBoolean().Should().BeFalse();
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -1,0 +1,353 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class ClipsReadEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public ClipsReadEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private async Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "reader")
+    {
+        var now = DateTimeOffset.UtcNow;
+        Guid id;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = username,
+                Email = $"{username}@example.com",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            id = user.Id;
+        }
+
+        using var scope = _factory!.Services.CreateScope();
+        var jwt = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var token = jwt.Issue(new User { Id = id, Username = username, Email = $"{username}@example.com" });
+        return (id, token);
+    }
+
+    private HttpClient ClientWithBearer(string token)
+    {
+        var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task<Guid> SeedClipAsync(
+        Guid userId,
+        DateTimeOffset createdAt,
+        string status = "ready",
+        string visibility = "public",
+        string? title = null)
+    {
+        var id = Guid.NewGuid();
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = title ?? $"clip-{id:N}".Substring(0, 20),
+            VideoKey = $"clips/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            Status = status,
+            Visibility = visibility,
+            DurationSecs = 30,
+            Width = 1920,
+            Height = 1080,
+            FileSizeBytes = 1_000_000,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    // ---- GET /clips/feed ----
+
+    [Fact]
+    public async Task Feed_Empty_Returns200WithNoItems()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/clips/feed");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Feed_OrdersByCreatedAtDesc_AndOmitsNonPublicOrNonReady()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var a = await SeedClipAsync(userId, now.AddMinutes(-3), title: "oldest-ready");
+        var b = await SeedClipAsync(userId, now.AddMinutes(-2), title: "middle-ready");
+        var c = await SeedClipAsync(userId, now.AddMinutes(-1), title: "newest-ready");
+        await SeedClipAsync(userId, now, status: "processing", title: "not-ready");
+        await SeedClipAsync(userId, now, visibility: "unlisted", title: "unlisted");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(c, b, a);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Feed_PaginationBoundary_ExposesNextCursorAndDrainsOnSecondPage()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var seeded = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            seeded.Add(await SeedClipAsync(userId, now.AddSeconds(-i), title: $"clip-{i}"));
+        }
+
+        using var client = _factory!.CreateClient();
+        var first = await client.GetAsync("/clips/feed?limit=2");
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        firstBody.GetProperty("items").GetArrayLength().Should().Be(2);
+        var nextCursor = firstBody.GetProperty("nextCursor").GetString();
+        nextCursor.Should().NotBeNullOrEmpty();
+
+        var second = await client.GetAsync($"/clips/feed?limit=2&cursor={Uri.EscapeDataString(nextCursor!)}");
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        secondBody.GetProperty("items").GetArrayLength().Should().Be(1);
+        secondBody.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+
+        var returned = firstBody.GetProperty("items").EnumerateArray()
+            .Concat(secondBody.GetProperty("items").EnumerateArray())
+            .Select(e => e.GetProperty("id").GetGuid())
+            .ToList();
+        returned.Should().BeEquivalentTo(seeded);
+    }
+
+    [Fact]
+    public async Task Feed_LimitClampedToBounds()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 3; i++)
+        {
+            await SeedClipAsync(userId, now.AddSeconds(-i), title: $"clip-{i}");
+        }
+
+        using var client = _factory!.CreateClient();
+
+        // limit=0 clamps up to 1
+        var low = await client.GetAsync("/clips/feed?limit=0");
+        var lowBody = await low.Content.ReadFromJsonAsync<JsonElement>();
+        lowBody.GetProperty("items").GetArrayLength().Should().Be(1);
+
+        // limit=999 clamps down to MaxLimit (100) but we only have 3 rows
+        var high = await client.GetAsync("/clips/feed?limit=999");
+        var highBody = await high.Content.ReadFromJsonAsync<JsonElement>();
+        highBody.GetProperty("items").GetArrayLength().Should().Be(3);
+        highBody.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Feed_Anonymous_LikedByMeFalseForAllItems()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = userId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var liked = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("likedByMe").GetBoolean());
+        liked.Should().OnlyContain(l => l == false);
+    }
+
+    [Fact]
+    public async Task Feed_WithJwt_LikedByMeReflectsLikeRows()
+    {
+        await _fx.ResetAsync();
+        var (viewerId, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var now = DateTimeOffset.UtcNow;
+        var liked = await SeedClipAsync(authorId, now.AddSeconds(-1), title: "liked");
+        var notLiked = await SeedClipAsync(authorId, now.AddSeconds(-2), title: "not-liked");
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = viewerId, ClipId = liked, CreatedAt = now });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = ClientWithBearer(viewerToken);
+        var resp = await client.GetAsync("/clips/feed");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        var states = body.GetProperty("items").EnumerateArray()
+            .ToDictionary(e => e.GetProperty("id").GetGuid(), e => e.GetProperty("likedByMe").GetBoolean());
+        states[liked].Should().BeTrue();
+        states[notLiked].Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Feed_FeedItemShape_ContainsAuthorAndThumbnailKey()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("shapely");
+        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "a clip");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+
+        item.GetProperty("id").GetGuid().Should().Be(clipId);
+        item.GetProperty("title").GetString().Should().Be("a clip");
+        item.GetProperty("thumbnailKey").GetString().Should().Be($"thumbs/{clipId}.jpg");
+        item.TryGetProperty("videoUrl", out _).Should().BeFalse("feed items intentionally omit presigned URLs");
+        var author = item.GetProperty("author");
+        author.GetProperty("id").GetGuid().Should().Be(userId);
+        author.GetProperty("username").GetString().Should().Be("shapely");
+    }
+
+    // ---- GET /clips/{id} ----
+
+    [Fact]
+    public async Task Detail_NotFound_Returns404()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync($"/clips/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Detail_NotReady_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, status: "processing");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Detail_Unlisted_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, visibility: "unlisted");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Detail_Found_ReturnsPresignedUrlAndMetadata()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("owner");
+        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "playback");
+
+        const string presigned = "https://minio.local/clips/presigned?sig=abc";
+        _storage
+            .GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns(presigned);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(clipId);
+        body.GetProperty("title").GetString().Should().Be("playback");
+        body.GetProperty("videoUrl").GetString().Should().Be(presigned);
+        body.GetProperty("likedByMe").GetBoolean().Should().BeFalse();
+
+        var expiresAt = body.GetProperty("videoUrlExpiresAt").GetDateTimeOffset();
+        expiresAt.Should().BeCloseTo(DateTimeOffset.UtcNow.AddHours(1), TimeSpan.FromMinutes(2));
+
+        // Expiry passed to the storage service should be roughly one hour.
+        _storage.Received(1).GetPresignedGetUrl(
+            Arg.Any<string>(),
+            $"clips/{clipId}.mp4",
+            Arg.Is<TimeSpan?>(ts => ts.HasValue && ts.Value == TimeSpan.FromHours(1)));
+    }
+
+    [Fact]
+    public async Task Detail_WithJwt_LikedByMeTrueWhenLikeExists()
+    {
+        await _fx.ResetAsync();
+        var (viewerId, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var clipId = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = viewerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await db.SaveChangesAsync();
+        }
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://example/url");
+
+        using var client = ClientWithBearer(viewerToken);
+        var resp = await client.GetAsync($"/clips/{clipId}");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
@@ -171,6 +171,63 @@ public class UsersEndpointsTests : IAsyncLifetime
         states[notLiked].Should().BeFalse();
     }
 
+    [Fact]
+    public async Task GetUser_CapsClipsAt20()
+    {
+        // UsersEndpoints.UserClipsPageSize = 20. Seed 21 ready clips and assert the cap holds —
+        // guards against accidental removal of the .Take(20) when someone adds cursor pagination.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("prolific");
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 21; i++)
+        {
+            await SeedClipAsync(userId, now.AddSeconds(-i), title: $"clip-{i}");
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/users/prolific");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("clips").GetArrayLength().Should().Be(20);
+    }
+
+    [Fact]
+    public async Task GetUser_DoesNotLeakClipsFromOtherUsers()
+    {
+        await _fx.ResetAsync();
+        var (aliceId, _) = await SeedUserAndIssueTokenAsync("alice");
+        var (bobId, _) = await SeedUserAndIssueTokenAsync("bob");
+        var now = DateTimeOffset.UtcNow;
+        var aliceClip = await SeedClipAsync(aliceId, now.AddSeconds(-1), title: "alice-clip");
+        await SeedClipAsync(bobId, now.AddSeconds(-2), title: "bob-clip");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/users/alice");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        var clipIds = body.GetProperty("clips").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        clipIds.Should().Equal(aliceClip);
+    }
+
+    [Fact]
+    public async Task GetUser_ExcludesFailedStatusClips()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("author");
+        var ready = await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddSeconds(-1), title: "ready");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, status: "failed", title: "failed");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/users/author");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        var clipIds = body.GetProperty("clips").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        clipIds.Should().Equal(ready);
+    }
+
     [Theory]
     [InlineData("a%")]
     [InlineData("a_____")]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class UsersEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public UsersEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private async Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(
+        string username = "owner",
+        string? bio = null,
+        string? avatarUrl = null)
+    {
+        var now = DateTimeOffset.UtcNow;
+        Guid id;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = username,
+                Email = $"{username}@example.com",
+                Bio = bio,
+                AvatarUrl = avatarUrl,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            id = user.Id;
+        }
+
+        using var scope = _factory!.Services.CreateScope();
+        var jwt = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var token = jwt.Issue(new User { Id = id, Username = username, Email = $"{username}@example.com" });
+        return (id, token);
+    }
+
+    private HttpClient ClientWithBearer(string token)
+    {
+        var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task<Guid> SeedClipAsync(
+        Guid userId,
+        DateTimeOffset createdAt,
+        string status = "ready",
+        string visibility = "public",
+        string? title = null)
+    {
+        var id = Guid.NewGuid();
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = title ?? "seed",
+            VideoKey = $"clips/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            Status = status,
+            Visibility = visibility,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task GetUser_NotFound_Returns404()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/users/nobody");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetUser_ReturnsProfileWithReadyPublicClipsOnly()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("alice", bio: "hi", avatarUrl: "https://cdn/a.png");
+        var now = DateTimeOffset.UtcNow;
+        var ready1 = await SeedClipAsync(userId, now.AddSeconds(-1), title: "ready-1");
+        var ready2 = await SeedClipAsync(userId, now.AddSeconds(-2), title: "ready-2");
+        await SeedClipAsync(userId, now, status: "processing", title: "not-ready");
+        await SeedClipAsync(userId, now, visibility: "unlisted", title: "unlisted");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/users/alice");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(userId);
+        body.GetProperty("username").GetString().Should().Be("alice");
+        body.GetProperty("bio").GetString().Should().Be("hi");
+        body.GetProperty("avatarUrl").GetString().Should().Be("https://cdn/a.png");
+
+        var clipIds = body.GetProperty("clips").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        clipIds.Should().Equal(ready1, ready2);
+    }
+
+    [Fact]
+    public async Task GetUser_CaseInsensitiveUsername()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("CamelCase");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/users/camelcase");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(userId);
+    }
+
+    [Fact]
+    public async Task GetUser_WithJwt_LikedByMeReflectsLikes()
+    {
+        await _fx.ResetAsync();
+        var (viewerId, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var now = DateTimeOffset.UtcNow;
+        var liked = await SeedClipAsync(authorId, now.AddSeconds(-1), title: "liked");
+        var notLiked = await SeedClipAsync(authorId, now.AddSeconds(-2), title: "not-liked");
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = viewerId, ClipId = liked, CreatedAt = now });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = ClientWithBearer(viewerToken);
+        var resp = await client.GetAsync("/users/author");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        var states = body.GetProperty("clips").EnumerateArray()
+            .ToDictionary(e => e.GetProperty("id").GetGuid(), e => e.GetProperty("likedByMe").GetBoolean());
+        states[liked].Should().BeTrue();
+        states[notLiked].Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetUser_EmptyClips_StillReturnsProfile()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("lurker");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/users/lurker");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(userId);
+        body.GetProperty("clips").GetArrayLength().Should().Be(0);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
@@ -171,6 +171,25 @@ public class UsersEndpointsTests : IAsyncLifetime
         states[notLiked].Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData("a%")]
+    [InlineData("a_____")]
+    [InlineData("%")]
+    public async Task GetUser_UsernameWithSqlWildcard_Returns404(string wildcardUsername)
+    {
+        // Regression: an earlier implementation used EF.Functions.ILike which interpreted `%` and `_`
+        // as wildcards, letting /users/a% match any username starting with "a" and legitimate `_` in
+        // usernames become match-any. Fix uses case-insensitive equality instead.
+        await _fx.ResetAsync();
+        await SeedUserAndIssueTokenAsync("alice");
+        await SeedUserAndIssueTokenAsync("alpha_one");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/users/{Uri.EscapeDataString(wildcardUsername)}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     [Fact]
     public async Task GetUser_EmptyClips_StillReturnsProfile()
     {


### PR DESCRIPTION
## Summary
Adds the three anonymous read endpoints from issue #7 — `GET /clips/feed` (cursor-paginated), `GET /clips/{id}` (1-hour presigned video URL + author), and `GET /users/{username}` (profile + their public clips) — and introduces a `Contracts/<Area>/` DTO convention with hand-written mappers that future server work can follow.

## What's here
- Three new minimal-API endpoints in `server/src/GankedTV.Api/Endpoints/`, anonymous by default with optional JWT-driven `likedByMe`.
- New `Contracts/Clips/` and `Contracts/Users/` DTO layout (one `sealed record` per file, static extension mappers). Convention documented in [PLAN.md §11](PLAN.md) and referenced from issues #8, #15, and follow-up #26.
- Composite `(CreatedAt, Id)` keyset cursor — tie-breaker prevents skips on identical timestamps.
- Case-insensitive username lookup via `LOWER(...)` equality rather than `ILIKE` (avoids `%`/`_` wildcard injection).
- 30 integration tests covering empty feed, pagination boundaries, limit clamps, status filters, cross-user like/clip isolation, wildcard regression, cursor tie-breakers, and invalid-cursor fallback.

Closes #7

## How to test manually
```bash
make up
dotnet test server                    # 157/157 pass
dotnet watch --project server/src/GankedTV.Api

# Anonymous
curl -s localhost:5000/clips/feed | jq
curl -s localhost:5000/clips/<id>  | jq
curl -s localhost:5000/users/<username> | jq

# With JWT (dev token via POST /dev/token)
curl -s -H "Authorization: Bearer $JWT" localhost:5000/clips/feed | jq '.items[0].likedByMe'
```

## Checklist
- [ ] Verified manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clip feed API with stable cursor-based pagination, deterministic ordering, and URL-safe cursors.
  * Clip detail API returning presigned video URLs (1-hour access window) plus clip metadata.
  * User profile API returning user info and their public clips (up to 20), with per-item liked-by-you status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->