### PR TITLE
Dependabot implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/server"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "area:server"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "bun"
+    directory: "/web"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "area:web"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "area:ci"
+    commit-message:
+      prefix: "chore"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` so NuGet, Bun, and GitHub Actions dependencies all get checked monthly. Two companion repo tweaks land outside the diff — new labels (`area:ci`, `dependencies`) and a squash-merge setting change so `Co-Authored-By` trailers can no longer leak into merged commits.

## What's here
- `nuget` at `/server`, `bun` at `/web`, `github-actions` at `/` — all monthly
- `minor` + `patch` grouped into one PR per ecosystem; majors stay as individual PRs
- Labels per ecosystem: `dependencies` + `area:server` / `area:web` / `area:ci`
- Out-of-diff: created `area:ci` and `dependencies` labels; repo squash-merge now `title=PR_TITLE`, `message=BLANK`

Closes #28

## How to test manually
1. After merge, open Insights → Dependency graph → Dependabot — all three ecosystems should list with a recent "Last checked" timestamp and no config errors.
2. Hit "Check for updates" on each ecosystem to force a first run instead of waiting for the monthly cron.
3. Confirm any resulting PR carries `dependencies` + the correct `area:*` label.

## Checklist
- [ ] Verified manually
