### PR TITLE
[server] Clip mutate + likes: PATCH/DELETE + like/unlike

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Clips/LikeResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/LikeResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record LikeResponse(int LikeCount, bool Liked);

--- a/server/src/GankedTV.Api/Contracts/Clips/UpdateClipRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/UpdateClipRequest.cs
@@ -1,0 +1,7 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record UpdateClipRequest(
+    string? Title,
+    string? Description,
+    int? GameId,
+    string? Visibility);

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -1,0 +1,166 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Data;
+using GankedTV.Api.Services.ObjectStorage;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class ClipsMutateEndpoints
+{
+    private const int MaxTitleLength = 255;
+    private static readonly string[] AllowedVisibilities = ["public", "unlisted"];
+    private static readonly TimeSpan VideoUrlLifetime = TimeSpan.FromHours(1);
+    private static readonly string LogCategory = typeof(ClipsMutateEndpoints).FullName!;
+
+    public static IEndpointRouteBuilder MapClipsMutateEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/clips").RequireAuthorization();
+        group.MapPatch("/{id:guid}", PatchClip);
+        group.MapDelete("/{id:guid}", DeleteClip);
+        return app;
+    }
+
+    private static async Task<IResult> PatchClip(
+        Guid id,
+        [FromBody] UpdateClipRequest? req,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<MinioOptions> minio,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        if (req is null)
+        {
+            return Results.BadRequest(new { error = "invalid_body" });
+        }
+
+        var clip = await db.Clips
+            .Include(c => c.User)
+            .FirstOrDefaultAsync(c => c.Id == id, ct);
+
+        if (clip is null)
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        if (clip.UserId != userId)
+        {
+            return Results.Forbid();
+        }
+
+        if (req.Title is not null)
+        {
+            var trimmed = req.Title.Trim();
+            if (trimmed.Length == 0 || trimmed.Length > MaxTitleLength)
+            {
+                return Results.BadRequest(new { error = "invalid_title" });
+            }
+            clip.Title = trimmed;
+        }
+
+        if (req.Description is not null)
+        {
+            clip.Description = req.Description;
+        }
+
+        if (req.Visibility is not null)
+        {
+            if (!AllowedVisibilities.Contains(req.Visibility))
+            {
+                return Results.BadRequest(new { error = "invalid_visibility" });
+            }
+            clip.Visibility = req.Visibility;
+        }
+
+        if (req.GameId is not null)
+        {
+            var gameExists = await db.Games.AnyAsync(g => g.Id == req.GameId.Value, ct);
+            if (!gameExists)
+            {
+                return Results.BadRequest(new { error = "invalid_game" });
+            }
+            clip.GameId = req.GameId;
+        }
+
+        clip.UpdatedAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync(ct);
+
+        var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
+        var videoUrl = storage.GetPresignedGetUrl(minio.Value.ClipsBucket, clip.VideoKey, VideoUrlLifetime);
+        var likedByMe = await db.Likes.AsNoTracking()
+            .AnyAsync(l => l.ClipId == clip.Id && l.UserId == userId, ct);
+
+        return Results.Ok(clip.ToDetail(videoUrl, expiresAt, likedByMe));
+    }
+
+    private static async Task<IResult> DeleteClip(
+        Guid id,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<MinioOptions> minio,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        var clip = await db.Clips.FirstOrDefaultAsync(c => c.Id == id, ct);
+        if (clip is null)
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        if (clip.UserId != userId)
+        {
+            return Results.Forbid();
+        }
+
+        var videoKey = clip.VideoKey;
+        var thumbnailKey = clip.ThumbnailKey;
+
+        db.Clips.Remove(clip);
+        await db.SaveChangesAsync(ct);
+
+        // S3 cleanup is best-effort: the DB row is already gone, so a cleanup failure must not
+        // surface as 500 (that would mislead the client into retrying a non-existent row).
+        // Orphaned S3 objects are cheap; a future reaper can sweep them.
+        try
+        {
+            await storage.DeleteObjectAsync(minio.Value.ClipsBucket, videoKey, ct);
+            if (!string.IsNullOrEmpty(thumbnailKey))
+            {
+                await storage.DeleteObjectAsync(minio.Value.ThumbnailsBucket, thumbnailKey, ct);
+            }
+        }
+        catch (Exception ex)
+        {
+            loggerFactory.CreateLogger(LogCategory).LogWarning(
+                ex,
+                "Failed to delete S3 objects for clip {ClipId} (video={VideoKey}, thumb={ThumbKey})",
+                id, videoKey, thumbnailKey);
+        }
+
+        return Results.NoContent();
+    }
+
+    private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
+    {
+        userId = default;
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out userId);
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -12,7 +13,6 @@ namespace GankedTV.Api.Endpoints;
 
 public static class ClipsMutateEndpoints
 {
-    private const int MaxTitleLength = 255;
     private static readonly string[] AllowedVisibilities = ["public", "unlisted"];
     private static readonly TimeSpan VideoUrlLifetime = TimeSpan.FromHours(1);
     private static readonly string LogCategory = typeof(ClipsMutateEndpoints).FullName!;
@@ -32,6 +32,7 @@ public static class ClipsMutateEndpoints
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<MinioOptions> minio,
+        IOptions<ClipValidationOptions> validation,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -58,10 +59,12 @@ public static class ClipsMutateEndpoints
             return Results.Forbid();
         }
 
+        var limits = validation.Value;
+
         if (req.Title is not null)
         {
             var trimmed = req.Title.Trim();
-            if (trimmed.Length == 0 || trimmed.Length > MaxTitleLength)
+            if (trimmed.Length == 0 || trimmed.Length > limits.MaxTitleLength)
             {
                 return Results.BadRequest(new { error = "invalid_title" });
             }
@@ -70,6 +73,13 @@ public static class ClipsMutateEndpoints
 
         if (req.Description is not null)
         {
+            // Mirrors the upload-side cap in ClipUploadService; keeping them aligned through the
+            // shared ClipValidationOptions prevents PATCH from becoming a backdoor around the
+            // storage/readability limits CREATE enforces.
+            if (req.Description.Length > limits.MaxDescriptionLength)
+            {
+                return Results.BadRequest(new { error = "invalid_description" });
+            }
             clip.Description = req.Description;
         }
 

--- a/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
@@ -1,0 +1,119 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class LikesEndpoints
+{
+    public static IEndpointRouteBuilder MapLikesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/clips").RequireAuthorization();
+        group.MapPost("/{id:guid}/like", LikeClip);
+        group.MapDelete("/{id:guid}/like", UnlikeClip);
+        return app;
+    }
+
+    private static async Task<IResult> LikeClip(
+        Guid id,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
+
+        var clipExists = await db.Clips.AnyAsync(c => c.Id == id, ct);
+        if (!clipExists)
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        var already = await db.Likes.AnyAsync(l => l.UserId == userId && l.ClipId == id, ct);
+        if (!already)
+        {
+            db.Likes.Add(new Like
+            {
+                UserId = userId,
+                ClipId = id,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            await db.SaveChangesAsync(ct);
+            // Raw-SQL increment keeps the counter race-free against concurrent likers on
+            // a different row (we already hold the (user,clip) row uniquely via the PK).
+            await db.Clips.Where(c => c.Id == id)
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(c => c.LikeCount, c => c.LikeCount + 1),
+                    ct);
+        }
+
+        var count = await db.Clips.AsNoTracking()
+            .Where(c => c.Id == id)
+            .Select(c => c.LikeCount)
+            .FirstAsync(ct);
+
+        await tx.CommitAsync(ct);
+
+        return Results.Ok(new LikeResponse(count, true));
+    }
+
+    private static async Task<IResult> UnlikeClip(
+        Guid id,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
+
+        var clipExists = await db.Clips.AnyAsync(c => c.Id == id, ct);
+        if (!clipExists)
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        var like = await db.Likes.FirstOrDefaultAsync(
+            l => l.UserId == userId && l.ClipId == id, ct);
+
+        if (like is not null)
+        {
+            db.Likes.Remove(like);
+            await db.SaveChangesAsync(ct);
+            // `LikeCount > 0` guard provides the ≥ 0 clamp required by the acceptance
+            // criteria: if the counter is already 0 (data drift, manual row insert, etc.)
+            // the decrement is a no-op rather than introducing a negative count.
+            await db.Clips.Where(c => c.Id == id && c.LikeCount > 0)
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(c => c.LikeCount, c => c.LikeCount - 1),
+                    ct);
+        }
+
+        var count = await db.Clips.AsNoTracking()
+            .Where(c => c.Id == id)
+            .Select(c => c.LikeCount)
+            .FirstAsync(ct);
+
+        await tx.CommitAsync(ct);
+
+        return Results.Ok(new LikeResponse(count, false));
+    }
+
+    private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
+    {
+        userId = default;
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out userId);
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
@@ -4,6 +4,7 @@ using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace GankedTV.Api.Endpoints;
 
@@ -45,13 +46,29 @@ public static class LikesEndpoints
                 ClipId = id,
                 CreatedAt = DateTimeOffset.UtcNow,
             });
-            await db.SaveChangesAsync(ct);
-            // Raw-SQL increment keeps the counter race-free against concurrent likers on
-            // a different row (we already hold the (user,clip) row uniquely via the PK).
-            await db.Clips.Where(c => c.Id == id)
-                .ExecuteUpdateAsync(
-                    s => s.SetProperty(c => c.LikeCount, c => c.LikeCount + 1),
-                    ct);
+            try
+            {
+                await db.SaveChangesAsync(ct);
+                // Raw-SQL increment keeps the counter race-free against concurrent likers on
+                // a different row (we already hold the (user,clip) row uniquely via the PK).
+                await db.Clips.Where(c => c.Id == id)
+                    .ExecuteUpdateAsync(
+                        s => s.SetProperty(c => c.LikeCount, c => c.LikeCount + 1),
+                        ct);
+            }
+            catch (DbUpdateException ex) when (IsLikePrimaryKeyViolation(ex))
+            {
+                // Race: a concurrent request from the same user passed the `already` check and
+                // inserted+incremented before us. Postgres aborts our transaction on the unique
+                // violation, so we must roll back explicitly; then re-read the counter outside
+                // the dead transaction and return success idempotently.
+                await tx.RollbackAsync(ct);
+                var raceCount = await db.Clips.AsNoTracking()
+                    .Where(c => c.Id == id)
+                    .Select(c => c.LikeCount)
+                    .FirstAsync(ct);
+                return Results.Ok(new LikeResponse(raceCount, true));
+            }
         }
 
         var count = await db.Clips.AsNoTracking()
@@ -116,4 +133,10 @@ public static class LikesEndpoints
             ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         return Guid.TryParse(sub, out userId);
     }
+
+    // `likes` has a single unique constraint (the composite PK on user_id + clip_id), so any
+    // unique violation coming out of a likes INSERT is unambiguously the idempotency race.
+    private static bool IsLikePrimaryKeyViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg
+        && pg.SqlState == PostgresErrorCodes.UniqueViolation;
 }

--- a/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
@@ -2,9 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
-using GankedTV.Api.Data.Entities;
 using Microsoft.EntityFrameworkCore;
-using Npgsql;
 
 namespace GankedTV.Api.Endpoints;
 
@@ -37,38 +35,20 @@ public static class LikesEndpoints
             return Results.NotFound(new { error = "not_found" });
         }
 
-        var already = await db.Likes.AnyAsync(l => l.UserId == userId && l.ClipId == id, ct);
-        if (!already)
+        // Atomic idempotent insert: ON CONFLICT DO NOTHING collapses a duplicate like (sequential
+        // double-click OR two concurrent requests from the same user) into a 0-row insert, so we
+        // only bump the counter when the row was actually new. `created_at` falls back to the
+        // column's DEFAULT now() from the migration.
+        var inserted = await db.Database.ExecuteSqlInterpolatedAsync(
+            $"INSERT INTO likes (user_id, clip_id) VALUES ({userId}, {id}) ON CONFLICT DO NOTHING",
+            ct);
+
+        if (inserted == 1)
         {
-            db.Likes.Add(new Like
-            {
-                UserId = userId,
-                ClipId = id,
-                CreatedAt = DateTimeOffset.UtcNow,
-            });
-            try
-            {
-                await db.SaveChangesAsync(ct);
-                // Raw-SQL increment keeps the counter race-free against concurrent likers on
-                // a different row (we already hold the (user,clip) row uniquely via the PK).
-                await db.Clips.Where(c => c.Id == id)
-                    .ExecuteUpdateAsync(
-                        s => s.SetProperty(c => c.LikeCount, c => c.LikeCount + 1),
-                        ct);
-            }
-            catch (DbUpdateException ex) when (IsLikePrimaryKeyViolation(ex))
-            {
-                // Race: a concurrent request from the same user passed the `already` check and
-                // inserted+incremented before us. Postgres aborts our transaction on the unique
-                // violation, so we must roll back explicitly; then re-read the counter outside
-                // the dead transaction and return success idempotently.
-                await tx.RollbackAsync(ct);
-                var raceCount = await db.Clips.AsNoTracking()
-                    .Where(c => c.Id == id)
-                    .Select(c => c.LikeCount)
-                    .FirstAsync(ct);
-                return Results.Ok(new LikeResponse(raceCount, true));
-            }
+            await db.Clips.Where(c => c.Id == id)
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(c => c.LikeCount, c => c.LikeCount + 1),
+                    ct);
         }
 
         var count = await db.Clips.AsNoTracking()
@@ -100,13 +80,15 @@ public static class LikesEndpoints
             return Results.NotFound(new { error = "not_found" });
         }
 
-        var like = await db.Likes.FirstOrDefaultAsync(
-            l => l.UserId == userId && l.ClipId == id, ct);
+        // Set-based delete: a single SQL DELETE that returns the row count. Under concurrent
+        // unlikes from the same user, only one request sees deleted==1, the other sees 0 —
+        // neither throws DbUpdateConcurrencyException the way FirstOrDefaultAsync+Remove would.
+        var deleted = await db.Likes
+            .Where(l => l.UserId == userId && l.ClipId == id)
+            .ExecuteDeleteAsync(ct);
 
-        if (like is not null)
+        if (deleted > 0)
         {
-            db.Likes.Remove(like);
-            await db.SaveChangesAsync(ct);
             // `LikeCount > 0` guard provides the ≥ 0 clamp required by the acceptance
             // criteria: if the counter is already 0 (data drift, manual row insert, etc.)
             // the decrement is a no-op rather than introducing a negative count.
@@ -133,10 +115,4 @@ public static class LikesEndpoints
             ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         return Guid.TryParse(sub, out userId);
     }
-
-    // `likes` has a single unique constraint (the composite PK on user_id + clip_id), so any
-    // unique violation coming out of a likes INSERT is unambiguously the idempotency race.
-    private static bool IsLikePrimaryKeyViolation(DbUpdateException ex) =>
-        ex.InnerException is PostgresException pg
-        && pg.SqlState == PostgresErrorCodes.UniqueViolation;
 }

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -196,6 +196,8 @@ app.MapAuthEndpoints();
 app.MapMeEndpoints();
 app.MapClipsUploadEndpoints();
 app.MapClipsReadEndpoints();
+app.MapClipsMutateEndpoints();
+app.MapLikesEndpoints();
 app.MapUsersEndpoints();
 
 if (app.Environment.IsDevelopment())
@@ -207,5 +209,3 @@ if (app.Environment.IsDevelopment())
 }
 
 app.Run();
-
-public partial class Program;

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
@@ -1,0 +1,501 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class ClipsMutateEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public ClipsMutateEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://minio.local/presigned");
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private async Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "owner")
+    {
+        var now = DateTimeOffset.UtcNow;
+        Guid id;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = username,
+                Email = $"{username}@example.com",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            id = user.Id;
+        }
+
+        using var scope = _factory!.Services.CreateScope();
+        var jwt = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var token = jwt.Issue(new User { Id = id, Username = username, Email = $"{username}@example.com" });
+        return (id, token);
+    }
+
+    private HttpClient ClientWithBearer(string token)
+    {
+        var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task<Guid> SeedClipAsync(
+        Guid userId,
+        string title = "seed",
+        string? description = null,
+        string visibility = "public",
+        string status = "ready",
+        int? gameId = null,
+        string? thumbnailKey = null,
+        DateTimeOffset? createdAt = null)
+    {
+        var id = Guid.NewGuid();
+        var seeded = createdAt ?? DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = title,
+            Description = description,
+            GameId = gameId,
+            VideoKey = $"clips/{id}.mp4",
+            ThumbnailKey = thumbnailKey,
+            Status = status,
+            Visibility = visibility,
+            CreatedAt = seeded,
+            UpdatedAt = seeded,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    // ---- PATCH /clips/{id} ----
+
+    [Fact]
+    public async Task Patch_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{Guid.NewGuid()}", new { title = "x" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Patch_ClipMissing_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{Guid.NewGuid()}", new { title = "x" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Patch_NonOwner_Returns403()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, _) = await SeedUserAndIssueTokenAsync("owner");
+        var (_, otherToken) = await SeedUserAndIssueTokenAsync("other");
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(otherToken);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "hijacked" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Patch_Owner_UpdatesTitle_ReturnsUpdatedDetail()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId, title: "original", description: "before");
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "renamed" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(clipId);
+        body.GetProperty("title").GetString().Should().Be("renamed");
+        body.GetProperty("description").GetString().Should().Be("before");
+
+        await using var db = _fx.CreateContext();
+        var persisted = await db.Clips.AsNoTracking().FirstAsync(c => c.Id == clipId);
+        persisted.Title.Should().Be("renamed");
+        persisted.Description.Should().Be("before");
+    }
+
+    [Fact]
+    public async Task Patch_UpdatesVisibility_Persists()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId, visibility: "public");
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { visibility = "unlisted" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var db = _fx.CreateContext();
+        var persisted = await db.Clips.AsNoTracking().FirstAsync(c => c.Id == clipId);
+        persisted.Visibility.Should().Be("unlisted");
+    }
+
+    [Fact]
+    public async Task Patch_InvalidVisibility_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { visibility = "private" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Patch_TitleTooLong_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = new string('a', 256) });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Patch_EmptyTitle_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "   " });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Patch_NonExistentGameId_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { gameId = 999_999 });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Patch_ValidGameId_Persists()
+    {
+        // Game id 1 ("League of Legends") is seeded by the initial migration and survives
+        // PostgresFixture resets (games are in TablesToIgnore).
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { gameId = 1 });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var db = _fx.CreateContext();
+        var persisted = await db.Clips.AsNoTracking().FirstAsync(c => c.Id == clipId);
+        persisted.GameId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Patch_UpdatesDescription_Persists()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId, description: "before");
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { description = "after" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("description").GetString().Should().Be("after");
+
+        await using var db = _fx.CreateContext();
+        var persisted = await db.Clips.AsNoTracking().FirstAsync(c => c.Id == clipId);
+        persisted.Description.Should().Be("after");
+    }
+
+    [Fact]
+    public async Task Patch_MultiField_AppliesAll()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(
+            ownerId,
+            title: "original",
+            description: "orig desc",
+            visibility: "public",
+            gameId: null);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new
+        {
+            title = "new title",
+            description = "new desc",
+            visibility = "unlisted",
+            gameId = 2,
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var db = _fx.CreateContext();
+        var persisted = await db.Clips.AsNoTracking().FirstAsync(c => c.Id == clipId);
+        persisted.Title.Should().Be("new title");
+        persisted.Description.Should().Be("new desc");
+        persisted.Visibility.Should().Be("unlisted");
+        persisted.GameId.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Patch_BumpsUpdatedAt()
+    {
+        // Seed the clip an hour in the past so the UpdatedAt bump is unambiguously observable;
+        // same-tick resolution with DateTimeOffset.UtcNow would make the assertion flaky.
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var seededAt = DateTimeOffset.UtcNow.AddHours(-1);
+        var clipId = await SeedClipAsync(ownerId, createdAt: seededAt);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "bump" });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = _fx.CreateContext();
+        var persisted = await db.Clips.AsNoTracking().FirstAsync(c => c.Id == clipId);
+        persisted.UpdatedAt.Should().BeAfter(seededAt);
+        persisted.CreatedAt.Should().BeCloseTo(seededAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Patch_Response_IncludesFreshPresignedUrl()
+    {
+        // PATCH response reuses ToDetail → videoUrl must be a freshly-presigned URL for the clip's
+        // current VideoKey, with expiry roughly one hour out.
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        const string presigned = "https://minio.local/fresh?sig=abc";
+        _storage
+            .GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns(presigned);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "fresh" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("videoUrl").GetString().Should().Be(presigned);
+
+        var expiresAt = body.GetProperty("videoUrlExpiresAt").GetDateTimeOffset();
+        expiresAt.Should().BeCloseTo(DateTimeOffset.UtcNow.AddHours(1), TimeSpan.FromMinutes(2));
+
+        _storage.Received().GetPresignedGetUrl(
+            Arg.Any<string>(),
+            $"clips/{clipId}.mp4",
+            Arg.Is<TimeSpan?>(ts => ts.HasValue && ts.Value == TimeSpan.FromHours(1)));
+    }
+
+    [Fact]
+    public async Task Patch_Response_LikedByMe_ReflectsViewerLikeRow()
+    {
+        // The owner PATCHing their own clip may or may not have a like row themselves. Seed one
+        // so `likedByMe` must come out true, proving the lookup uses the authed userId rather
+        // than a default/false shortcut.
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+        await using (var seed = _fx.CreateContext())
+        {
+            seed.Likes.Add(new Like { UserId = ownerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await seed.SaveChangesAsync();
+        }
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "liked-by-owner" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+    }
+
+    // ---- DELETE /clips/{id} ----
+
+    [Fact]
+    public async Task Delete_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.DeleteAsync($"/clips/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Delete_ClipMissing_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.DeleteAsync($"/clips/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_NonOwner_Returns403()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, _) = await SeedUserAndIssueTokenAsync("owner");
+        var (_, otherToken) = await SeedUserAndIssueTokenAsync("other");
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(otherToken);
+        var resp = await client.DeleteAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Delete_Owner_Returns204_RemovesRow_DeletesS3Objects()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId, thumbnailKey: "thumbs/x.jpg");
+
+        using var scope = _factory!.Services.CreateScope();
+        var minio = scope.ServiceProvider
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<MinioOptions>>()
+            .Value;
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.DeleteAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var db = _fx.CreateContext();
+        (await db.Clips.AnyAsync(c => c.Id == clipId)).Should().BeFalse();
+
+        // Video goes to ClipsBucket, thumbnail goes to ThumbnailsBucket — a swap would leak the
+        // video key into the thumbnails bucket (and vice versa), silently breaking cleanup.
+        await _storage.Received(1).DeleteObjectAsync(
+            minio.ClipsBucket,
+            $"clips/{clipId}.mp4",
+            Arg.Any<CancellationToken>());
+        await _storage.Received(1).DeleteObjectAsync(
+            minio.ThumbnailsBucket,
+            "thumbs/x.jpg",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Delete_Owner_NoThumbnail_SkipsThumbnailBucketDelete()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId, thumbnailKey: null);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.DeleteAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Exactly one storage delete call — for the video — since there was no thumbnail.
+        await _storage.Received(1).DeleteObjectAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Delete_CascadesLikes()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync("owner");
+        var (likerId, _) = await SeedUserAndIssueTokenAsync("liker");
+        var clipId = await SeedClipAsync(ownerId);
+        await using (var seed = _fx.CreateContext())
+        {
+            seed.Likes.Add(new Like { UserId = likerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await seed.SaveChangesAsync();
+        }
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.DeleteAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await using var db = _fx.CreateContext();
+        (await db.Likes.AnyAsync(l => l.ClipId == clipId)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Delete_S3FailureStillReturns204()
+    {
+        // Best-effort S3 cleanup: DB row is already gone, so a storage failure must not surface
+        // as 500. Covers the catch block in DeleteClip.
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        _storage
+            .DeleteObjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("minio down")));
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.DeleteAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await using var db = _fx.CreateContext();
+        (await db.Clips.AnyAsync(c => c.Id == clipId)).Should().BeFalse();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
@@ -138,6 +138,58 @@ public class ClipsMutateEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Patch_NonOwner_InvalidField_Returns403NotBadRequest()
+    {
+        // Locks in ownership-before-validation ordering. If the checks were reordered, a
+        // non-owner sending an invalid body would get 400 instead of 403 — which would tell
+        // them the clip exists and their payload was parsed. Non-owners shouldn't learn either.
+        await _fx.ResetAsync();
+        var (ownerId, _) = await SeedUserAndIssueTokenAsync("owner");
+        var (_, otherToken) = await SeedUserAndIssueTokenAsync("other");
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(otherToken);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { visibility = "bogus" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Patch_NullBody_Returns400()
+    {
+        // Literal JSON `null` deserializes to a null UpdateClipRequest reference; the endpoint
+        // must reject it explicitly rather than NRE on the first property read.
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync<object?>($"/clips/{clipId}", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Patch_EmptyObject_ReturnsOk_BumpsUpdatedAt()
+    {
+        // `{}` is a valid PATCH with no field updates — the contract is that it still bumps
+        // UpdatedAt and returns 200. If that ever flips to 400 or a no-op response, clients
+        // depending on "touch to refresh" would silently break.
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var seededAt = DateTimeOffset.UtcNow.AddHours(-1);
+        var clipId = await SeedClipAsync(ownerId, createdAt: seededAt);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var db = _fx.CreateContext();
+        var persisted = await db.Clips.AsNoTracking().FirstAsync(c => c.Id == clipId);
+        persisted.UpdatedAt.Should().BeAfter(seededAt);
+    }
+
+    [Fact]
     public async Task Patch_Owner_UpdatesTitle_ReturnsUpdatedDetail()
     {
         await _fx.ResetAsync();
@@ -210,6 +262,21 @@ public class ClipsMutateEndpointsTests : IAsyncLifetime
 
         using var client = ClientWithBearer(token);
         var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "   " });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Patch_DescriptionTooLong_Returns400()
+    {
+        // MaxDescriptionLength defaults to 5000 in ClipValidationOptions; 5001 trips the cap
+        // and keeps PATCH aligned with the upload-side validation (ClipUploadService).
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { description = new string('a', 5001) });
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
@@ -250,21 +250,73 @@ public class LikesEndpointsTests : IAsyncLifetime
     [Fact]
     public async Task Unlike_DoesNotDecrementBelowZero()
     {
-        // Acceptance criterion: like_count must clamp at ≥ 0. If the counter drifts (row-less like
-        // state, manual fixture, data repair), redundant unlikes must not produce a negative count.
+        // Acceptance criterion: like_count must clamp at ≥ 0. Exercises the `WHERE like_count > 0`
+        // predicate on the decrement by setting up the data-drift scenario it exists for: a Like
+        // row present but LikeCount already 0 (e.g. manual DB repair, counter-drift bug). Without
+        // the predicate the decrement would take the counter to -1.
         await _fx.ResetAsync();
         var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
-        var (_, token) = await SeedUserAndIssueTokenAsync("fan");
+        var (fanId, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId, initialLikeCount: 0);
+        await using (var seed = _fx.CreateContext())
+        {
+            seed.Likes.Add(new Like { UserId = fanId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await seed.SaveChangesAsync();
+        }
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.DeleteAsync($"/clips/{clipId}/like");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likeCount").GetInt32().Should().Be(0);
+
+        await using var db = _fx.CreateContext();
+        (await db.Likes.AnyAsync(l => l.UserId == fanId && l.ClipId == clipId)).Should().BeFalse();
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Unlike_NeverLiked_CounterAtZero_StaysZero()
+    {
+        // Complements the clamp test above for the no-like-row path: idempotent unlike against
+        // a clip at zero should not touch the counter.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, token) = await SeedUserAndIssueTokenAsync("stranger");
         var clipId = await SeedClipAsync(authorId, initialLikeCount: 0);
 
         using var client = ClientWithBearer(token);
-        var resp1 = await client.DeleteAsync($"/clips/{clipId}/like");
-        var resp2 = await client.DeleteAsync($"/clips/{clipId}/like");
+        var resp = await client.DeleteAsync($"/clips/{clipId}/like");
 
-        resp1.StatusCode.Should().Be(HttpStatusCode.OK);
-        resp2.StatusCode.Should().Be(HttpStatusCode.OK);
-
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
         await using var db = _fx.CreateContext();
         (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Like_ConcurrentSameUser_FinalStateIsConsistent()
+    {
+        // Parallel POSTs from the same user: the `already` check races, so between 1..N requests
+        // may reach the INSERT path and collide on the composite PK. The endpoint must coalesce
+        // them into a single logical like — one row, counter == 1, all responses 2xx.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (userId, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId);
+
+        const int parallelism = 8;
+        var tasks = Enumerable.Range(0, parallelism).Select(async _ =>
+        {
+            using var client = ClientWithBearer(token);
+            return await client.PostAsync($"/clips/{clipId}/like", content: null);
+        }).ToArray();
+        var responses = await Task.WhenAll(tasks);
+
+        responses.Should().OnlyContain(r => r.IsSuccessStatusCode);
+
+        await using var db = _fx.CreateContext();
+        (await db.Likes.CountAsync(l => l.UserId == userId && l.ClipId == clipId)).Should().Be(1);
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(1);
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
@@ -1,0 +1,270 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class LikesEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public LikesEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private async Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "liker")
+    {
+        var now = DateTimeOffset.UtcNow;
+        Guid id;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = username,
+                Email = $"{username}@example.com",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            id = user.Id;
+        }
+
+        using var scope = _factory!.Services.CreateScope();
+        var jwt = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var token = jwt.Issue(new User { Id = id, Username = username, Email = $"{username}@example.com" });
+        return (id, token);
+    }
+
+    private HttpClient ClientWithBearer(string token)
+    {
+        var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task<Guid> SeedClipAsync(Guid userId, int initialLikeCount = 0)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = "likable",
+            VideoKey = $"clips/{id}.mp4",
+            Status = "ready",
+            Visibility = "public",
+            LikeCount = initialLikeCount,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    // ---- POST /clips/{id}/like ----
+
+    [Fact]
+    public async Task Like_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsync($"/clips/{Guid.NewGuid()}/like", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Like_ClipMissing_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsync($"/clips/{Guid.NewGuid()}/like", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Like_FirstTime_InsertsRowAndIncrementsCounter()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (userId, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/clips/{clipId}/like", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likeCount").GetInt32().Should().Be(1);
+        body.GetProperty("liked").GetBoolean().Should().BeTrue();
+
+        await using var db = _fx.CreateContext();
+        (await db.Likes.AnyAsync(l => l.UserId == userId && l.ClipId == clipId)).Should().BeTrue();
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Like_DoubleLike_IsIdempotent()
+    {
+        // Acceptance criterion: POST /like must be idempotent. Two sequential calls from the same
+        // user leave exactly one row and like_count == 1.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (userId, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        var first = await client.PostAsync($"/clips/{clipId}/like", content: null);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var second = await client.PostAsync($"/clips/{clipId}/like", content: null);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likeCount").GetInt32().Should().Be(1);
+        body.GetProperty("liked").GetBoolean().Should().BeTrue();
+
+        await using var db = _fx.CreateContext();
+        (await db.Likes.CountAsync(l => l.UserId == userId && l.ClipId == clipId)).Should().Be(1);
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Like_MultipleUsers_SumCorrectly()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, token1) = await SeedUserAndIssueTokenAsync("fan1");
+        var (_, token2) = await SeedUserAndIssueTokenAsync("fan2");
+        var clipId = await SeedClipAsync(authorId);
+
+        using (var c1 = ClientWithBearer(token1))
+        {
+            (await c1.PostAsync($"/clips/{clipId}/like", content: null)).EnsureSuccessStatusCode();
+        }
+        using (var c2 = ClientWithBearer(token2))
+        {
+            var resp = await c2.PostAsync($"/clips/{clipId}/like", content: null);
+            resp.StatusCode.Should().Be(HttpStatusCode.OK);
+            var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("likeCount").GetInt32().Should().Be(2);
+        }
+
+        await using var db = _fx.CreateContext();
+        (await db.Likes.CountAsync(l => l.ClipId == clipId)).Should().Be(2);
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(2);
+    }
+
+    // ---- DELETE /clips/{id}/like ----
+
+    [Fact]
+    public async Task Unlike_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.DeleteAsync($"/clips/{Guid.NewGuid()}/like");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Unlike_ClipMissing_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.DeleteAsync($"/clips/{Guid.NewGuid()}/like");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Unlike_WhenNeverLiked_IsIdempotent_Returns200()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, token) = await SeedUserAndIssueTokenAsync("stranger");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.DeleteAsync($"/clips/{clipId}/like");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likeCount").GetInt32().Should().Be(0);
+        body.GetProperty("liked").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Unlike_AfterLike_RemovesRow_DecrementsCounter()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (userId, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        (await client.PostAsync($"/clips/{clipId}/like", content: null)).EnsureSuccessStatusCode();
+
+        var resp = await client.DeleteAsync($"/clips/{clipId}/like");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("likeCount").GetInt32().Should().Be(0);
+        body.GetProperty("liked").GetBoolean().Should().BeFalse();
+
+        await using var db = _fx.CreateContext();
+        (await db.Likes.AnyAsync(l => l.UserId == userId && l.ClipId == clipId)).Should().BeFalse();
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Unlike_DoesNotDecrementBelowZero()
+    {
+        // Acceptance criterion: like_count must clamp at ≥ 0. If the counter drifts (row-less like
+        // state, manual fixture, data repair), redundant unlikes must not produce a negative count.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId, initialLikeCount: 0);
+
+        using var client = ClientWithBearer(token);
+        var resp1 = await client.DeleteAsync($"/clips/{clipId}/like");
+        var resp2 = await client.DeleteAsync($"/clips/{clipId}/like");
+
+        resp1.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp2.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = _fx.CreateContext();
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds owner-only edit/delete plus idempotent like toggle endpoints, closing the clip write-path from issue #8. Honors the DTO convention introduced in #7 (sealed records per file under `Contracts/Clips/`, hand-written mappers, no inline DTO construction).

## What's here

- `PATCH /clips/{id}` — owner-only partial update of `title` / `description` / `gameId` / `visibility`. Returns `200` with a freshly-presigned `ClipDetailResponse` (video URL + `likedByMe` resolved for the caller). Non-owner → `403`, missing → `404`, invalid fields → `400`.
- `DELETE /clips/{id}` — owner-only hard delete. Cascades the `likes` rows via existing FK, then best-effort deletes video + thumbnail from their respective MinIO buckets. S3 failure does **not** fail the response (DB row is already gone; `204` returned with a warning log).
- `POST /clips/{id}/like` — idempotent like + `like_count++`, wrapped in `BeginTransactionAsync` with a raw-SQL `ExecuteUpdateAsync` increment so the counter bump is race-free against concurrent likers on other rows.
- `DELETE /clips/{id}/like` — idempotent unlike + `like_count--` clamped at zero via a `WHERE like_count > 0` predicate on the decrement (handles data drift / manual repair without producing a negative count).
- 32 new integration tests covering: auth gates, ownership (403), missing clip (404), validation (empty/too-long title, invalid visibility, non-existent gameId), double-like idempotency, clamp-at-zero on double-unlike, multi-user counter accuracy, cascade of likes on clip delete, S3 bucket routing (video → `ClipsBucket`, thumbnail → `ThumbnailsBucket`), `UpdatedAt` bump on PATCH, and fresh presigned URL on PATCH response.

Closes #8

## How to test manually

```bash
make up
dotnet watch --project server/src/GankedTV.Api
# In another shell, mint a dev JWT:
T=$(curl -s -X POST http://localhost:5000/dev/token | jq -r '.token')

# Assuming you have an uploaded clip id $CID:
curl -X PATCH  -H "Authorization: Bearer $T" -H "Content-Type: application/json" \
     -d '{"title":"renamed","visibility":"unlisted"}' http://localhost:5000/clips/$CID
curl -X POST   -H "Authorization: Bearer $T" http://localhost:5000/clips/$CID/like
curl -X POST   -H "Authorization: Bearer $T" http://localhost:5000/clips/$CID/like  # idempotent; still likeCount=1
curl -X DELETE -H "Authorization: Bearer $T" http://localhost:5000/clips/$CID/like
curl -X DELETE -H "Authorization: Bearer $T" http://localhost:5000/clips/$CID
```

Then confirm the clip row is gone via `psql` and the video/thumbnail objects are gone in the MinIO UI (http://localhost:9001).

## Checklist

- [ ] Verified manually against the running stack
