### PR TITLE
Converted DTOs to contracts

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Auth/AuthMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/AuthMappings.cs
@@ -1,0 +1,12 @@
+using GankedTV.Api.Auth.Tokens;
+
+namespace GankedTV.Api.Contracts.Auth;
+
+public static class AuthMappings
+{
+    public static TokenResponse ToTokenResponse(
+        this RotateResult result,
+        string accessToken,
+        int expiresInSeconds) =>
+        new(accessToken, result.NewRawToken, expiresInSeconds);
+}

--- a/server/src/GankedTV.Api/Contracts/Auth/RefreshRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/RefreshRequest.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Auth;
+
+public sealed record RefreshRequest(string Refresh);

--- a/server/src/GankedTV.Api/Contracts/Auth/TokenResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/TokenResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Auth;
+
+public sealed record TokenResponse(string Token, string Refresh, int ExpiresIn);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
@@ -1,4 +1,5 @@
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Clips;
 
 namespace GankedTV.Api.Contracts.Clips;
 
@@ -6,6 +7,15 @@ public static class ClipMappings
 {
     public static AuthorSummary ToAuthorSummary(this User user) =>
         new(user.Id, user.Username, user.AvatarUrl);
+
+    public static CreateClipResponse ToCreateClipResponse(this CreateClipResult result) =>
+        new(result.ClipId);
+
+    public static UploadUrlResponse ToUploadUrlResponse(this UploadUrlResult result) =>
+        new(result.Url, result.ExpiresAt);
+
+    public static CompleteClipResponse ToCompleteClipResponse(this CompleteClipResult result) =>
+        new(result.ClipId, result.FileSizeBytes);
 
     public static ClipFeedItem ToFeedItem(this Clip clip, bool likedByMe) =>
         new(

--- a/server/src/GankedTV.Api/Contracts/Clips/CompleteClipResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/CompleteClipResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record CompleteClipResponse(Guid Id, long FileSizeBytes);

--- a/server/src/GankedTV.Api/Contracts/Clips/CreateClipRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/CreateClipRequest.cs
@@ -1,0 +1,7 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record CreateClipRequest(
+    string? Title,
+    string? Description,
+    int? GameId,
+    string? Visibility);

--- a/server/src/GankedTV.Api/Contracts/Clips/CreateClipResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/CreateClipResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record CreateClipResponse(Guid Id);

--- a/server/src/GankedTV.Api/Contracts/Clips/UploadUrlResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/UploadUrlResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+public sealed record UploadUrlResponse(string Url, DateTimeOffset ExpiresAt);

--- a/server/src/GankedTV.Api/Contracts/Users/MeResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/MeResponse.cs
@@ -1,0 +1,9 @@
+namespace GankedTV.Api.Contracts.Users;
+
+public sealed record MeResponse(
+    Guid Id,
+    string Username,
+    string? Email,
+    string? Bio,
+    string? AvatarUrl,
+    DateTimeOffset CreatedAt);

--- a/server/src/GankedTV.Api/Contracts/Users/UpdateMeRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/UpdateMeRequest.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Users;
+
+public sealed record UpdateMeRequest(string? Username, string? Bio, string? AvatarUrl);

--- a/server/src/GankedTV.Api/Contracts/Users/UserMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/UserMappings.cs
@@ -7,4 +7,7 @@ public static class UserMappings
 {
     public static UserProfileResponse ToProfile(this User user, IReadOnlyList<ClipFeedItem> clips) =>
         new(user.Id, user.Username, user.Bio, user.AvatarUrl, user.CreatedAt, clips);
+
+    public static MeResponse ToMe(this User user) =>
+        new(user.Id, user.Username, user.Email, user.Bio, user.AvatarUrl, user.CreatedAt);
 }

--- a/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
@@ -3,6 +3,7 @@ using GankedTV.Api.Auth.Jwt;
 using GankedTV.Api.Auth.Providers;
 using GankedTV.Api.Auth.State;
 using GankedTV.Api.Auth.Tokens;
+using GankedTV.Api.Contracts.Auth;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -11,9 +12,6 @@ namespace GankedTV.Api.Endpoints;
 
 public static class AuthEndpoints
 {
-    public sealed record RefreshRequest(string Refresh);
-    public sealed record TokenResponse(string Token, string Refresh, int ExpiresIn);
-
     public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapGet("/auth/providers", ListProviders);
@@ -125,9 +123,8 @@ public static class AuthEndpoints
         {
             var result = await refreshTokens.RotateAsync(req.Refresh, ct);
             var token = jwt.Issue(result.User);
-            return TypedResults.Ok(new TokenResponse(
+            return TypedResults.Ok(result.ToTokenResponse(
                 token,
-                result.NewRawToken,
                 jwtOptions.Value.ExpiryMinutes * 60));
         }
         catch (InvalidRefreshTokenException)

--- a/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Services.Clips;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -11,16 +12,6 @@ public static class ClipsUploadEndpoints
     // Category used when logging unmapped enum values so the failure is traceable
     // if a new ClipUploadError case is added without updating MapError.
     private static readonly string LogCategory = typeof(ClipsUploadEndpoints).FullName!;
-
-    public sealed record CreateClipRequest(
-        string? Title,
-        string? Description,
-        int? GameId,
-        string? Visibility);
-
-    public sealed record CreateClipResponse(Guid Id);
-    public sealed record UploadUrlResponse(string Url, DateTimeOffset ExpiresAt);
-    public sealed record CompleteClipResponse(Guid Id, long FileSizeBytes);
 
     public static IEndpointRouteBuilder MapClipsUploadEndpoints(this IEndpointRouteBuilder app)
     {
@@ -56,7 +47,7 @@ public static class ClipsUploadEndpoints
             ct);
 
         return result.IsSuccess
-            ? Results.Ok(new CreateClipResponse(result.Value!.ClipId))
+            ? Results.Ok(result.Value!.ToCreateClipResponse())
             : MapError(result.Error!.Value, loggerFactory);
     }
 
@@ -74,7 +65,7 @@ public static class ClipsUploadEndpoints
 
         var result = await clips.GetUploadUrlAsync(userId, id, ct);
         return result.IsSuccess
-            ? Results.Ok(new UploadUrlResponse(result.Value!.Url, result.Value.ExpiresAt))
+            ? Results.Ok(result.Value!.ToUploadUrlResponse())
             : MapError(result.Error!.Value, loggerFactory);
     }
 
@@ -92,7 +83,7 @@ public static class ClipsUploadEndpoints
 
         var result = await clips.CompleteAsync(userId, id, ct);
         return result.IsSuccess
-            ? Results.Ok(new CompleteClipResponse(result.Value!.ClipId, result.Value.FileSizeBytes))
+            ? Results.Ok(result.Value!.ToCompleteClipResponse())
             : MapError(result.Error!.Value, loggerFactory);
     }
 

--- a/server/src/GankedTV.Api/Endpoints/MeEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/MeEndpoints.cs
@@ -1,8 +1,8 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using GankedTV.Api.Auth;
+using GankedTV.Api.Contracts.Users;
 using GankedTV.Api.Data;
-using GankedTV.Api.Data.Entities;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -14,16 +14,6 @@ public static class MeEndpoints
 {
     private const int MaxAvatarUrlLength = 2048;
     private const int MaxBioLength = 500;
-
-    public sealed record MeResponse(
-        Guid Id,
-        string Username,
-        string? Email,
-        string? Bio,
-        string? AvatarUrl,
-        DateTimeOffset CreatedAt);
-
-    public sealed record UpdateMeRequest(string? Username, string? Bio, string? AvatarUrl);
 
     public static IEndpointRouteBuilder MapMeEndpoints(this IEndpointRouteBuilder app)
     {
@@ -49,7 +39,7 @@ public static class MeEndpoints
             // 404 so the SPA can drop tokens and redirect to sign-in.
             return TypedResults.Unauthorized();
         }
-        return TypedResults.Ok(ToResponse(user));
+        return TypedResults.Ok(user.ToMe());
     }
 
     private static async Task<IResult> PatchMe(
@@ -129,7 +119,7 @@ public static class MeEndpoints
 
         if (!changed)
         {
-            return Results.Ok(ToResponse(user));
+            return Results.Ok(user.ToMe());
         }
 
         user.UpdatedAt = DateTimeOffset.UtcNow;
@@ -142,7 +132,7 @@ public static class MeEndpoints
             // A concurrent writer took the username between our AnyAsync check and the save.
             return Results.Conflict(new { error = "username_taken" });
         }
-        return Results.Ok(ToResponse(user));
+        return Results.Ok(user.ToMe());
     }
 
     private static (bool ok, string? value) ValidateAvatarUrl(string raw)
@@ -189,12 +179,4 @@ public static class MeEndpoints
             ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         return Guid.TryParse(sub, out userId);
     }
-
-    private static MeResponse ToResponse(User user) => new(
-        user.Id,
-        user.Username,
-        user.Email,
-        user.Bio,
-        user.AvatarUrl,
-        user.CreatedAt);
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/MeEndpointsSmokeTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/MeEndpointsSmokeTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using FluentAssertions;
 using GankedTV.Api.Auth.Jwt;
 using GankedTV.Api.Data.Entities;
@@ -81,6 +82,73 @@ public class MeEndpointsSmokeTests : IAsyncLifetime
 
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         (await resp.Content.ReadAsStringAsync()).Should().Contain(username);
+    }
+
+    [Fact]
+    public async Task Get_WithPopulatedUser_ReturnsAllMeResponseFields()
+    {
+        await _fx.ResetAsync();
+
+        const string username = "fulluser";
+        const string email = "fulluser@example.com";
+        const string bio = "Built different. Dies first.";
+        const string avatarUrl = "https://example.com/avatars/fulluser.png";
+        var createdAt = DateTimeOffset.UtcNow.AddDays(-3);
+
+        Guid userId;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = username,
+                Email = email,
+                Bio = bio,
+                AvatarUrl = avatarUrl,
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            userId = user.Id;
+        }
+
+        using var scope = _factory!.Services.CreateScope();
+        var jwt = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var token = jwt.Issue(new User { Id = userId, Username = username, Email = email });
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.GetAsync("/me");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(userId);
+        body.GetProperty("username").GetString().Should().Be(username);
+        body.GetProperty("email").GetString().Should().Be(email);
+        body.GetProperty("bio").GetString().Should().Be(bio);
+        body.GetProperty("avatarUrl").GetString().Should().Be(avatarUrl);
+        // Postgres timestamptz stores microsecond precision; .NET DateTimeOffset has 100ns ticks,
+        // so a round-trip rounds by up to 1 microsecond. 1ms tolerance comfortably absorbs that.
+        body.GetProperty("createdAt").GetDateTimeOffset()
+            .Should().BeCloseTo(createdAt, TimeSpan.FromMilliseconds(1));
+    }
+
+    [Fact]
+    public async Task Get_WithSparseUser_ReturnsNullsForBioAndAvatar()
+    {
+        await _fx.ResetAsync();
+        var (userId, token, username) = await SeedUserAndIssueTokenAsync("sparse");
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.GetAsync("/me");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(userId);
+        body.GetProperty("username").GetString().Should().Be(username);
+        body.GetProperty("email").GetString().Should().Be($"{username}@example.com");
+        body.GetProperty("bio").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("avatarUrl").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("createdAt").ValueKind.Should().Be(JsonValueKind.String);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Migrates the remaining inline DTO records from `ClipsUploadEndpoints`, `MeEndpoints`, and `AuthEndpoints` into the per-area `Contracts/{Clips,Users,Auth}/` layout introduced in #7. Endpoint handlers now construct responses via hand-written static extension mappers instead of inline `new …Response(...)` calls, so the whole server follows one convention.

## What's here
- New `Contracts/Clips/` DTOs — `CreateClipRequest`, `CreateClipResponse`, `UploadUrlResponse`, `CompleteClipResponse`; `ClipMappings.cs` extended with `ToCreateClipResponse`, `ToUploadUrlResponse`, `ToCompleteClipResponse` extensions on the `IClipUploadService` result records.
- New `Contracts/Users/` DTOs — `MeResponse`, `UpdateMeRequest`; `UserMappings.ToMe(this User)` added; the private `ToResponse(User)` helper in `MeEndpoints.cs` removed.
- New `Contracts/Auth/` area — `RefreshRequest`, `TokenResponse`, `AuthMappings.ToTokenResponse(this RotateResult, string accessToken, int expiresInSeconds)`.
- Pure refactor — JSON wire format preserved (positional records, no `[JsonPropertyName]`, same field order). Validation, error mapping, routing, and auth logic untouched.
- Two new tests in `MeEndpointsSmokeTests` (`Get_WithPopulatedUser_ReturnsAllMeResponseFields`, `Get_WithSparseUser_ReturnsNullsForBioAndAvatar`) pin down every field of `MeResponse`, closing a pre-existing gap where `id`, `email`, `avatarUrl`, and `createdAt` were not explicitly asserted.

Closes #26

## How to test manually
- `dotnet build server` — must be clean.
- `dotnet test server` — 198 tests pass (196 existing + 2 new).
- Optional smoke: `dotnet watch --project src/GankedTV.Api` from `server/`, then hit `POST /auth/refresh`, `GET /me`, `POST /clips` and confirm the response JSON shapes are identical to `main`.

## Checklist
- [ ] Verified manually
