### PR TITLE
feat(web): login page with Discord + Google OAuth buttons

### DIFF
--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -8,13 +8,6 @@ const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
 
-// Redirect away if the user is already authenticated.
-watchEffect(() => {
-  if (auth.isAuthenticated) {
-    router.replace('/')
-  }
-})
-
 const rawRedirect = route.query.redirect
 let returnTo: string | undefined
 if (
@@ -24,6 +17,13 @@ if (
 ) {
   returnTo = rawRedirect
 }
+
+// Redirect away if the user is already authenticated.
+watchEffect(() => {
+  if (auth.isAuthenticated) {
+    router.replace(returnTo || '/')
+  }
+})
 </script>
 
 <template>

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -1,8 +1,20 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router'
+import { watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 import { oauthStartUrl } from '@/api/auth'
 
 const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+// Redirect away if the user is already authenticated.
+watchEffect(() => {
+  if (auth.isAuthenticated) {
+    router.replace('/')
+  }
+})
+
 const rawRedirect = route.query.redirect
 let returnTo: string | undefined
 if (
@@ -29,7 +41,7 @@ if (
       <!-- Discord -->
       <a
         :href="oauthStartUrl('discord', returnTo)"
-        class="flex items-center justify-center gap-3 rounded-md bg-brand px-5 py-3 font-heading text-sm font-bold uppercase tracking-wider text-text-primary transition-colors duration-150 hover:bg-brand-light"
+        class="flex items-center justify-center gap-3 rounded-md bg-[#5865F2] px-5 py-3 font-heading text-sm font-bold uppercase tracking-wider text-white transition-colors duration-150 hover:bg-[#4752C4]"
       >
         <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path


### PR DESCRIPTION
## Summary
Implements the `/login` page with correctly branded OAuth buttons and redirects authenticated users away from the page.

## What's here
- Discord button uses the official blurple (`#5865F2`) instead of the generic brand token
- Auth guard: `watchEffect` redirects already-authenticated users to `/`

Closes #10

## How to test manually
1. `cd web && bun dev`
2. Visit `http://localhost:5173/login` — should see Discord (blurple) and Google buttons
3. Click Discord — should redirect to `<VITE_API_URL>/auth/discord/start`
4. While logged in, visit `/login` directly — should immediately redirect to `/`

## Checklist
- [ ] Verified manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authenticated users are now automatically redirected from the login page to the main application.

* **Style**
  * Updated Discord sign-in button colors for improved visual consistency and better platform branding alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->