### PR TITLE
[server] CORS + error envelope + DTO validation + dev seed script

### DIFF
--- a/server/src/GankedTV.Api/Configuration/CorsOriginsParser.cs
+++ b/server/src/GankedTV.Api/Configuration/CorsOriginsParser.cs
@@ -1,0 +1,35 @@
+namespace GankedTV.Api.Configuration;
+
+public static class CorsOriginsParser
+{
+    /// <summary>
+    /// Parses a comma-separated <c>CORS_ORIGINS</c> value and guarantees that
+    /// <paramref name="alwaysInclude"/> (typically <c>WEB_ORIGIN</c>) is in the result,
+    /// since OAuth callback redirects land on it and the browser's subsequent XHR back
+    /// to the API must pass CORS regardless of the operator's list.
+    /// </summary>
+    public static string[] Parse(string? raw, string alwaysInclude)
+    {
+        if (string.IsNullOrWhiteSpace(alwaysInclude))
+        {
+            throw new ArgumentException("alwaysInclude origin must be a non-empty string.", nameof(alwaysInclude));
+        }
+
+        var parts = string.IsNullOrWhiteSpace(raw)
+            ? []
+            : raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        // Preserve order (caller-specified first, then the always-include), de-dupe by ordinal
+        // string equality. Case-sensitive match is fine — WithOrigins treats origins as opaque
+        // strings and browsers send the scheme+host+port verbatim.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>(parts.Length + 1);
+        foreach (var part in parts)
+        {
+            if (seen.Add(part)) result.Add(part);
+        }
+        if (seen.Add(alwaysInclude)) result.Add(alwaysInclude);
+
+        return [.. result];
+    }
+}

--- a/server/src/GankedTV.Api/Contracts/Auth/RefreshRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/RefreshRequest.cs
@@ -1,3 +1,7 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace GankedTV.Api.Contracts.Auth;
 
-public sealed record RefreshRequest(string Refresh);
+public sealed record RefreshRequest(
+    [property: Required]
+    string Refresh);

--- a/server/src/GankedTV.Api/Contracts/Clips/CreateClipRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/CreateClipRequest.cs
@@ -1,7 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using GankedTV.Api.Validation;
+
 namespace GankedTV.Api.Contracts.Clips;
 
 public sealed record CreateClipRequest(
+    [property: Required]
+    [property: StringLength(ClipValidationLimits.MaxTitleLength, MinimumLength = 1)]
     string? Title,
+    [property: StringLength(ClipValidationLimits.MaxDescriptionLength)]
     string? Description,
     int? GameId,
     string? Visibility);

--- a/server/src/GankedTV.Api/Contracts/Clips/UpdateClipRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/UpdateClipRequest.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+using GankedTV.Api.Validation;
+
 namespace GankedTV.Api.Contracts.Clips;
 
 public sealed record UpdateClipRequest(
+    [property: StringLength(ClipValidationLimits.MaxTitleLength)]
     string? Title,
+    [property: StringLength(ClipValidationLimits.MaxDescriptionLength)]
     string? Description,
     int? GameId,
     string? Visibility);

--- a/server/src/GankedTV.Api/Contracts/Users/UpdateMeRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/UpdateMeRequest.cs
@@ -1,3 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace GankedTV.Api.Contracts.Users;
 
-public sealed record UpdateMeRequest(string? Username, string? Bio, string? AvatarUrl);
+public sealed record UpdateMeRequest(
+    [property: StringLength(30)]
+    string? Username,
+    [property: StringLength(500)]
+    string? Bio,
+    [property: StringLength(2048)]
+    string? AvatarUrl);

--- a/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
@@ -4,7 +4,8 @@ using GankedTV.Api.Auth.Providers;
 using GankedTV.Api.Auth.State;
 using GankedTV.Api.Auth.Tokens;
 using GankedTV.Api.Contracts.Auth;
-using Microsoft.AspNetCore.Http.HttpResults;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -17,7 +18,14 @@ public static class AuthEndpoints
         app.MapGet("/auth/providers", ListProviders);
         app.MapGet("/auth/{provider}/start", Start);
         app.MapGet("/auth/{provider}/callback", Callback);
-        app.MapPost("/auth/refresh", Refresh);
+        app.MapPost("/auth/refresh", Refresh)
+            .WithValidation<RefreshRequest>()
+            // Keep OpenAPI in sync with the three shapes Refresh can return. Moved onto the
+            // route-group call because the handler now returns IResult (needed to return a
+            // ProblemDetails body on 401 via ProblemResults.Unauthorized).
+            .Produces<TokenResponse>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
         return app;
     }
 
@@ -34,7 +42,7 @@ public static class AuthEndpoints
     {
         if (!registry.TryGet(provider, out var oauth))
         {
-            return Results.NotFound(new { error = "unknown_provider" });
+            return ProblemResults.NotFound("unknown_provider");
         }
 
         var state = stateCookies.IssueState(returnTo);
@@ -66,12 +74,12 @@ public static class AuthEndpoints
     {
         if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
         {
-            return Results.BadRequest(new { error = "missing_code_or_state" });
+            return ProblemResults.BadRequest("missing_code_or_state");
         }
 
         if (!registry.TryGet(provider, out var oauth))
         {
-            return Results.NotFound(new { error = "unknown_provider" });
+            return ProblemResults.NotFound("unknown_provider");
         }
 
         var cookie = http.Request.Cookies[StateCookieService.CookieName];
@@ -80,7 +88,7 @@ public static class AuthEndpoints
         var stateResult = stateCookies.ValidateState(state, cookie);
         if (!stateResult.Ok)
         {
-            return Results.BadRequest(new { error = "invalid_state" });
+            return ProblemResults.BadRequest("invalid_state");
         }
 
         OAuthUserInfo info;
@@ -90,7 +98,7 @@ public static class AuthEndpoints
         }
         catch (OAuthExchangeException ex)
         {
-            return Results.BadRequest(new { error = "oauth_exchange_failed", message = ex.Message });
+            return ProblemResults.BadRequest("oauth_exchange_failed", ex.Message);
         }
 
         var user = await users.UpsertFromOAuthAsync(oauth.Name, info, ct);
@@ -107,29 +115,31 @@ public static class AuthEndpoints
         return Results.Redirect(location);
     }
 
-    private static async Task<Results<Ok<TokenResponse>, UnauthorizedHttpResult, BadRequest>> Refresh(
-        [FromBody] RefreshRequest req,
+    private static async Task<IResult> Refresh(
+        // Nullable so a literal JSON `null` body reaches the ValidationEndpointFilter.
+        [FromBody] RefreshRequest? req,
         IJwtService jwt,
         IRefreshTokenService refreshTokens,
         IOptions<JwtOptions> jwtOptions,
         CancellationToken ct)
     {
-        if (req is null || string.IsNullOrEmpty(req.Refresh))
+        // Defensive: the WithValidation<RefreshRequest> filter returns 400 for null bodies.
+        if (req is null)
         {
-            return TypedResults.BadRequest();
+            return ProblemResults.InvalidBody();
         }
 
         try
         {
             var result = await refreshTokens.RotateAsync(req.Refresh, ct);
             var token = jwt.Issue(result.User);
-            return TypedResults.Ok(result.ToTokenResponse(
+            return Results.Ok(result.ToTokenResponse(
                 token,
                 jwtOptions.Value.ExpiryMinutes * 60));
         }
         catch (InvalidRefreshTokenException)
         {
-            return TypedResults.Unauthorized();
+            return ProblemResults.Unauthorized("invalid_refresh");
         }
     }
 }

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
+using GankedTV.Api.Problems;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Mvc;
@@ -20,13 +21,16 @@ public static class ClipsMutateEndpoints
     public static IEndpointRouteBuilder MapClipsMutateEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/clips").RequireAuthorization();
-        group.MapPatch("/{id:guid}", PatchClip);
+        group.MapPatch("/{id:guid}", PatchClip).WithValidation<UpdateClipRequest>();
         group.MapDelete("/{id:guid}", DeleteClip);
         return app;
     }
 
     private static async Task<IResult> PatchClip(
         Guid id,
+        // Nullable so a literal JSON `null` body reaches the ValidationEndpointFilter, which
+        // shapes it into the same ValidationProblemDetails response as a missing field rather
+        // than surfacing as a framework-generated 400 that bypasses our filter.
         [FromBody] UpdateClipRequest? req,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
@@ -37,12 +41,15 @@ public static class ClipsMutateEndpoints
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
+        // Defensive: the WithValidation<T> filter already returns 400 for null bodies, so this
+        // path is unreachable at runtime. Kept so future removals of the filter (or test
+        // harnesses that bypass it) fail closed rather than NRE — same envelope as the filter.
         if (req is null)
         {
-            return Results.BadRequest(new { error = "invalid_body" });
+            return ProblemResults.InvalidBody();
         }
 
         var clip = await db.Clips
@@ -51,12 +58,12 @@ public static class ClipsMutateEndpoints
 
         if (clip is null)
         {
-            return Results.NotFound(new { error = "not_found" });
+            return ProblemResults.NotFound("not_found");
         }
 
         if (clip.UserId != userId)
         {
-            return Results.Forbid();
+            return ProblemResults.Forbidden("forbidden");
         }
 
         var limits = validation.Value;
@@ -66,7 +73,7 @@ public static class ClipsMutateEndpoints
             var trimmed = req.Title.Trim();
             if (trimmed.Length == 0 || trimmed.Length > limits.MaxTitleLength)
             {
-                return Results.BadRequest(new { error = "invalid_title" });
+                return ProblemResults.BadRequest("invalid_title");
             }
             clip.Title = trimmed;
         }
@@ -78,7 +85,7 @@ public static class ClipsMutateEndpoints
             // storage/readability limits CREATE enforces.
             if (req.Description.Length > limits.MaxDescriptionLength)
             {
-                return Results.BadRequest(new { error = "invalid_description" });
+                return ProblemResults.BadRequest("invalid_description");
             }
             clip.Description = req.Description;
         }
@@ -87,7 +94,7 @@ public static class ClipsMutateEndpoints
         {
             if (!AllowedVisibilities.Contains(req.Visibility))
             {
-                return Results.BadRequest(new { error = "invalid_visibility" });
+                return ProblemResults.BadRequest("invalid_visibility");
             }
             clip.Visibility = req.Visibility;
         }
@@ -97,7 +104,7 @@ public static class ClipsMutateEndpoints
             var gameExists = await db.Games.AnyAsync(g => g.Id == req.GameId.Value, ct);
             if (!gameExists)
             {
-                return Results.BadRequest(new { error = "invalid_game" });
+                return ProblemResults.BadRequest("invalid_game");
             }
             clip.GameId = req.GameId;
         }
@@ -124,18 +131,18 @@ public static class ClipsMutateEndpoints
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
         var clip = await db.Clips.FirstOrDefaultAsync(c => c.Id == id, ct);
         if (clip is null)
         {
-            return Results.NotFound(new { error = "not_found" });
+            return ProblemResults.NotFound("not_found");
         }
 
         if (clip.UserId != userId)
         {
-            return Results.Forbid();
+            return ProblemResults.Forbidden("forbidden");
         }
 
         var videoKey = clip.VideoKey;

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Text;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
+using GankedTV.Api.Problems;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -121,7 +122,7 @@ public static class ClipsReadEndpoints
 
         if (clip is null)
         {
-            return Results.NotFound(new { error = "not_found" });
+            return ProblemResults.NotFound("not_found");
         }
 
         var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);

--- a/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
@@ -1,7 +1,9 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Problems;
 using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -16,13 +18,15 @@ public static class ClipsUploadEndpoints
     public static IEndpointRouteBuilder MapClipsUploadEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/clips").RequireAuthorization();
-        group.MapPost("/", CreateClip);
+        group.MapPost("/", CreateClip).WithValidation<CreateClipRequest>();
         group.MapPost("/{id:guid}/upload-url", GetUploadUrl);
         group.MapPost("/{id:guid}/complete", CompleteClip);
         return app;
     }
 
     private static async Task<IResult> CreateClip(
+        // Nullable so a literal JSON `null` body hits the ValidationEndpointFilter (which
+        // returns 400 ValidationProblemDetails) rather than a framework-generated 400.
         [FromBody] CreateClipRequest? req,
         ClaimsPrincipal principal,
         IClipUploadService clips,
@@ -31,14 +35,14 @@ public static class ClipsUploadEndpoints
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
-        // A literal JSON `null` body deserializes to a null reference even though the
-        // parameter type is non-nullable, so guard explicitly before dereferencing.
+        // Defensive: the WithValidation<T> filter guards null bodies; this is unreachable at
+        // runtime but keeps the handler safe if the filter is ever removed — same envelope.
         if (req is null)
         {
-            return Results.BadRequest(new { error = "invalid_body" });
+            return ProblemResults.InvalidBody();
         }
 
         var result = await clips.CreateAsync(
@@ -60,7 +64,7 @@ public static class ClipsUploadEndpoints
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
         var result = await clips.GetUploadUrlAsync(userId, id, ct);
@@ -78,7 +82,7 @@ public static class ClipsUploadEndpoints
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
         var result = await clips.CompleteAsync(userId, id, ct);
@@ -89,14 +93,14 @@ public static class ClipsUploadEndpoints
 
     private static IResult MapError(ClipUploadError error, ILoggerFactory loggerFactory) => error switch
     {
-        ClipUploadError.InvalidTitle => Results.BadRequest(new { error = "invalid_title" }),
-        ClipUploadError.InvalidDescription => Results.BadRequest(new { error = "invalid_description" }),
-        ClipUploadError.InvalidVisibility => Results.BadRequest(new { error = "invalid_visibility" }),
-        ClipUploadError.NotFound => Results.NotFound(new { error = "not_found" }),
-        ClipUploadError.InvalidState => Results.BadRequest(new { error = "invalid_state" }),
-        ClipUploadError.ObjectNotUploaded => Results.BadRequest(new { error = "object_not_uploaded" }),
-        ClipUploadError.FileTooLarge => Results.BadRequest(new { error = "file_too_large" }),
-        ClipUploadError.UnsupportedContentType => Results.BadRequest(new { error = "unsupported_content_type" }),
+        ClipUploadError.InvalidTitle => ProblemResults.BadRequest("invalid_title"),
+        ClipUploadError.InvalidDescription => ProblemResults.BadRequest("invalid_description"),
+        ClipUploadError.InvalidVisibility => ProblemResults.BadRequest("invalid_visibility"),
+        ClipUploadError.NotFound => ProblemResults.NotFound("not_found"),
+        ClipUploadError.InvalidState => ProblemResults.BadRequest("invalid_state"),
+        ClipUploadError.ObjectNotUploaded => ProblemResults.BadRequest("object_not_uploaded"),
+        ClipUploadError.FileTooLarge => ProblemResults.BadRequest("file_too_large"),
+        ClipUploadError.UnsupportedContentType => ProblemResults.BadRequest("unsupported_content_type"),
         _ => UnmappedError(error, loggerFactory),
     };
 
@@ -104,10 +108,7 @@ public static class ClipsUploadEndpoints
     {
         loggerFactory.CreateLogger(LogCategory)
             .LogError("Unmapped ClipUploadError value {Error}; add a case to MapError.", error);
-        return Results.Problem(
-            title: "unmapped_error",
-            detail: $"Unhandled error: {error}",
-            statusCode: StatusCodes.Status500InternalServerError);
+        return ProblemResults.Internal("unmapped_error", $"Unhandled error: {error}");
     }
 
     private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)

--- a/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
+using GankedTV.Api.Problems;
 using Microsoft.EntityFrameworkCore;
 
 namespace GankedTV.Api.Endpoints;
@@ -24,7 +25,7 @@ public static class LikesEndpoints
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
         await using var tx = await db.Database.BeginTransactionAsync(ct);
@@ -32,7 +33,7 @@ public static class LikesEndpoints
         var clipExists = await db.Clips.AnyAsync(c => c.Id == id, ct);
         if (!clipExists)
         {
-            return Results.NotFound(new { error = "not_found" });
+            return ProblemResults.NotFound("not_found");
         }
 
         // Atomic idempotent insert: ON CONFLICT DO NOTHING collapses a duplicate like (sequential
@@ -69,7 +70,7 @@ public static class LikesEndpoints
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
         await using var tx = await db.Database.BeginTransactionAsync(ct);
@@ -77,7 +78,7 @@ public static class LikesEndpoints
         var clipExists = await db.Clips.AnyAsync(c => c.Id == id, ct);
         if (!clipExists)
         {
-            return Results.NotFound(new { error = "not_found" });
+            return ProblemResults.NotFound("not_found");
         }
 
         // Set-based delete: a single SQL DELETE that returns the row count. Under concurrent

--- a/server/src/GankedTV.Api/Endpoints/MeEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/MeEndpoints.cs
@@ -3,8 +3,10 @@ using System.Security.Claims;
 using GankedTV.Api.Auth;
 using GankedTV.Api.Contracts.Users;
 using GankedTV.Api.Data;
+using GankedTV.Api.Problems;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using GankedTV.Api.Validation;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 
@@ -18,7 +20,7 @@ public static class MeEndpoints
     public static IEndpointRouteBuilder MapMeEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapGet("/me", GetMe).RequireAuthorization();
-        app.MapPatch("/me", PatchMe).RequireAuthorization();
+        app.MapPatch("/me", PatchMe).RequireAuthorization().WithValidation<UpdateMeRequest>();
         return app;
     }
 
@@ -43,20 +45,30 @@ public static class MeEndpoints
     }
 
     private static async Task<IResult> PatchMe(
-        [FromBody] UpdateMeRequest req,
+        // Nullable so a literal JSON `null` body reaches the ValidationEndpointFilter (which
+        // shapes it into the same ValidationProblemDetails response as a missing field)
+        // rather than surfacing as a framework-generated 400 that bypasses our filter.
+        [FromBody] UpdateMeRequest? req,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
         }
 
         var user = await db.Users.FindAsync([userId], ct);
         if (user is null)
         {
-            return Results.Unauthorized();
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        // Defensive: the WithValidation<T> filter guards null bodies before this handler runs
+        // — same envelope so a filter removal doesn't change the shape clients see.
+        if (req is null)
+        {
+            return ProblemResults.InvalidBody();
         }
 
         var changed = false;
@@ -67,7 +79,7 @@ public static class MeEndpoints
             // fallback ("player") and silently rename the user.
             if (string.IsNullOrWhiteSpace(req.Username))
             {
-                return Results.BadRequest(new { error = "invalid_username" });
+                return ProblemResults.BadRequest("invalid_username");
             }
             var slug = UsernameGenerator.Slugify(req.Username);
             // Slugify caps at MaxLength (≤ 24 chars, under the 30-char DB column), so the only
@@ -75,14 +87,14 @@ public static class MeEndpoints
             // Accept literal "player" from the client; reject other input that decays to it.
             if (slug == UsernameGenerator.Fallback && !req.Username.Equals(UsernameGenerator.Fallback, StringComparison.OrdinalIgnoreCase))
             {
-                return Results.BadRequest(new { error = "invalid_username" });
+                return ProblemResults.BadRequest("invalid_username");
             }
             if (slug != user.Username)
             {
                 var taken = await db.Users.AnyAsync(u => u.Id != userId && u.Username == slug, ct);
                 if (taken)
                 {
-                    return Results.Conflict(new { error = "username_taken" });
+                    return ProblemResults.Conflict("username_taken");
                 }
                 user.Username = slug;
                 changed = true;
@@ -93,7 +105,7 @@ public static class MeEndpoints
         {
             if (req.Bio.Length > MaxBioLength)
             {
-                return Results.BadRequest(new { error = "bio_too_long" });
+                return ProblemResults.BadRequest("bio_too_long");
             }
             var newBio = req.Bio.Length == 0 ? null : req.Bio;
             if (user.Bio != newBio)
@@ -108,7 +120,7 @@ public static class MeEndpoints
             var (ok, newAvatar) = ValidateAvatarUrl(req.AvatarUrl);
             if (!ok)
             {
-                return Results.BadRequest(new { error = "invalid_avatar_url" });
+                return ProblemResults.BadRequest("invalid_avatar_url");
             }
             if (user.AvatarUrl != newAvatar)
             {
@@ -130,7 +142,7 @@ public static class MeEndpoints
         catch (DbUpdateException ex) when (IsUsernameUniqueViolation(ex))
         {
             // A concurrent writer took the username between our AnyAsync check and the save.
-            return Results.Conflict(new { error = "username_taken" });
+            return ProblemResults.Conflict("username_taken");
         }
         return Results.Ok(user.ToMe());
     }

--- a/server/src/GankedTV.Api/Endpoints/UsersEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/UsersEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Contracts.Users;
 using GankedTV.Api.Data;
+using GankedTV.Api.Problems;
 using Microsoft.EntityFrameworkCore;
 
 namespace GankedTV.Api.Endpoints;
@@ -25,7 +26,7 @@ public static class UsersEndpoints
     {
         if (string.IsNullOrWhiteSpace(username))
         {
-            return Results.NotFound(new { error = "not_found" });
+            return ProblemResults.NotFound("not_found");
         }
 
         // Case-insensitive equality via LOWER(...). Avoid EF.Functions.ILike here — `%` and `_`
@@ -37,7 +38,7 @@ public static class UsersEndpoints
 
         if (user is null)
         {
-            return Results.NotFound(new { error = "not_found" });
+            return ProblemResults.NotFound("not_found");
         }
 
         var clips = await db.Clips.AsNoTracking()

--- a/server/src/GankedTV.Api/Middleware/ErrorHandlingMiddleware.cs
+++ b/server/src/GankedTV.Api/Middleware/ErrorHandlingMiddleware.cs
@@ -1,0 +1,42 @@
+using GankedTV.Api.Problems;
+
+namespace GankedTV.Api.Middleware;
+
+/// <summary>
+/// Catches unhandled exceptions from the pipeline and writes an RFC 7807
+/// ProblemDetails response with <c>code = "internal_error"</c>. No stack trace
+/// in the body — details go to the logger instead.
+/// </summary>
+public sealed class ErrorHandlingMiddleware : IMiddleware
+{
+    private readonly ILogger<ErrorHandlingMiddleware> _logger;
+
+    public ErrorHandlingMiddleware(ILogger<ErrorHandlingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex)
+        {
+            if (context.Response.HasStarted)
+            {
+                // Response is already on the wire; the best we can do is log and let the
+                // client see a truncated body. Rethrowing here would just crash Kestrel.
+                _logger.LogError(ex, "Unhandled exception after response started for {Path}", context.Request.Path);
+                throw;
+            }
+
+            _logger.LogError(ex, "Unhandled exception for {Method} {Path}", context.Request.Method, context.Request.Path);
+
+            context.Response.Clear();
+            var result = ProblemResults.Internal("internal_error");
+            await result.ExecuteAsync(context);
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Problems/ProblemResults.cs
+++ b/server/src/GankedTV.Api/Problems/ProblemResults.cs
@@ -1,0 +1,48 @@
+namespace GankedTV.Api.Problems;
+
+/// <summary>
+/// RFC 7807 ProblemDetails factory that stamps a machine-readable <c>code</c> into
+/// <c>extensions</c>. Use these in place of <c>Results.BadRequest(new { error = "..." })</c>
+/// so every 4xx/5xx body has the same shape.
+/// </summary>
+public static class ProblemResults
+{
+    public const string CodeKey = "code";
+
+    public static IResult BadRequest(string code, string? detail = null) =>
+        Build(StatusCodes.Status400BadRequest, code, detail);
+
+    public static IResult Unauthorized(string code, string? detail = null) =>
+        Build(StatusCodes.Status401Unauthorized, code, detail);
+
+    public static IResult Forbidden(string code, string? detail = null) =>
+        Build(StatusCodes.Status403Forbidden, code, detail);
+
+    public static IResult NotFound(string code, string? detail = null) =>
+        Build(StatusCodes.Status404NotFound, code, detail);
+
+    public static IResult Conflict(string code, string? detail = null) =>
+        Build(StatusCodes.Status409Conflict, code, detail);
+
+    public static IResult UnsupportedMediaType(string code, string? detail = null) =>
+        Build(StatusCodes.Status415UnsupportedMediaType, code, detail);
+
+    public static IResult Internal(string code, string? detail = null) =>
+        Build(StatusCodes.Status500InternalServerError, code, detail);
+
+    /// <summary>
+    /// Shared null-body response used by both <c>ValidationEndpointFilter&lt;T&gt;</c> and
+    /// handler-side defensive guards, so clients see one shape regardless of which guard fires.
+    /// </summary>
+    public static IResult InvalidBody() =>
+        Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["body"] = ["Request body is required."],
+        });
+
+    private static IResult Build(int status, string code, string? detail) =>
+        Results.Problem(
+            statusCode: status,
+            detail: detail,
+            extensions: new Dictionary<string, object?> { [CodeKey] = code });
+}

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -195,8 +195,12 @@ builder.Services
     .Configure<IOptions<OAuthOptions>>((cors, oauth) =>
     {
         var origins = CorsOriginsParser.Parse(corsOriginsRaw, oauth.Value.WebOrigin);
+        // SetIsOriginAllowed with an explicit predicate (not WithOrigins) so a literal "*"
+        // in CORS_ORIGINS is matched as a string, not interpreted by CorsService as the
+        // CORS-spec wildcard (which silently disables AllowCredentials). Host comparison
+        // is case-insensitive per RFC 6454; scheme/port exact-match.
         cors.AddPolicy(corsPolicy, policy => policy
-            .WithOrigins(origins)
+            .SetIsOriginAllowed(origin => origins.Contains(origin, StringComparer.OrdinalIgnoreCase))
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials());

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -4,10 +4,13 @@ using GankedTV.Api.Auth.Jwt;
 using GankedTV.Api.Auth.Providers;
 using GankedTV.Api.Auth.State;
 using GankedTV.Api.Auth.Tokens;
+using GankedTV.Api.Configuration;
 using GankedTV.Api.Data;
 using GankedTV.Api.Endpoints;
+using GankedTV.Api.Middleware;
 using GankedTV.Api.Services.Clips;
 using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tools;
 using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Cors.Infrastructure;
@@ -30,6 +33,13 @@ if (builder.Environment.IsDevelopment())
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+// RFC 7807 ProblemDetails for all framework-generated 4xx/5xx bodies (empty responses
+// from UseAuthorization/UseAuthentication get shaped automatically). Endpoint-authored
+// errors go through ProblemResults.*.
+builder.Services.AddProblemDetails();
+builder.Services.AddTransient<ErrorHandlingMiddleware>();
+builder.Services.AddScoped<SeedCommand>();
 
 var connectionString = Environment.GetEnvironmentVariable("DATABASE_URL")
     ?? builder.Configuration.GetConnectionString("DefaultConnection")
@@ -173,16 +183,20 @@ builder.Services
 builder.Services.AddAuthorization();
 
 const string corsPolicy = "WebOrigin";
-// We register the CORS policy via AddOptions<CorsOptions>().Configure<IOptions<OAuthOptions>>
-// instead of the idiomatic AddCors(o => o.AddPolicy(...)) because the policy's origin comes
-// from the already-bound OAuthOptions — the AddCors lambda overload can't inject IOptions<T>.
-// AddCors() below wires the middleware + ICorsService; our ConfigureOptions adds the policy.
+// Allowed origins = CORS_ORIGINS (comma-separated) ∪ WebOrigin. WebOrigin is always included
+// because OAuth redirects land on it and the browser's follow-up XHR must pass CORS — an
+// operator who forgets to list it in CORS_ORIGINS would otherwise break the sign-in flow.
+// We register the policy via AddOptions<CorsOptions>().Configure<IOptions<OAuthOptions>>
+// instead of AddCors(o => o.AddPolicy(...)) because the origin list depends on the already-
+// bound OAuthOptions and the AddCors lambda overload can't inject IOptions<T>.
+var corsOriginsRaw = Environment.GetEnvironmentVariable("CORS_ORIGINS");
 builder.Services
     .AddOptions<CorsOptions>()
     .Configure<IOptions<OAuthOptions>>((cors, oauth) =>
     {
+        var origins = CorsOriginsParser.Parse(corsOriginsRaw, oauth.Value.WebOrigin);
         cors.AddPolicy(corsPolicy, policy => policy
-            .WithOrigins(oauth.Value.WebOrigin)
+            .WithOrigins(origins)
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials());
@@ -191,12 +205,27 @@ builder.Services.AddCors();
 
 var app = builder.Build();
 
+// --seed short-circuit: runs the dev seed against the configured DB and exits. We still build
+// the full app so DbContext/options are wired identically to the runtime path.
+if (SeedCommand.ShouldRun(args))
+{
+    using var scope = app.Services.CreateScope();
+    var seed = scope.ServiceProvider.GetRequiredService<SeedCommand>();
+    await seed.RunAsync(CancellationToken.None);
+    return;
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
 
+app.UseMiddleware<ErrorHandlingMiddleware>();
+// Shape framework-generated empty-body 4xx/5xx responses (JwtBearer 401 challenges,
+// 404 for unmatched routes, 415 for unsupported media types) into ProblemDetails so every
+// error response from the API has the same JSON envelope regardless of origin.
+app.UseStatusCodePages();
 app.UseHttpsRedirection();
 app.UseCors(corsPolicy);
 app.UseAuthentication();

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -1,0 +1,94 @@
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Tools;
+
+/// <summary>
+/// Idempotent dev seed: creates one test user plus ten sample clips keyed by deterministic
+/// ids, so repeated runs leave the DB in the same state. Invoked via
+/// <c>dotnet run --project server/src/GankedTV.Api -- --seed</c>.
+/// </summary>
+public sealed class SeedCommand
+{
+    public const string FlagName = "--seed";
+
+    public static readonly Guid SeedUserId = new("00000000-0000-0000-0000-00000000CAFE");
+    public const string SeedUsername = "seeduser";
+    public const int SeedClipCount = 10;
+
+    private readonly GankedTvDbContext _db;
+    private readonly ILogger<SeedCommand> _logger;
+    private readonly TimeProvider _clock;
+
+    public SeedCommand(GankedTvDbContext db, ILogger<SeedCommand> logger, TimeProvider clock)
+    {
+        _db = db;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    public static bool ShouldRun(string[] args) => args.Contains(FlagName);
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        var now = _clock.GetUtcNow();
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == SeedUserId, ct);
+        if (user is null)
+        {
+            user = new User
+            {
+                Id = SeedUserId,
+                Username = SeedUsername,
+                Email = $"{SeedUsername}@dev.local",
+                Bio = "Seeded dev user.",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            _db.Users.Add(user);
+            await _db.SaveChangesAsync(ct);
+            _logger.LogInformation("Seed: created user {Username}", user.Username);
+        }
+
+        for (var i = 1; i <= SeedClipCount; i++)
+        {
+            var clipId = SeedClipId(i);
+            var exists = await _db.Clips.AnyAsync(c => c.Id == clipId, ct);
+            if (exists) continue;
+
+            _db.Clips.Add(new Clip
+            {
+                Id = clipId,
+                UserId = user.Id,
+                Title = SeedClipTitle(i),
+                Description = $"Seeded sample clip #{i:D2}.",
+                VideoKey = $"seed/clip-{i:D2}.mp4",
+                ThumbnailKey = $"seed/clip-{i:D2}.jpg",
+                Status = "ready",
+                Visibility = "public",
+                FileSizeBytes = 1_048_576L * i,
+                DurationSecs = (short)(30 + i),
+                CreatedAt = now.AddMinutes(-i),
+                UpdatedAt = now.AddMinutes(-i),
+            });
+        }
+
+        var inserted = await _db.SaveChangesAsync(ct);
+        if (inserted > 0)
+        {
+            _logger.LogInformation("Seed: inserted {Count} row(s).", inserted);
+        }
+        else
+        {
+            _logger.LogInformation("Seed: already present, no changes.");
+        }
+    }
+
+    // Deterministic ids so re-runs find the existing row via equality — no title-based lookup
+    // (titles can legitimately collide with user-created clips, ids cannot).
+    public static Guid SeedClipId(int i) =>
+        new($"00000000-0000-0000-0000-0000000000{i:D2}");
+
+    public static string SeedClipTitle(int i) => $"Seed Clip {i:D2}";
+}

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -9,7 +9,11 @@ namespace GankedTV.Api.Tools;
 /// ids, so repeated runs leave the DB in the same state. Invoked via
 /// <c>dotnet run --project server/src/GankedTV.Api -- --seed</c>.
 /// </summary>
-public sealed class SeedCommand
+public sealed class SeedCommand(
+    GankedTvDbContext db,
+    ILogger<SeedCommand> logger,
+    TimeProvider clock,
+    IHostEnvironment env)
 {
     public const string FlagName = "--seed";
 
@@ -17,24 +21,24 @@ public sealed class SeedCommand
     public const string SeedUsername = "seeduser";
     public const int SeedClipCount = 10;
 
-    private readonly GankedTvDbContext _db;
-    private readonly ILogger<SeedCommand> _logger;
-    private readonly TimeProvider _clock;
-
-    public SeedCommand(GankedTvDbContext db, ILogger<SeedCommand> logger, TimeProvider clock)
-    {
-        _db = db;
-        _logger = logger;
-        _clock = clock;
-    }
-
     public static bool ShouldRun(string[] args) => args.Contains(FlagName);
 
     public async Task RunAsync(CancellationToken ct)
     {
-        var now = _clock.GetUtcNow();
+        // Hard guard: seed is a dev-only tool. Running it against a production DB would
+        // create a predictable test user with a predictable id, which is both a data-quality
+        // and a security problem. Fail closed — ASPNETCORE_ENVIRONMENT must be Development.
+        if (!env.IsDevelopment())
+        {
+            logger.LogError(
+                "Seed refused: environment is {Env}, not Development. Set ASPNETCORE_ENVIRONMENT=Development to proceed.",
+                env.EnvironmentName);
+            return;
+        }
 
-        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == SeedUserId, ct);
+        var now = clock.GetUtcNow();
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == SeedUserId, ct);
         if (user is null)
         {
             user = new User
@@ -46,18 +50,18 @@ public sealed class SeedCommand
                 CreatedAt = now,
                 UpdatedAt = now,
             };
-            _db.Users.Add(user);
-            await _db.SaveChangesAsync(ct);
-            _logger.LogInformation("Seed: created user {Username}", user.Username);
+            db.Users.Add(user);
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seed: created user {Username}", user.Username);
         }
 
         for (var i = 1; i <= SeedClipCount; i++)
         {
             var clipId = SeedClipId(i);
-            var exists = await _db.Clips.AnyAsync(c => c.Id == clipId, ct);
+            var exists = await db.Clips.AnyAsync(c => c.Id == clipId, ct);
             if (exists) continue;
 
-            _db.Clips.Add(new Clip
+            db.Clips.Add(new Clip
             {
                 Id = clipId,
                 UserId = user.Id,
@@ -74,14 +78,14 @@ public sealed class SeedCommand
             });
         }
 
-        var inserted = await _db.SaveChangesAsync(ct);
+        var inserted = await db.SaveChangesAsync(ct);
         if (inserted > 0)
         {
-            _logger.LogInformation("Seed: inserted {Count} row(s).", inserted);
+            logger.LogInformation("Seed: inserted {Count} row(s).", inserted);
         }
         else
         {
-            _logger.LogInformation("Seed: already present, no changes.");
+            logger.LogInformation("Seed: already present, no changes.");
         }
     }
 

--- a/server/src/GankedTV.Api/Validation/ClipValidationLimits.cs
+++ b/server/src/GankedTV.Api/Validation/ClipValidationLimits.cs
@@ -1,0 +1,13 @@
+namespace GankedTV.Api.Validation;
+
+/// <summary>
+/// Compile-time mirrors of <see cref="ClipValidationOptions"/> defaults, for use in
+/// <c>System.ComponentModel.DataAnnotations</c> attributes (which require constant args).
+/// These are the *hard ceiling* — <see cref="ClipValidationOptions"/> may impose a tighter
+/// runtime cap via the upload service.
+/// </summary>
+public static class ClipValidationLimits
+{
+    public const int MaxTitleLength = 255;
+    public const int MaxDescriptionLength = 5000;
+}

--- a/server/src/GankedTV.Api/Validation/ValidationEndpointFilter.cs
+++ b/server/src/GankedTV.Api/Validation/ValidationEndpointFilter.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+using GankedTV.Api.Problems;
+
+namespace GankedTV.Api.Validation;
+
+/// <summary>
+/// Endpoint filter that runs DataAnnotations validation on the first argument of type
+/// <typeparamref name="T"/> in the endpoint signature. On failure, short-circuits with
+/// a 400 <c>ValidationProblemDetails</c> response whose <c>errors</c> dictionary is
+/// keyed by property name.
+/// </summary>
+public sealed class ValidationEndpointFilter<T> : IEndpointFilter where T : class
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var target = context.Arguments.OfType<T>().FirstOrDefault();
+        if (target is null)
+        {
+            // A literal JSON `null` body deserializes to a null reference; short-circuit
+            // with the same shape that ProblemResults.InvalidBody() produces so handler-side
+            // defensive guards (if the filter is ever bypassed) return an identical envelope.
+            return ProblemResults.InvalidBody();
+        }
+
+        var ctx = new ValidationContext(target);
+        var results = new List<ValidationResult>();
+        if (Validator.TryValidateObject(target, ctx, results, validateAllProperties: true))
+        {
+            return await next(context);
+        }
+
+        var errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        foreach (var result in results)
+        {
+            var members = result.MemberNames.DefaultIfEmpty(string.Empty);
+            foreach (var member in members)
+            {
+                var key = string.IsNullOrEmpty(member) ? "body" : member;
+                if (!errors.TryGetValue(key, out var existing))
+                {
+                    errors[key] = [result.ErrorMessage ?? "Invalid value."];
+                }
+                else
+                {
+                    errors[key] = [.. existing, result.ErrorMessage ?? "Invalid value."];
+                }
+            }
+        }
+
+        return Results.ValidationProblem(errors);
+    }
+}
+
+public static class ValidationEndpointFilterExtensions
+{
+    /// <summary>
+    /// Attach DataAnnotations validation for the request body of type <typeparamref name="T"/>.
+    /// </summary>
+    public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder) where T : class =>
+        builder.AddEndpointFilter<ValidationEndpointFilter<T>>();
+}

--- a/server/tests/GankedTV.Api.Tests/Configuration/CorsOriginsParserTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Configuration/CorsOriginsParserTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using GankedTV.Api.Configuration;
+
+namespace GankedTV.Api.Tests.Configuration;
+
+public class CorsOriginsParserTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Unset_ReturnsAlwaysIncludeOnly(string? raw)
+    {
+        CorsOriginsParser.Parse(raw, "http://web").Should().Equal("http://web");
+    }
+
+    [Fact]
+    public void SingleOrigin_UnionedWithAlwaysInclude()
+    {
+        CorsOriginsParser.Parse("http://a.test", "http://web")
+            .Should().Equal("http://a.test", "http://web");
+    }
+
+    [Fact]
+    public void CommaSeparated_SplitsTrimsAndAppendsAlwaysInclude()
+    {
+        CorsOriginsParser.Parse("http://a.test, http://b.test ,http://c.test", "http://web")
+            .Should().Equal("http://a.test", "http://b.test", "http://c.test", "http://web");
+    }
+
+    [Fact]
+    public void EmptyEntries_Dropped()
+    {
+        CorsOriginsParser.Parse(",,http://a.test,,", "http://web")
+            .Should().Equal("http://a.test", "http://web");
+    }
+
+    [Fact]
+    public void WhitespaceOnlyEntries_FallBackToAlwaysInclude()
+    {
+        CorsOriginsParser.Parse(" , ,  ", "http://web")
+            .Should().Equal("http://web");
+    }
+
+    [Fact]
+    public void AlwaysIncludeAlreadyInList_NotDuplicated()
+    {
+        CorsOriginsParser.Parse("http://web,http://admin.test", "http://web")
+            .Should().Equal("http://web", "http://admin.test");
+    }
+
+    [Fact]
+    public void DuplicateEntries_Deduped()
+    {
+        CorsOriginsParser.Parse("http://a.test,http://a.test", "http://web")
+            .Should().Equal("http://a.test", "http://web");
+    }
+
+    [Fact]
+    public void WildcardInList_KeptAsLiteralOrigin()
+    {
+        // The parser doesn't interpret "*" — that's the caller's (AllowCredentials vs
+        // SetIsOriginAllowed) concern. Here we just verify the literal survives parsing.
+        CorsOriginsParser.Parse("*", "http://web")
+            .Should().Equal("*", "http://web");
+    }
+
+    [Fact]
+    public void EmptyAlwaysInclude_Throws()
+    {
+        var act = () => CorsOriginsParser.Parse("http://a.test", "");
+        act.Should().Throw<ArgumentException>().WithParameterName("alwaysInclude");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
@@ -148,6 +148,8 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
     [Fact]
     public async Task Create_WhitespaceTitle_Returns400()
     {
+        // [Required] (default AllowEmptyStrings=false) rejects whitespace-only before it
+        // reaches the service layer → ValidationProblemDetails keyed by "Title".
         await _fx.ResetAsync();
         var (_, token) = await SeedUserAndIssueTokenAsync();
         using var client = ClientWithBearer(token);
@@ -155,12 +157,14 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
         var resp = await client.PostAsJsonAsync("/clips", new { title = "   " });
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_title");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("Title").GetArrayLength().Should().BeGreaterThan(0);
     }
 
     [Fact]
     public async Task Create_TitleTooLong_Returns400()
     {
+        // Caught by the [StringLength] attribute in CreateClipRequest → ValidationProblemDetails.
         await _fx.ResetAsync();
         var (_, token) = await SeedUserAndIssueTokenAsync();
         using var client = ClientWithBearer(token);
@@ -168,12 +172,15 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
         var resp = await client.PostAsJsonAsync("/clips", new { title = new string('x', 256) });
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_title");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("Title").GetArrayLength().Should().BeGreaterThan(0);
     }
 
     [Fact]
     public async Task Create_InvalidVisibility_Returns400()
     {
+        // Visibility validation lives in ClipUploadService (case-insensitive allowed-values)
+        // rather than a DataAnnotation, so this surfaces via ProblemResults with code=invalid_visibility.
         await _fx.ResetAsync();
         var (_, token) = await SeedUserAndIssueTokenAsync();
         using var client = ClientWithBearer(token);
@@ -181,7 +188,8 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
         var resp = await client.PostAsJsonAsync("/clips", new { title = "x", visibility = "private" });
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_visibility");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_visibility");
     }
 
     [Fact]
@@ -208,6 +216,8 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
     [Fact]
     public async Task Create_NullBody_Returns400()
     {
+        // ValidationEndpointFilter<CreateClipRequest> catches a null-deserialized body and
+        // short-circuits with a ValidationProblemDetails keyed by "body".
         await _fx.ResetAsync();
         var (_, token) = await SeedUserAndIssueTokenAsync();
         using var client = ClientWithBearer(token);
@@ -216,12 +226,14 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
         var resp = await client.PostAsync("/clips", content);
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_body");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("body").GetArrayLength().Should().BeGreaterThan(0);
     }
 
     [Fact]
     public async Task Create_DescriptionTooLong_Returns400()
     {
+        // Caught by the [StringLength] attribute on CreateClipRequest.Description.
         await _fx.ResetAsync();
         var (_, token) = await SeedUserAndIssueTokenAsync();
         using var client = ClientWithBearer(token);
@@ -233,7 +245,8 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
         });
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_description");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("Description").GetArrayLength().Should().BeGreaterThan(0);
     }
 
     // ---- POST /clips/{id}/upload-url ----

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CorsOriginsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CorsOriginsTests.cs
@@ -1,0 +1,113 @@
+using System.Net.Http;
+using FluentAssertions;
+using GankedTV.Api.Tests.TestSupport;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class CorsOriginsTests
+{
+    private readonly PostgresFixture _fx;
+
+    public CorsOriginsTests(PostgresFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task MultiOrigin_AllowsEachListedOrigin()
+    {
+        Environment.SetEnvironmentVariable("CORS_ORIGINS", "http://a.test,http://b.test");
+        try
+        {
+            await using var factory = new AuthApiFactory(_fx.ConnectionString);
+            using var client = factory.CreateClient();
+
+            (await PreflightAllowOrigin(client, "http://a.test")).Should().Be("http://a.test");
+            (await PreflightAllowOrigin(client, "http://b.test")).Should().Be("http://b.test");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CORS_ORIGINS", null);
+        }
+    }
+
+    [Fact]
+    public async Task UnlistedOrigin_IsNotAllowed()
+    {
+        Environment.SetEnvironmentVariable("CORS_ORIGINS", "http://a.test");
+        try
+        {
+            await using var factory = new AuthApiFactory(_fx.ConnectionString);
+            using var client = factory.CreateClient();
+
+            (await PreflightAllowOrigin(client, "http://evil.test")).Should().BeNull();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CORS_ORIGINS", null);
+        }
+    }
+
+    [Fact]
+    public async Task Unset_FallsBackToWebOrigin()
+    {
+        // CORS_ORIGINS not set → the policy should accept the default WebOrigin set by AuthApiFactory.
+        Environment.SetEnvironmentVariable("CORS_ORIGINS", null);
+        await using var factory = new AuthApiFactory(_fx.ConnectionString);
+        using var client = factory.CreateClient();
+
+        (await PreflightAllowOrigin(client, "http://localhost:5173")).Should().Be("http://localhost:5173");
+    }
+
+    [Fact]
+    public async Task CorsOrigins_AlwaysUnionsWebOrigin()
+    {
+        // Operator sets CORS_ORIGINS without including WEB_ORIGIN. The parser still adds
+        // WEB_ORIGIN because OAuth callback pages served from it need to XHR the API — if
+        // we stripped it out, the sign-in flow would silently break.
+        Environment.SetEnvironmentVariable("CORS_ORIGINS", "http://ops.test");
+        try
+        {
+            await using var factory = new AuthApiFactory(_fx.ConnectionString);
+            using var client = factory.CreateClient();
+
+            (await PreflightAllowOrigin(client, "http://ops.test")).Should().Be("http://ops.test");
+            (await PreflightAllowOrigin(client, "http://localhost:5173"))
+                .Should().Be("http://localhost:5173");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CORS_ORIGINS", null);
+        }
+    }
+
+    [Fact]
+    public async Task Wildcard_IsTreatedAsLiteralOrigin_NotBlanketAllow()
+    {
+        // "*" in CORS_ORIGINS is a literal origin string, not a wildcard. A real request
+        // from any host other than the literal "*" must be rejected — otherwise combining
+        // AllowCredentials() + wildcard would silently disable CORS protection.
+        Environment.SetEnvironmentVariable("CORS_ORIGINS", "*");
+        try
+        {
+            await using var factory = new AuthApiFactory(_fx.ConnectionString);
+            using var client = factory.CreateClient();
+
+            (await PreflightAllowOrigin(client, "http://evil.test")).Should().BeNull();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CORS_ORIGINS", null);
+        }
+    }
+
+    private static async Task<string?> PreflightAllowOrigin(HttpClient client, string origin)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Options, "/clips/feed");
+        req.Headers.Add("Origin", origin);
+        req.Headers.Add("Access-Control-Request-Method", "GET");
+
+        var resp = await client.SendAsync(req);
+        return resp.Headers.TryGetValues("Access-Control-Allow-Origin", out var values)
+            ? values.FirstOrDefault()
+            : null;
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CorsOriginsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CorsOriginsTests.cs
@@ -106,6 +106,9 @@ public class CorsOriginsTests
         req.Headers.Add("Access-Control-Request-Method", "GET");
 
         var resp = await client.SendAsync(req);
+        // A 5xx here would also produce no ACAO header; asserting 2xx first prevents the
+        // test from silently passing "origin denied" when the real fault was a server error.
+        resp.IsSuccessStatusCode.Should().BeTrue($"preflight should not 500 for origin {origin}; got {resp.StatusCode}");
         return resp.Headers.TryGetValues("Access-Control-Allow-Origin", out var values)
             ? values.FirstOrDefault()
             : null;

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ValidationShapeTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ValidationShapeTests.cs
@@ -1,0 +1,234 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using GankedTV.Api.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+/// <summary>
+/// Golden-shape assertions for the RFC 7807 ProblemDetails + ValidationProblemDetails
+/// envelope. One representative of each error category — status code/body shape alone is
+/// cheaper and more maintainable than duplicating across every per-field case already
+/// covered by the endpoint-specific test suites.
+/// </summary>
+[Collection("Postgres")]
+public class ValidationShapeTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+
+    public ValidationShapeTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        var storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task PatchMe_BioTooLong_ReturnsValidationProblem()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("alice");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync("/me", new { bio = new string('x', 501) });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("status").GetInt32().Should().Be(400);
+        body.GetProperty("errors").GetProperty("Bio").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task PatchMe_NullBody_ReturnsValidationProblem()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("bob");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync<object?>("/me", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("body").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task PatchMe_Unauthenticated_ReturnsEnvelopeFor401()
+    {
+        // The JwtBearer challenge produces the 401; AddProblemDetails() shapes the empty
+        // body into a ProblemDetails with status=401. We deliberately don't assert on
+        // "code" here — framework-authored 401s don't carry our extensions.code, only
+        // endpoint-authored ones do (e.g. Refresh's invalid_refresh, tested separately).
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PatchAsJsonAsync("/me", new { bio = "ok" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("status").GetInt32().Should().Be(401);
+    }
+
+    [Fact]
+    public async Task PatchClip_NonOwner_Returns403ProblemWithForbiddenCode()
+    {
+        // Non-owner sees 403 with the unified ProblemDetails envelope (code=forbidden)
+        // rather than an empty body from Results.Forbid().
+        await _fx.ResetAsync();
+        var (ownerId, _) = await SeedUserAndIssueTokenAsync("owner");
+        var (_, otherToken) = await SeedUserAndIssueTokenAsync("intruder");
+        var clipId = await SeedClipAsync(ownerId);
+        using var client = ClientWithBearer(otherToken);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "hijacked" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be("forbidden");
+    }
+
+    [Fact]
+    public async Task PatchMe_UsernameWhitespace_ReturnsProblemWithCode()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("carol");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync("/me", new { username = "   " });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be("invalid_username");
+    }
+
+    [Fact]
+    public async Task PatchClip_TitleTooLong_ReturnsValidationProblemWithTitleError()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, token) = await SeedUserAndIssueTokenAsync("owner");
+        var clipId = await SeedClipAsync(ownerId);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync(
+            $"/clips/{clipId}",
+            new { title = new string('a', ClipValidationLimits.MaxTitleLength + 1) });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("Title").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task CreateClip_MissingTitle_ReturnsValidationProblem()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("creator");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips/", new { description = "no title" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("Title").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Refresh_EmptyToken_ReturnsValidationProblem()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/auth/refresh", new { refresh = "" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("errors").GetProperty("Refresh").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Refresh_InvalidToken_ReturnsProblemWithCode()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/auth/refresh", new { refresh = "not-a-real-token" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be("invalid_refresh");
+    }
+
+    private async Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username)
+    {
+        var now = DateTimeOffset.UtcNow;
+        Guid id;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = username,
+                Email = $"{username}@example.com",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            id = user.Id;
+        }
+
+        using var scope = _factory!.Services.CreateScope();
+        var jwt = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var token = jwt.Issue(new User { Id = id, Username = username, Email = $"{username}@example.com" });
+        return (id, token);
+    }
+
+    private async Task<Guid> SeedClipAsync(Guid userId, string title = "seed")
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = title,
+            VideoKey = $"clips/{id}.mp4",
+            Status = "ready",
+            Visibility = "public",
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    private HttpClient ClientWithBearer(string token)
+    {
+        var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Middleware/ErrorHandlingMiddlewareTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Middleware/ErrorHandlingMiddlewareTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GankedTV.Api.Tests.Middleware;
+
+public class ErrorHandlingMiddlewareTests
+{
+    [Fact]
+    public async Task NoException_PassesThroughUnchanged()
+    {
+        var middleware = new ErrorHandlingMiddleware(NullLogger<ErrorHandlingMiddleware>.Instance);
+        var ctx = BuildContext(out var body);
+
+        await middleware.InvokeAsync(ctx, next: c =>
+        {
+            c.Response.StatusCode = 204;
+            return Task.CompletedTask;
+        });
+
+        ctx.Response.StatusCode.Should().Be(204);
+        body.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task UnhandledException_Returns500ProblemJson()
+    {
+        var middleware = new ErrorHandlingMiddleware(NullLogger<ErrorHandlingMiddleware>.Instance);
+        var ctx = BuildContext(out var body);
+
+        await middleware.InvokeAsync(ctx, _ => throw new InvalidOperationException("kaboom"));
+
+        ctx.Response.StatusCode.Should().Be(500);
+        ctx.Response.ContentType.Should().StartWith("application/problem+json");
+
+        body.Position = 0;
+        var doc = await JsonDocument.ParseAsync(body);
+        doc.RootElement.GetProperty("status").GetInt32().Should().Be(500);
+        doc.RootElement.GetProperty("code").GetString().Should().Be("internal_error");
+        doc.RootElement.TryGetProperty("stackTrace", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("exception", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExceptionAfterResponseStarted_Rethrows()
+    {
+        // Once the response has begun streaming, the best the middleware can do is log;
+        // rewriting is impossible and swallowing would mask the fault. Contract: rethrow.
+        var middleware = new ErrorHandlingMiddleware(NullLogger<ErrorHandlingMiddleware>.Instance);
+        var ctx = BuildContext(out _);
+        // DefaultHttpContext's response feature doesn't track HasStarted from a MemoryStream
+        // write, so swap in a feature that reports HasStarted=true to exercise this branch.
+        ctx.Features.Set<IHttpResponseFeature>(new StartedResponseFeature());
+
+        var act = async () => await middleware.InvokeAsync(ctx, _ =>
+            throw new InvalidOperationException("late"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("late");
+    }
+
+    private sealed class StartedResponseFeature : IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = 200;
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = Stream.Null;
+        public bool HasStarted => true;
+        public void OnStarting(Func<object, Task> callback, object state) { }
+        public void OnCompleted(Func<object, Task> callback, object state) { }
+    }
+
+    [Fact]
+    public async Task ExceptionLogged_AtErrorLevel()
+    {
+        var logger = new CollectingLogger();
+        var middleware = new ErrorHandlingMiddleware(logger);
+        var ctx = BuildContext(out _);
+
+        await middleware.InvokeAsync(ctx, _ => throw new InvalidOperationException("kaboom"));
+
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Error);
+    }
+
+    private static DefaultHttpContext BuildContext(out MemoryStream body)
+    {
+        body = new MemoryStream();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddProblemDetails();
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            Response = { Body = body },
+            Request = { Method = "GET", Path = "/test" },
+        };
+    }
+
+    private sealed class CollectingLogger : ILogger<ErrorHandlingMiddleware>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Problems/ProblemResultsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Problems/ProblemResultsTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Problems;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GankedTV.Api.Tests.Problems;
+
+public class ProblemResultsTests
+{
+    public static TheoryData<Func<IResult>, int, string> Cases => new()
+    {
+        { () => ProblemResults.BadRequest("bad"), StatusCodes.Status400BadRequest, "bad" },
+        { () => ProblemResults.Unauthorized("no"), StatusCodes.Status401Unauthorized, "no" },
+        { () => ProblemResults.Forbidden("nope"), StatusCodes.Status403Forbidden, "nope" },
+        { () => ProblemResults.NotFound("missing"), StatusCodes.Status404NotFound, "missing" },
+        { () => ProblemResults.Conflict("conflict"), StatusCodes.Status409Conflict, "conflict" },
+        { () => ProblemResults.UnsupportedMediaType("bad_ct"), StatusCodes.Status415UnsupportedMediaType, "bad_ct" },
+        { () => ProblemResults.Internal("boom"), StatusCodes.Status500InternalServerError, "boom" },
+    };
+
+    [Theory, MemberData(nameof(Cases))]
+    public async Task Factory_ProducesExpectedStatusAndCode(Func<IResult> build, int expectedStatus, string expectedCode)
+    {
+        var (status, body) = await ExecuteAsync(build());
+
+        status.Should().Be(expectedStatus);
+        body.RootElement.GetProperty("status").GetInt32().Should().Be(expectedStatus);
+        body.RootElement.GetProperty(ProblemResults.CodeKey).GetString().Should().Be(expectedCode);
+    }
+
+    [Fact]
+    public async Task Detail_IsIncludedWhenProvided()
+    {
+        var (_, body) = await ExecuteAsync(ProblemResults.BadRequest("bad", "why"));
+        body.RootElement.GetProperty("detail").GetString().Should().Be("why");
+    }
+
+    private static async Task<(int status, JsonDocument body)> ExecuteAsync(IResult result)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddProblemDetails();
+        var sp = services.BuildServiceProvider();
+
+        var ctx = new DefaultHttpContext { RequestServices = sp };
+        using var ms = new MemoryStream();
+        ctx.Response.Body = ms;
+
+        await result.ExecuteAsync(ctx);
+
+        ms.Position = 0;
+        var body = await JsonDocument.ParseAsync(ms);
+        return (ctx.Response.StatusCode, body);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using GankedTV.Api.Tests.TestSupport;
+using GankedTV.Api.Tools;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GankedTV.Api.Tests.Tools;
+
+[Collection("Postgres")]
+public class SeedCommandTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+
+    public SeedCommandTests(PostgresFixture fx) => _fx = fx;
+
+    public async Task InitializeAsync() => await _fx.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData(new[] { "--seed" }, true)]
+    [InlineData(new[] { "--other", "--seed", "trailing" }, true)]
+    [InlineData(new[] { "--other" }, false)]
+    [InlineData(new string[0], false)]
+    public void ShouldRun_DetectsFlag(string[] args, bool expected)
+    {
+        SeedCommand.ShouldRun(args).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task FreshDb_CreatesOneUserAndTenClips()
+    {
+        await using var db = _fx.CreateContext();
+        var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
+
+        await seed.RunAsync(CancellationToken.None);
+
+        await using var verify = _fx.CreateContext();
+        (await verify.Users.CountAsync()).Should().Be(1);
+        (await verify.Clips.CountAsync()).Should().Be(SeedCommand.SeedClipCount);
+        (await verify.Users.SingleAsync()).Username.Should().Be(SeedCommand.SeedUsername);
+    }
+
+    [Fact]
+    public async Task RunTwice_IsIdempotent()
+    {
+        await using (var db = _fx.CreateContext())
+        {
+            var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
+            await seed.RunAsync(CancellationToken.None);
+        }
+
+        await using (var db = _fx.CreateContext())
+        {
+            var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
+            await seed.RunAsync(CancellationToken.None);
+        }
+
+        await using var verify = _fx.CreateContext();
+        (await verify.Users.CountAsync()).Should().Be(1);
+        (await verify.Clips.CountAsync()).Should().Be(SeedCommand.SeedClipCount);
+    }
+
+    [Fact]
+    public async Task ClipIds_AreDeterministic()
+    {
+        await using var db = _fx.CreateContext();
+        var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
+        await seed.RunAsync(CancellationToken.None);
+
+        await using var verify = _fx.CreateContext();
+        var ids = await verify.Clips.Select(c => c.Id).OrderBy(id => id).ToListAsync();
+        ids.Should().Equal(
+            Enumerable.Range(1, SeedCommand.SeedClipCount)
+                .Select(SeedCommand.SeedClipId)
+                .OrderBy(id => id));
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
@@ -1,7 +1,10 @@
 using FluentAssertions;
+using GankedTV.Api.Data;
 using GankedTV.Api.Tests.TestSupport;
 using GankedTV.Api.Tools;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GankedTV.Api.Tests.Tools;
@@ -30,7 +33,7 @@ public class SeedCommandTests : IAsyncLifetime
     public async Task FreshDb_CreatesOneUserAndTenClips()
     {
         await using var db = _fx.CreateContext();
-        var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
+        var seed = NewSeed(db);
 
         await seed.RunAsync(CancellationToken.None);
 
@@ -45,14 +48,12 @@ public class SeedCommandTests : IAsyncLifetime
     {
         await using (var db = _fx.CreateContext())
         {
-            var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
-            await seed.RunAsync(CancellationToken.None);
+            await NewSeed(db).RunAsync(CancellationToken.None);
         }
 
         await using (var db = _fx.CreateContext())
         {
-            var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
-            await seed.RunAsync(CancellationToken.None);
+            await NewSeed(db).RunAsync(CancellationToken.None);
         }
 
         await using var verify = _fx.CreateContext();
@@ -64,8 +65,7 @@ public class SeedCommandTests : IAsyncLifetime
     public async Task ClipIds_AreDeterministic()
     {
         await using var db = _fx.CreateContext();
-        var seed = new SeedCommand(db, NullLogger<SeedCommand>.Instance, TimeProvider.System);
-        await seed.RunAsync(CancellationToken.None);
+        await NewSeed(db).RunAsync(CancellationToken.None);
 
         await using var verify = _fx.CreateContext();
         var ids = await verify.Clips.Select(c => c.Id).OrderBy(id => id).ToListAsync();
@@ -73,5 +73,36 @@ public class SeedCommandTests : IAsyncLifetime
             Enumerable.Range(1, SeedCommand.SeedClipCount)
                 .Select(SeedCommand.SeedClipId)
                 .OrderBy(id => id));
+    }
+
+    [Fact]
+    public async Task NonDevelopmentEnvironment_RefusesToSeed_AndLogsError()
+    {
+        // Production/Staging DBs must not get predictable seeded test data. The guard
+        // lives in SeedCommand itself (not just Program.cs) so any caller — CLI, hosted
+        // service, admin endpoint — gets the same fail-closed behavior.
+        await using var db = _fx.CreateContext();
+        var seed = new SeedCommand(
+            db,
+            NullLogger<SeedCommand>.Instance,
+            TimeProvider.System,
+            new FakeHostEnvironment("Production"));
+
+        await seed.RunAsync(CancellationToken.None);
+
+        await using var verify = _fx.CreateContext();
+        (await verify.Users.CountAsync()).Should().Be(0);
+        (await verify.Clips.CountAsync()).Should().Be(0);
+    }
+
+    private SeedCommand NewSeed(GankedTvDbContext db) =>
+        new(db, NullLogger<SeedCommand>.Instance, TimeProvider.System, new FakeHostEnvironment("Development"));
+
+    private sealed class FakeHostEnvironment(string name) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = name;
+        public string ApplicationName { get; set; } = "GankedTV.Api.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
     }
 }


### PR DESCRIPTION
## Summary

Production-shape backend polish: CORS becomes multi-origin (`CORS_ORIGINS`), every 4xx/5xx returns an RFC 7807 `ProblemDetails` body with a machine-readable `code` in `extensions`, POST/PATCH DTOs gain declarative validation, and a one-liner `--seed` command bootstraps realistic local data.

## What's here

- **CORS**: `CORS_ORIGINS` env var (comma-separated), always unioned with `WEB_ORIGIN` so the OAuth callback origin can't be accidentally dropped. Parsed by `CorsOriginsParser` (unit-tested incl. wildcard-literal and dedup cases).
- **Error envelope**: `AddProblemDetails()` + `UseStatusCodePages()` shape framework-generated 4xx/5xx; `ErrorHandlingMiddleware` catches unhandled exceptions → 500 problem+json (no stack leak). New `ProblemResults.*` helpers (`BadRequest`, `Unauthorized`, `Forbidden`, `NotFound`, `Conflict`, `UnsupportedMediaType`, `Internal`, `InvalidBody`) replace every ad-hoc `{ error: "..." }` across endpoints. Existing error-code vocabulary (`invalid_username`, `username_taken`, `invalid_state`, etc.) preserved in `extensions.code`.
- **DTO validation**: `ValidationEndpointFilter<T>` + `.WithValidation<T>()` extension runs DataAnnotations on `CreateClipRequest`, `UpdateClipRequest`, `UpdateMeRequest`, `RefreshRequest`. Length caps mirrored from `ClipValidationOptions` via new `ClipValidationLimits` constants. No new NuGet packages.
- **Dev seed**: `dotnet run -- --seed` short-circuits in `Program.cs`, resolves `SeedCommand`, upserts one user + ten clips with deterministic GUIDs (idempotent).

Closes #15

## How to test manually

```bash
# tests + coverage gate (85/85)
dotnet test server /p:CollectCoverage=true /p:Threshold=85%2C85

# seed (run twice — second run is a no-op)
DATABASE_URL=postgres://gankedtv:gankedtv_dev@localhost:5435/gankedtv \
  dotnet run --project server/src/GankedTV.Api -- --seed

# multi-origin CORS
CORS_ORIGINS=http://localhost:5173,http://localhost:5174 \
  dotnet watch --project server/src/GankedTV.Api
curl -i -H "Origin: http://localhost:5174" http://localhost:5000/clips/feed
# → Access-Control-Allow-Origin: http://localhost:5174

# ProblemDetails envelope + validation
curl -i -X PATCH http://localhost:5000/me \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"bio":"'"$(printf 'x%.0s' {1..501})"'"}'
# → 400 application/problem+json with errors.Bio array
```

## Checklist

- [ ] Tested manually against local Postgres + MinIO
- [ ] Verified `--seed` is idempotent on a non-empty DB
- [ ] Confirmed web client still parses error responses (reads `body.code` instead of `body.error`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized error response formatting across API endpoints for consistency
  * Enhanced validation with clearer, more detailed error messages for failed requests
  * Improved error handling and recovery for unexpected exceptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->