### PR TITLE
feat(web): wire clip detail, upload, and profile to live API

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -50,12 +50,33 @@ if [ -z "$touched_server" ] && [ -z "$touched_web" ]; then
   exit 0
 fi
 
+# Run formatters first (write mode) so we can fail fast if anything changed.
+# Snapshot the diff before so we can detect formatter-induced changes even on
+# files that were already dirty.
+diff_before=$(git diff)
+
+if [ -n "$touched_server" ]; then
+  echo "pre-push: formatting server…"
+  (cd server && dotnet format)
+fi
+
+if [ -n "$touched_web" ]; then
+  echo "pre-push: formatting web…"
+  (cd web && bun install --frozen-lockfile && bun run format)
+fi
+
+if [ "$diff_before" != "$(git diff)" ]; then
+  echo
+  echo "pre-push: the formatter modified files. Review, commit, and push again:"
+  git diff --name-only | sed 's/^/  /'
+  exit 1
+fi
+
 if [ -n "$touched_server" ]; then
   echo "pre-push: running server checks…"
   (
     cd server
     dotnet build --configuration Release
-    dotnet format --verify-no-changes --no-restore
     dotnet test --configuration Release /p:CollectCoverage=true /p:Threshold=85%2C85
   )
 fi
@@ -64,8 +85,6 @@ if [ -n "$touched_web" ]; then
   echo "pre-push: running web checks…"
   (
     cd web
-    bun install --frozen-lockfile
-    bun run format:check
     bun run lint:check
     bun run build
     bun run test:coverage

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -61,8 +61,17 @@ if [ -n "$touched_server" ]; then
 fi
 
 if [ -n "$touched_web" ]; then
+  # Only re-install when a manifest changed in the pushed range; cached node_modules
+  # is otherwise reused, saving a cold-cache install on every push.
+  manifest_changed=$(echo "$changed_files" | grep -E '^web/(package\.json|bun\.lock)$' || true)
   echo "pre-push: formatting web…"
-  (cd web && bun install --frozen-lockfile && bun run format)
+  (
+    cd web
+    if [ -n "$manifest_changed" ]; then
+      bun install --frozen-lockfile
+    fi
+    bun run format
+  )
 fi
 
 if [ "$diff_before" != "$(git diff)" ]; then

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
@@ -12,7 +12,7 @@ public static class ClipMappings
         new(result.ClipId);
 
     public static UploadUrlResponse ToUploadUrlResponse(this UploadUrlResult result) =>
-        new(result.Url, result.ExpiresAt);
+        new(result.Url, result.ExpiresAt, result.ContentType);
 
     public static CompleteClipResponse ToCompleteClipResponse(this CompleteClipResult result) =>
         new(result.ClipId, result.FileSizeBytes);

--- a/server/src/GankedTV.Api/Contracts/Clips/UploadUrlResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/UploadUrlResponse.cs
@@ -1,3 +1,6 @@
 namespace GankedTV.Api.Contracts.Clips;
 
-public sealed record UploadUrlResponse(string Url, DateTimeOffset ExpiresAt);
+// ContentType: the MIME the server signed the presigned PUT for. The client MUST send
+// this exact value as the request Content-Type — S3/MinIO includes it in the signature
+// and will reject the upload with 403 SignatureDoesNotMatch otherwise.
+public sealed record UploadUrlResponse(string Url, DateTimeOffset ExpiresAt, string ContentType);

--- a/server/src/GankedTV.Api/GankedTV.Api.csproj
+++ b/server/src/GankedTV.Api/GankedTV.Api.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>05a9775a-98be-4d18-bdbb-4807bdec365e</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/server/src/GankedTV.Api/Properties/launchSettings.json
+++ b/server/src/GankedTV.Api/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5293",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7035;http://localhost:5293",
+      "applicationUrl": "https://localhost:7035;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -68,7 +68,9 @@ public sealed class ClipUploadService : IClipUploadService
             GameId = input.GameId,
             Title = title,
             Description = string.IsNullOrEmpty(input.Description) ? null : input.Description,
-            VideoKey = $"clips/{id}.mp4",
+            // Namespace by user id (immutable — username can change via PATCH /me)
+            // so a single bucket listing groups one user's blobs together.
+            VideoKey = $"clips/{userId}/{id}.mp4",
             Status = ClipStatuses.Draft,
             Visibility = visibility,
             CreatedAt = now,

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -102,14 +102,15 @@ public sealed class ClipUploadService : IClipUploadService
             return ClipResult<UploadUrlResult>.Fail(ClipUploadError.InvalidState);
         }
 
+        var contentType = PrimaryContentType;
         var url = _storage.GetPresignedPutUrl(
             _minio.ClipsBucket,
             clip.VideoKey,
-            PrimaryContentType,
+            contentType,
             UploadUrlExpiry);
         var expiresAt = _clock.GetUtcNow().Add(UploadUrlExpiry);
 
-        return ClipResult<UploadUrlResult>.Ok(new UploadUrlResult(url, expiresAt));
+        return ClipResult<UploadUrlResult>.Ok(new UploadUrlResult(url, expiresAt, contentType));
     }
 
     public async Task<ClipResult<CompleteClipResult>> CompleteAsync(

--- a/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
@@ -14,7 +14,7 @@ public sealed record CreateClipInput(
     string? Visibility);
 
 public sealed record CreateClipResult(Guid ClipId);
-public sealed record UploadUrlResult(string Url, DateTimeOffset ExpiresAt);
+public sealed record UploadUrlResult(string Url, DateTimeOffset ExpiresAt, string ContentType);
 public sealed record CompleteClipResult(Guid ClipId, long FileSizeBytes);
 
 public enum ClipUploadError

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
@@ -407,7 +407,7 @@ public class ClipsMutateEndpointsTests : IAsyncLifetime
 
         _storage.Received().GetPresignedGetUrl(
             Arg.Any<string>(),
-            $"clips/{clipId}.mp4",
+            $"clips/{ownerId}/{clipId}.mp4",
             Arg.Is<TimeSpan?>(ts => ts.HasValue && ts.Value == TimeSpan.FromHours(1)));
     }
 
@@ -497,7 +497,7 @@ public class ClipsMutateEndpointsTests : IAsyncLifetime
         // video key into the thumbnails bucket (and vice versa), silently breaking cleanup.
         await _storage.Received(1).DeleteObjectAsync(
             minio.ClipsBucket,
-            $"clips/{clipId}.mp4",
+            $"clips/{ownerId}/{clipId}.mp4",
             Arg.Any<CancellationToken>());
         await _storage.Received(1).DeleteObjectAsync(
             minio.ThumbnailsBucket,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
@@ -87,7 +87,7 @@ public class ClipsMutateEndpointsTests : IAsyncLifetime
             Title = title,
             Description = description,
             GameId = gameId,
-            VideoKey = $"clips/{id}.mp4",
+            VideoKey = $"clips/{userId}/{id}.mp4",
             ThumbnailKey = thumbnailKey,
             Status = status,
             Visibility = visibility,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -78,7 +78,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             Id = id,
             UserId = userId,
             Title = title ?? $"clip-{id:N}".Substring(0, 20),
-            VideoKey = $"clips/{id}.mp4",
+            VideoKey = $"clips/{userId}/{id}.mp4",
             ThumbnailKey = $"thumbs/{id}.jpg",
             Status = status,
             Visibility = visibility,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -486,7 +486,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         // Expiry passed to the storage service should be roughly one hour.
         _storage.Received(1).GetPresignedGetUrl(
             Arg.Any<string>(),
-            $"clips/{clipId}.mp4",
+            $"clips/{userId}/{clipId}.mp4",
             Arg.Is<TimeSpan?>(ts => ts.HasValue && ts.Value == TimeSpan.FromHours(1)));
     }
 

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
@@ -75,7 +75,7 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
             Id = id,
             UserId = userId,
             Title = "seed",
-            VideoKey = $"clips/{id}.mp4",
+            VideoKey = $"clips/{userId}/{id}.mp4",
             Status = status,
             Visibility = "public",
             FileSizeBytes = fileSizeBytes,
@@ -322,10 +322,13 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
         body.GetProperty("url").GetString().Should().Be("http://localhost:9000/clips/signed?sig=abc");
         body.GetProperty("expiresAt").GetDateTimeOffset()
             .Should().BeCloseTo(DateTimeOffset.UtcNow.AddMinutes(15), TimeSpan.FromMinutes(1));
+        // Pinned to the same content type the server signed for so a future contract
+        // change is forced to think about the client-side Content-Type header too.
+        body.GetProperty("contentType").GetString().Should().Be("video/mp4");
 
         _storage.Received(1).GetPresignedPutUrl(
             "clips",
-            $"clips/{clipId}.mp4",
+            $"clips/{userId}/{clipId}.mp4",
             "video/mp4",
             TimeSpan.FromMinutes(15));
     }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
@@ -121,7 +121,7 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
         var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == id);
         clip.UserId.Should().Be(userId);
         clip.Status.Should().Be("draft");
-        clip.VideoKey.Should().Be($"clips/{id}.mp4");
+        clip.VideoKey.Should().Be($"clips/{userId}/{id}.mp4");
         clip.Visibility.Should().Be("unlisted");
         clip.Title.Should().Be("My first clip");
         clip.Description.Should().Be("did a thing");

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
@@ -75,7 +75,7 @@ public class LikesEndpointsTests : IAsyncLifetime
             Id = id,
             UserId = userId,
             Title = "likable",
-            VideoKey = $"clips/{id}.mp4",
+            VideoKey = $"clips/{userId}/{id}.mp4",
             Status = "ready",
             Visibility = "public",
             LikeCount = initialLikeCount,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
@@ -83,7 +83,7 @@ public class UsersEndpointsTests : IAsyncLifetime
             Id = id,
             UserId = userId,
             Title = title ?? "seed",
-            VideoKey = $"clips/{id}.mp4",
+            VideoKey = $"clips/{userId}/{id}.mp4",
             ThumbnailKey = $"thumbs/{id}.jpg",
             Status = status,
             Visibility = visibility,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ValidationShapeTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ValidationShapeTests.cs
@@ -215,7 +215,7 @@ public class ValidationShapeTests : IAsyncLifetime
             Id = id,
             UserId = userId,
             Title = title,
-            VideoKey = $"clips/{id}.mp4",
+            VideoKey = $"clips/{userId}/{id}.mp4",
             Status = "ready",
             Visibility = "public",
             CreatedAt = now,

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -6,6 +6,7 @@
       "name": "gankedtv",
       "dependencies": {
         "pinia": "^3.0.4",
+        "plyr": "3.8.4",
         "vue": "^3.5.32",
         "vue-router": "^4.5.0",
       },
@@ -545,6 +546,8 @@
 
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
@@ -552,6 +555,8 @@
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "custom-event-polyfill": ["custom-event-polyfill@1.0.7", "", {}, "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
@@ -747,6 +752,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "loadjs": ["loadjs@4.3.0", "", {}, "sha512-vNX4ZZLJBeDEOBvdr2v/F+0aN5oMuPu7JTqrMwp+DtgK+AryOlpy6Xtm2/HpNr+azEa828oQjOtWsB6iDtSfSQ=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
@@ -829,6 +836,8 @@
 
     "pinia": ["pinia@3.0.4", "", { "dependencies": { "@vue/devtools-api": "^7.7.7" }, "peerDependencies": { "typescript": ">=4.5.0", "vue": "^3.5.11" }, "optionalPeers": ["typescript"] }, "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw=="],
 
+    "plyr": ["plyr@3.8.4", "", { "dependencies": { "core-js": "^3.45.1", "custom-event-polyfill": "^1.0.7", "loadjs": "^4.3.0", "rangetouch": "^2.0.1", "url-polyfill": "^1.1.13" } }, "sha512-DrzLbK9Wol3zeiuZCleD9aUOl0KAaBHR9H6WVVVYPZ4Ya+LYxUFTgSF1jooHcMQCv96Ws96wCaZzIoP3bES8pQ=="],
+
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
@@ -842,6 +851,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "rangetouch": ["rangetouch@2.0.1", "", {}, "sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA=="],
 
     "read-package-json-fast": ["read-package-json-fast@4.0.0", "", { "dependencies": { "json-parse-even-better-errors": "^4.0.0", "npm-normalize-package-bin": "^4.0.0" } }, "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg=="],
 
@@ -940,6 +951,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "url-polyfill": ["url-polyfill@1.1.14", "", {}, "sha512-p4f3TTAG6ADVF3mwbXw7hGw+QJyw5CnNGvYh5fCuQQZIiuKUswqcznyV3pGDP9j0TSmC4UvRKm8kl1QsX1diiQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -6,7 +6,7 @@
       "name": "gankedtv",
       "dependencies": {
         "pinia": "^3.0.4",
-        "plyr": "3.8.4",
+        "plyr": "^3.8.4",
         "vue": "^3.5.32",
         "vue-router": "^4.5.0",
       },

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -11,6 +11,9 @@ declare module '*.vue' {
 // `verbatimModuleSyntax`. Re-declare the minimal surface we actually use as a
 // clean ESM default class so `import Plyr from 'plyr'` type-checks both as a
 // value (constructor) and as a type.
+//
+// If you need additional Plyr methods (e.g. `play()`, `source = ...`,
+// `on('ended', ...)`), extend this shim — don't reach into `plyr/src/js/plyr`.
 declare module 'plyr' {
   export interface PlyrOptions {
     controls?: string[]

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -6,3 +6,21 @@ declare module '*.vue' {
   const component: DefineComponent<{}, {}, any>
   export default component
 }
+
+// Plyr ships a .d.ts that mixes `export =` and `export default`, which trips
+// `verbatimModuleSyntax`. Re-declare the minimal surface we actually use as a
+// clean ESM default class so `import Plyr from 'plyr'` type-checks both as a
+// value (constructor) and as a type.
+declare module 'plyr' {
+  export interface PlyrOptions {
+    controls?: string[]
+    tooltips?: { controls?: boolean; seek?: boolean }
+  }
+  export default class Plyr {
+    constructor(
+      target: HTMLElement | string | NodeList | HTMLElement[],
+      options?: PlyrOptions,
+    )
+    destroy(): void
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "pinia": "^3.0.4",
+    "plyr": "3.8.4",
     "vue": "^3.5.32",
     "vue-router": "^4.5.0"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "pinia": "^3.0.4",
-    "plyr": "3.8.4",
+    "plyr": "^3.8.4",
     "vue": "^3.5.32",
     "vue-router": "^4.5.0"
   },

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -41,7 +41,10 @@ describe('api/clips', () => {
         author: { id: 'u', username: 'zoe', avatarUrl: null },
         likedByMe: false,
       }
-      vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(detail)))
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(detail)),
+      )
 
       const result = await clips.getDetail(detail.id)
 

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -52,6 +52,17 @@ describe('api/clips', () => {
       const [url] = vi.mocked(fetch).mock.calls[0] as [string]
       expect(url).toBe(`${BASE_URL}/clips/${detail.id}`)
     })
+
+    it('URI-encodes special characters in the id path segment', async () => {
+      // Server uses GUIDs today, but encoding is a cheap insurance against future
+      // schemes (slugs, short codes) that could include reserved characters.
+      vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({})))
+
+      await clips.getDetail('weird id/with?chars')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/clips/${encodeURIComponent('weird id/with?chars')}`)
+    })
   })
 
   describe('create()', () => {

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -56,7 +56,10 @@ describe('api/clips', () => {
     it('URI-encodes special characters in the id path segment', async () => {
       // Server uses GUIDs today, but encoding is a cheap insurance against future
       // schemes (slugs, short codes) that could include reserved characters.
-      vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({})))
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({})),
+      )
 
       await clips.getDetail('weird id/with?chars')
 

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -86,6 +86,9 @@ describe('api/clips', () => {
       const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
       expect(url).toBe(`${BASE_URL}/clips`)
       expect(init.method).toBe('POST')
+      // The api() client must auto-set this when body is a plain object — locked here
+      // so a future client refactor doesn't silently drop the header on JSON requests.
+      expect(new Headers(init.headers).get('Content-Type')).toBe('application/json')
       expect(JSON.parse(String(init.body))).toEqual({
         title: 'My clip',
         description: 'desc',

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { clips } from '../clips'
+import { configureAuth, BASE_URL } from '../client'
+
+beforeEach(() => {
+  configureAuth({
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    onTokenRefreshed: () => {},
+    onRefreshFailed: () => {},
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('api/clips', () => {
+  describe('getDetail()', () => {
+    it('issues GET /clips/{id} and returns the parsed detail', async () => {
+      const detail = {
+        id: 'a4f1e2c0-0000-0000-0000-000000000001',
+        title: 'Sample',
+        description: null,
+        videoUrl: 'https://cdn.example.com/clips/abc.mp4?sig=xyz',
+        videoUrlExpiresAt: '2026-04-26T13:00:00Z',
+        thumbnailKey: null,
+        durationSecs: 42,
+        width: 1920,
+        height: 1080,
+        viewCount: 7,
+        likeCount: 3,
+        createdAt: '2026-04-26T12:00:00Z',
+        author: { id: 'u', username: 'zoe', avatarUrl: null },
+        likedByMe: false,
+      }
+      vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(detail)))
+
+      const result = await clips.getDetail(detail.id)
+
+      expect(result).toEqual(detail)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/clips/${detail.id}`)
+    })
+  })
+
+  describe('create()', () => {
+    it('POSTs the clip metadata and returns the new clip id', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ id: 'new-clip-id' }, 201)),
+      )
+
+      const result = await clips.create({
+        title: 'My clip',
+        description: 'desc',
+        gameId: null,
+        visibility: 'public',
+      })
+
+      expect(result).toEqual({ id: 'new-clip-id' })
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips`)
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(String(init.body))).toEqual({
+        title: 'My clip',
+        description: 'desc',
+        gameId: null,
+        visibility: 'public',
+      })
+    })
+  })
+
+  describe('getUploadUrl()', () => {
+    it('POSTs to /clips/{id}/upload-url and returns the presigned PUT URL', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          jsonResponse({
+            url: 'https://minio.example.com/clips/abc?sig=xyz',
+            expiresAt: '2026-04-26T13:15:00Z',
+          }),
+        ),
+      )
+
+      const result = await clips.getUploadUrl('clip-id')
+
+      expect(result.url).toBe('https://minio.example.com/clips/abc?sig=xyz')
+      expect(result.expiresAt).toBe('2026-04-26T13:15:00Z')
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips/clip-id/upload-url`)
+      expect(init.method).toBe('POST')
+    })
+  })
+
+  describe('complete()', () => {
+    it('POSTs to /clips/{id}/complete and returns the file size confirmation', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ id: 'clip-id', fileSizeBytes: 1234567 })),
+      )
+
+      const result = await clips.complete('clip-id')
+
+      expect(result).toEqual({ id: 'clip-id', fileSizeBytes: 1234567 })
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips/clip-id/complete`)
+      expect(init.method).toBe('POST')
+    })
+  })
+
+  describe('like() / unlike()', () => {
+    it('POSTs /clips/{id}/like and returns the new count + liked flag', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ likeCount: 8, liked: true })),
+      )
+
+      const result = await clips.like('clip-id')
+
+      expect(result).toEqual({ likeCount: 8, liked: true })
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips/clip-id/like`)
+      expect(init.method).toBe('POST')
+    })
+
+    it('DELETEs /clips/{id}/like to unlike', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ likeCount: 7, liked: false })),
+      )
+
+      const result = await clips.unlike('clip-id')
+
+      expect(result).toEqual({ likeCount: 7, liked: false })
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips/clip-id/like`)
+      expect(init.method).toBe('DELETE')
+    })
+  })
+})

--- a/web/src/api/__tests__/users.spec.ts
+++ b/web/src/api/__tests__/users.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { users } from '../users'
+import { configureAuth, BASE_URL } from '../client'
+
+beforeEach(() => {
+  configureAuth({
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    onTokenRefreshed: () => {},
+    onRefreshFailed: () => {},
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('api/users', () => {
+  describe('getByUsername()', () => {
+    it('issues GET /users/{username} (URI-encoded) and returns the parsed profile', async () => {
+      const profile = {
+        id: 'u-1',
+        username: 'zoe.qa',
+        bio: null,
+        avatarUrl: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        clips: [],
+      }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify(profile), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+        ),
+      )
+
+      const result = await users.getByUsername('zoe.qa')
+
+      expect(result).toEqual(profile)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      // Encoding matters — usernames may contain '.' (legal, no encoding) but the API
+      // also accepts case-sensitive lookups; encodeURIComponent guards against future
+      // characters that would otherwise corrupt the path.
+      expect(url).toBe(`${BASE_URL}/users/zoe.qa`)
+    })
+
+    it('URI-encodes special characters in the username path segment', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify({}), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+        ),
+      )
+
+      await users.getByUsername('weird user/name')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/users/${encodeURIComponent('weird user/name')}`)
+    })
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -75,10 +75,12 @@ function buildHeaders(accessToken: string | null, extra?: HeadersInit): Headers 
   return headers
 }
 
-export async function api<T = undefined>(
-  path: string,
-  init: RequestInit & { _isRetry?: boolean } = {},
-): Promise<T> {
+export type ApiInit = Omit<RequestInit, 'body'> & {
+  body?: BodyInit | object | null
+  _isRetry?: boolean
+}
+
+export async function api<T = undefined>(path: string, init: ApiInit = {}): Promise<T> {
   const { _isRetry, ...fetchInit } = init
 
   const headers = buildHeaders(_auth.getAccessToken(), fetchInit.headers)
@@ -97,7 +99,11 @@ export async function api<T = undefined>(
     fetchInit.body = JSON.stringify(fetchInit.body)
   }
 
-  const response = await fetch(`${BASE_URL}${path}`, { ...fetchInit, headers })
+  const response = await fetch(`${BASE_URL}${path}`, {
+    ...fetchInit,
+    headers,
+    body: fetchInit.body as BodyInit | null | undefined,
+  })
 
   if (response.status === 401 && !_isRetry && _auth.getRefreshToken()) {
     // Streaming request bodies cannot be replayed on retry.

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -1,0 +1,88 @@
+import { api } from './client'
+
+export interface AuthorSummary {
+  id: string
+  username: string
+  avatarUrl: string | null
+}
+
+export interface ClipFeedItem {
+  id: string
+  title: string
+  description: string | null
+  thumbnailKey: string | null
+  durationSecs: number | null
+  viewCount: number
+  likeCount: number
+  createdAt: string
+  author: AuthorSummary
+  likedByMe: boolean
+}
+
+export interface ClipDetail {
+  id: string
+  title: string
+  description: string | null
+  videoUrl: string
+  videoUrlExpiresAt: string
+  thumbnailKey: string | null
+  durationSecs: number | null
+  width: number | null
+  height: number | null
+  viewCount: number
+  likeCount: number
+  createdAt: string
+  author: AuthorSummary
+  likedByMe: boolean
+}
+
+export interface UploadUrl {
+  url: string
+  expiresAt: string
+}
+
+export interface CreateClipBody {
+  title: string
+  description: string | null
+  gameId: number | null
+  visibility: 'public' | 'unlisted'
+}
+
+export interface CompleteClipResult {
+  id: string
+  fileSizeBytes: number
+}
+
+export interface LikeResult {
+  likeCount: number
+  liked: boolean
+}
+
+export const clips = {
+  getDetail(id: string): Promise<ClipDetail> {
+    return api<ClipDetail>(`/clips/${encodeURIComponent(id)}`)
+  },
+
+  create(body: CreateClipBody): Promise<{ id: string }> {
+    return api<{ id: string }>('/clips', {
+      method: 'POST',
+      body: body as unknown as BodyInit,
+    })
+  },
+
+  getUploadUrl(id: string): Promise<UploadUrl> {
+    return api<UploadUrl>(`/clips/${encodeURIComponent(id)}/upload-url`, { method: 'POST' })
+  },
+
+  complete(id: string): Promise<CompleteClipResult> {
+    return api<CompleteClipResult>(`/clips/${encodeURIComponent(id)}/complete`, { method: 'POST' })
+  },
+
+  like(id: string): Promise<LikeResult> {
+    return api<LikeResult>(`/clips/${encodeURIComponent(id)}/like`, { method: 'POST' })
+  },
+
+  unlike(id: string): Promise<LikeResult> {
+    return api<LikeResult>(`/clips/${encodeURIComponent(id)}/like`, { method: 'DELETE' })
+  },
+}

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -39,6 +39,10 @@ export interface ClipDetail {
 export interface UploadUrl {
   url: string
   expiresAt: string
+  // The MIME the server signed the presigned PUT for. The client MUST send this exact
+  // value as the request Content-Type — S3/MinIO includes it in the signature and will
+  // 403 the upload otherwise.
+  contentType: string
 }
 
 export interface CreateClipBody {

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -64,10 +64,7 @@ export const clips = {
   },
 
   create(body: CreateClipBody): Promise<{ id: string }> {
-    return api<{ id: string }>('/clips', {
-      method: 'POST',
-      body: body as unknown as BodyInit,
-    })
+    return api<{ id: string }>('/clips', { method: 'POST', body })
   },
 
   getUploadUrl(id: string): Promise<UploadUrl> {

--- a/web/src/api/users.ts
+++ b/web/src/api/users.ts
@@ -1,0 +1,17 @@
+import { api } from './client'
+import type { ClipFeedItem } from './clips'
+
+export interface UserProfile {
+  id: string
+  username: string
+  bio: string | null
+  avatarUrl: string | null
+  createdAt: string
+  clips: ClipFeedItem[]
+}
+
+export const users = {
+  getByUsername(username: string): Promise<UserProfile> {
+    return api<UserProfile>(`/users/${encodeURIComponent(username)}`)
+  },
+}

--- a/web/src/lib/__tests__/url.spec.ts
+++ b/web/src/lib/__tests__/url.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { safeImageUrl } from '../url'
+
+describe('safeImageUrl()', () => {
+  it('passes https URLs through', () => {
+    expect(safeImageUrl('https://cdn.example.com/avatar.png')).toBe(
+      'https://cdn.example.com/avatar.png',
+    )
+  })
+
+  it('passes http URLs through', () => {
+    expect(safeImageUrl('http://example.com/a.png')).toBe('http://example.com/a.png')
+  })
+
+  it('passes data:image URLs through', () => {
+    expect(safeImageUrl('data:image/png;base64,iVBORw0KGgo=')).toBe(
+      'data:image/png;base64,iVBORw0KGgo=',
+    )
+  })
+
+  it('returns null for non-image data URLs', () => {
+    // `data:text/html,...` is harmless in an <img>, but rejecting it keeps the
+    // helper safe to reuse in <iframe src> etc.
+    expect(safeImageUrl('data:text/html,<script>alert(1)</script>')).toBeNull()
+  })
+
+  it('returns null for javascript: URLs', () => {
+    expect(safeImageUrl('javascript:alert(1)')).toBeNull()
+  })
+
+  it('returns null for unknown schemes', () => {
+    expect(safeImageUrl('ftp://example.com/a.png')).toBeNull()
+  })
+
+  it('returns null for null/undefined/empty', () => {
+    expect(safeImageUrl(null)).toBeNull()
+    expect(safeImageUrl(undefined)).toBeNull()
+    expect(safeImageUrl('')).toBeNull()
+  })
+
+  it('resolves protocol-relative URLs against the page origin', () => {
+    // `//cdn.example.com/x.png` should be treated as same-protocol, which on
+    // jsdom defaults to http: — so this passes.
+    expect(safeImageUrl('//cdn.example.com/x.png')).toBe('//cdn.example.com/x.png')
+  })
+})

--- a/web/src/lib/__tests__/url.spec.ts
+++ b/web/src/lib/__tests__/url.spec.ts
@@ -19,9 +19,15 @@ describe('safeImageUrl()', () => {
   })
 
   it('returns null for non-image data URLs', () => {
-    // `data:text/html,...` is harmless in an <img>, but rejecting it keeps the
-    // helper safe to reuse in <iframe src> etc.
     expect(safeImageUrl('data:text/html,<script>alert(1)</script>')).toBeNull()
+  })
+
+  it('returns null for SVG data URLs (script-capable)', () => {
+    // SVG can carry inline <script> that executes in <object>/<iframe> contexts.
+    expect(
+      safeImageUrl('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"/>'),
+    ).toBeNull()
+    expect(safeImageUrl('data:image/svg+xml;base64,PHN2Zy8+')).toBeNull()
   })
 
   it('returns null for javascript: URLs', () => {

--- a/web/src/lib/url.ts
+++ b/web/src/lib/url.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns `url` if it's a safe `<img src>` candidate, else `null`.
+ *
+ * Server validates avatar URLs on `PATCH /me` today, but the frontend should
+ * never bind a `javascript:` or unknown-scheme URL into an `<img>` regardless
+ * of where it came from — defence in depth against a future server bug or a
+ * compromised OAuth provider response.
+ */
+export function safeImageUrl(url: string | null | undefined): string | null {
+  if (!url) return null
+  try {
+    const parsed = new URL(url, window.location.origin)
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') return url
+    // Allow only image data URLs — `data:text/html,...` is harmless inside <img> but
+    // would be dangerous if this helper ever gets reused for <iframe src> etc.
+    if (parsed.protocol === 'data:' && /^data:image\//i.test(url)) return url
+    return null
+  } catch {
+    return null
+  }
+}

--- a/web/src/lib/url.ts
+++ b/web/src/lib/url.ts
@@ -11,9 +11,16 @@ export function safeImageUrl(url: string | null | undefined): string | null {
   try {
     const parsed = new URL(url, window.location.origin)
     if (parsed.protocol === 'https:' || parsed.protocol === 'http:') return url
-    // Allow only image data URLs — `data:text/html,...` is harmless inside <img> but
-    // would be dangerous if this helper ever gets reused for <iframe src> etc.
-    if (parsed.protocol === 'data:' && /^data:image\//i.test(url)) return url
+    // Allow image data URLs but reject SVG explicitly — SVG can carry inline
+    // <script> that executes in <object>/<iframe> contexts (and historically in
+    // some <img> contexts via foreignObject). `data:text/html,...` would also
+    // be dangerous outside <img>; rejecting both keeps this helper safe to
+    // reuse anywhere a URL is bound to a media-loading element.
+    if (parsed.protocol === 'data:') {
+      const isImage = /^data:image\//i.test(url)
+      const isSvg = /^data:image\/svg\b/i.test(url)
+      if (isImage && !isSvg) return url
+    }
     return null
   } catch {
     return null

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -27,37 +27,45 @@ const toastText = ref('')
 const videoEl = useTemplateRef<HTMLVideoElement>('videoEl')
 let player: Plyr | null = null
 
+// Monotonic request counter — guards against A→B→A races where comparing
+// `clipId.value === id` would falsely accept the first A response after the
+// second A request supersedes it.
+let latestLoadId = 0
+
 const clipId = computed(() => {
   const id = route.params.id
   return Array.isArray(id) ? id[0] : id
 })
 
+async function loadClip(id: string) {
+  const myLoadId = ++latestLoadId
+  loading.value = true
+  errored.value = false
+  clip.value = null
+  teardownPlayer()
+  try {
+    const detail = await clips.getDetail(id)
+    if (myLoadId !== latestLoadId) return
+    clip.value = detail
+    liked.value = detail.likedByMe
+    likeCount.value = detail.likeCount
+  } catch (err) {
+    if (myLoadId !== latestLoadId) return
+    if (err instanceof ApiError && err.status === 404) {
+      router.replace({ name: 'not-found' })
+      return
+    }
+    errored.value = true
+  } finally {
+    if (myLoadId === latestLoadId) loading.value = false
+  }
+}
+
 watch(
   clipId,
-  async (id) => {
+  (id) => {
     if (!id) return
-    loading.value = true
-    errored.value = false
-    clip.value = null
-    teardownPlayer()
-    try {
-      const detail = await clips.getDetail(id)
-      // Bail if the user navigated to a different clip while we were loading;
-      // applying this response would corrupt the new clip's state.
-      if (clipId.value !== id) return
-      clip.value = detail
-      liked.value = detail.likedByMe
-      likeCount.value = detail.likeCount
-    } catch (err) {
-      if (clipId.value !== id) return
-      if (err instanceof ApiError && err.status === 404) {
-        router.replace({ name: 'not-found' })
-        return
-      }
-      errored.value = true
-    } finally {
-      if (clipId.value === id) loading.value = false
-    }
+    loadClip(id)
   },
   { immediate: true },
 )
@@ -84,8 +92,6 @@ function teardownPlayer() {
   }
 }
 
-onBeforeUnmount(teardownPlayer)
-
 let toastTimer: ReturnType<typeof setTimeout> | null = null
 function fireToast(text: string) {
   toastText.value = text
@@ -95,6 +101,11 @@ function fireToast(text: string) {
     showToast.value = false
   }, 2400)
 }
+
+onBeforeUnmount(() => {
+  teardownPlayer()
+  if (toastTimer !== null) clearTimeout(toastTimer)
+})
 
 async function toggleLike() {
   if (!clip.value || likeBusy.value) return
@@ -162,6 +173,9 @@ const authorColor = computed(() => {
   for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0
   return `hsl(${Math.abs(hash) % 360}, 65%, 45%)`
 })
+
+// Hoisted so the template doesn't re-parse the URL on every render.
+const authorAvatarUrl = computed(() => safeImageUrl(clip.value?.author.avatarUrl))
 </script>
 
 <template>
@@ -178,7 +192,7 @@ const authorColor = computed(() => {
       </span>
       <button
         class="cursor-pointer rounded-sm border border-border bg-surface-raised px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
-        @click="router.go(0)"
+        @click="clipId && loadClip(clipId)"
       >
         Retry
       </button>
@@ -217,8 +231,8 @@ const authorColor = computed(() => {
               }"
             >
               <img
-                v-if="safeImageUrl(clip.author.avatarUrl)"
-                :src="safeImageUrl(clip.author.avatarUrl) ?? ''"
+                v-if="authorAvatarUrl"
+                :src="authorAvatarUrl"
                 :alt="clip.author.username"
                 class="h-full w-full object-cover"
               />

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, useTemplateRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Plyr from 'plyr'
 import 'plyr/dist/plyr.css'
 import { ApiError } from '@/api/client'
 import { clips, type ClipDetail } from '@/api/clips'
 import { useAuthStore } from '@/stores/auth'
+import { safeImageUrl } from '@/lib/url'
 import IconHeart from '@/components/icons/IconHeart.vue'
-import IconBookmark from '@/components/icons/IconBookmark.vue'
 import IconShare from '@/components/icons/IconShare.vue'
 import IconMoreVertical from '@/components/icons/IconMoreVertical.vue'
 
@@ -163,10 +163,6 @@ const authorColor = computed(() => {
   return `hsl(${Math.abs(hash) % 360}, 65%, 45%)`
 })
 
-onMounted(() => {
-  // ensure auth is bootstrapped so likedByMe reflects the current session
-  auth.bootstrap().catch(() => {})
-})
 </script>
 
 <template>
@@ -222,8 +218,8 @@ onMounted(() => {
               }"
             >
               <img
-                v-if="clip.author.avatarUrl"
-                :src="clip.author.avatarUrl"
+                v-if="safeImageUrl(clip.author.avatarUrl)"
+                :src="safeImageUrl(clip.author.avatarUrl) ?? ''"
                 :alt="clip.author.username"
                 class="h-full w-full object-cover"
               />
@@ -257,15 +253,6 @@ onMounted(() => {
             >
               <IconHeart :size="14" />
               <span>{{ formatNum(likeCount) }}</span>
-            </button>
-
-            <button
-              class="flex items-center gap-1.5 rounded border border-border bg-surface-raised px-3 py-1.5 font-mono text-[12px] text-text-secondary transition-all duration-150"
-              disabled
-              title="Coming soon"
-            >
-              <IconBookmark :size="14" />
-              <span>Save</span>
             </button>
 
             <button

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -162,7 +162,6 @@ const authorColor = computed(() => {
   for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0
   return `hsl(${Math.abs(hash) % 360}, 65%, 45%)`
 })
-
 </script>
 
 <template>

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -1,80 +1,88 @@
 <script setup lang="ts">
-import { ref, computed, watch, watchEffect, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { CLIPS, USERS, GAMES, COMMENTS, formatNum, formatDuration, clipById } from '@/lib/mock-data'
-import UserAvatar from '@/components/UserAvatar.vue'
-import IconPlay from '@/components/icons/IconPlay.vue'
-import IconPause from '@/components/icons/IconPause.vue'
+import Plyr from 'plyr'
+import 'plyr/dist/plyr.css'
+import { ApiError } from '@/api/client'
+import { clips, type ClipDetail } from '@/api/clips'
+import { useAuthStore } from '@/stores/auth'
 import IconHeart from '@/components/icons/IconHeart.vue'
 import IconBookmark from '@/components/icons/IconBookmark.vue'
 import IconShare from '@/components/icons/IconShare.vue'
 import IconMoreVertical from '@/components/icons/IconMoreVertical.vue'
-import IconVerifiedBadge from '@/components/icons/IconVerifiedBadge.vue'
-import IconVolume from '@/components/icons/IconVolume.vue'
-import IconFullscreen from '@/components/icons/IconFullscreen.vue'
 
 const route = useRoute()
 const router = useRouter()
+const auth = useAuthStore()
+
+const clip = ref<ClipDetail | null>(null)
+const loading = ref(false)
+const errored = ref(false)
+const liked = ref(false)
+const likeCount = ref(0)
+const likeBusy = ref(false)
+const showToast = ref(false)
+const toastText = ref('')
+
+const videoEl = useTemplateRef<HTMLVideoElement>('videoEl')
+let player: Plyr | null = null
 
 const clipId = computed(() => {
   const id = route.params.id
   return Array.isArray(id) ? id[0] : id
 })
 
-const resolvedClip = computed(() => (clipId.value ? clipById(clipId.value) : undefined))
-
-watchEffect(() => {
-  // Surface unknown clip ids as a real 404 instead of silently falling back to CLIPS[0]
-  if (clipId.value && resolvedClip.value === undefined) {
-    router.replace({ name: 'not-found' })
-  }
-})
-
-// Fallback to CLIPS[0] keeps the template safe during the brief tick before the redirect lands
-const clip = computed(() => resolvedClip.value ?? CLIPS[0])
-const game = computed(() => GAMES[clip.value.game])
-const user = computed(() => USERS[clip.value.user])
-
-const relatedClips = computed(() =>
-  CLIPS.filter((c) => c.game === clip.value.game && c.id !== clip.value.id).slice(0, 6),
+watch(
+  clipId,
+  async (id) => {
+    if (!id) return
+    loading.value = true
+    errored.value = false
+    clip.value = null
+    teardownPlayer()
+    try {
+      const detail = await clips.getDetail(id)
+      clip.value = detail
+      liked.value = detail.likedByMe
+      likeCount.value = detail.likeCount
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        router.replace({ name: 'not-found' })
+        return
+      }
+      errored.value = true
+    } finally {
+      loading.value = false
+    }
+  },
+  { immediate: true },
 )
 
-// --- State ---
-const liked = ref(false)
-const likeCount = ref(clip.value.likes)
-const playing = ref(true)
-const progress = ref(0.32)
-const following = ref(false)
-const showToast = ref(false)
-const toastText = ref('')
-const comment = ref('')
+// Mount Plyr on the <video> element after both the element and the clip data exist.
+// We watch both — Vue may render the <video> before the API resolves, or vice versa.
+watch(
+  [clip, videoEl],
+  ([detail, el]) => {
+    if (!detail || !el || player) return
+    el.src = detail.videoUrl
+    player = new Plyr(el, {
+      controls: ['play-large', 'play', 'progress', 'current-time', 'mute', 'volume', 'fullscreen'],
+      tooltips: { controls: true, seek: true },
+    })
+  },
+  { flush: 'post' },
+)
 
-// Reset state when clip changes
-watch(clip, (newClip) => {
-  liked.value = false
-  likeCount.value = newClip.likes
-  progress.value = 0.32
-  playing.value = true
-})
+function teardownPlayer() {
+  if (player) {
+    player.destroy()
+    player = null
+  }
+}
 
-// Simulate progress
-let intervalId: ReturnType<typeof setInterval> | null = null
+onBeforeUnmount(teardownPlayer)
 
-onMounted(() => {
-  intervalId = setInterval(() => {
-    if (playing.value) {
-      progress.value = progress.value >= 1 ? 0 : progress.value + 0.003
-    }
-  }, 100)
-})
-
-onUnmounted(() => {
-  if (intervalId !== null) clearInterval(intervalId)
-})
-
-// --- Actions ---
 let toastTimer: ReturnType<typeof setTimeout> | null = null
-
 function fireToast(text: string) {
   toastText.value = text
   showToast.value = true
@@ -84,432 +92,217 @@ function fireToast(text: string) {
   }, 2400)
 }
 
-function toggleLike() {
-  liked.value = !liked.value
-  likeCount.value = liked.value ? likeCount.value + 1 : likeCount.value - 1
-  if (liked.value) fireToast('♥ Added to your liked clips')
+async function toggleLike() {
+  if (!clip.value || likeBusy.value) return
+  if (!auth.isAuthenticated) {
+    router.push({ name: 'login', query: { redirect: route.fullPath } })
+    return
+  }
+  // Optimistic UI: flip locally first, roll back on error so a flaky network doesn't strand
+  // the user on a wrong-looking counter.
+  const wasLiked = liked.value
+  liked.value = !wasLiked
+  likeCount.value += wasLiked ? -1 : 1
+  likeBusy.value = true
+  try {
+    const res = wasLiked ? await clips.unlike(clip.value.id) : await clips.like(clip.value.id)
+    liked.value = res.liked
+    likeCount.value = res.likeCount
+    if (res.liked) fireToast('♥ Added to your liked clips')
+  } catch {
+    liked.value = wasLiked
+    likeCount.value += wasLiked ? 1 : -1
+    fireToast('Could not update like — try again')
+  } finally {
+    likeBusy.value = false
+  }
 }
 
-function toggleFollow() {
-  following.value = !following.value
-  fireToast(
-    following.value ? `Following @${user.value.username}` : `Unfollowed @${user.value.username}`,
-  )
+async function handleShare() {
+  try {
+    await navigator.clipboard.writeText(window.location.href)
+    fireToast('🔗 Link copied to clipboard')
+  } catch {
+    fireToast('Copy failed')
+  }
 }
 
-function handleShare() {
-  fireToast('🔗 Link copied to clipboard')
+function formatNum(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K'
+  return String(n)
 }
 
-function togglePlay() {
-  playing.value = !playing.value
+function timeAgo(iso: string): string {
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000
+  if (diff < 60) return `${Math.floor(diff)}s`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`
+  return `${Math.floor(diff / 86400)}d`
 }
 
-function seek(e: MouseEvent) {
-  const bar = e.currentTarget as HTMLElement
-  const rect = bar.getBoundingClientRect()
-  progress.value = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
-}
+const initialsFor = (username: string): string =>
+  username
+    .replace(/[^a-zA-Z]/g, '')
+    .slice(0, 2)
+    .toUpperCase() || '??'
 
-function postComment() {
-  if (!comment.value.trim()) return
-  comment.value = ''
-}
+const authorColor = computed(() => {
+  const name = clip.value?.author.username ?? ''
+  let hash = 0
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0
+  return `hsl(${Math.abs(hash) % 360}, 65%, 45%)`
+})
 
-const currentTime = computed(() => {
-  const total = clip.value.duration
-  const elapsed = Math.floor(progress.value * total)
-  const m = Math.floor(elapsed / 60)
-  const s = elapsed % 60
-  return `${m}:${String(s).padStart(2, '0')}`
+onMounted(() => {
+  // ensure auth is bootstrapped so likedByMe reflects the current session
+  auth.bootstrap().catch(() => {})
 })
 </script>
 
 <template>
   <div class="mx-auto max-w-350 px-6 pt-8 pb-30">
-    <div class="grid grid-cols-1 items-start gap-7 min-[961px]:grid-cols-[minmax(0,1fr)_340px]">
-      <!-- LEFT COLUMN -->
-      <div>
-        <!-- Breadcrumb -->
-        <div
-          class="mb-5 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.08em] text-text-muted"
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-30">
+      <span class="font-mono text-sm uppercase tracking-widest text-text-muted">Loading…</span>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="errored" class="flex flex-col items-center justify-center gap-3 py-30">
+      <span class="font-mono text-sm uppercase tracking-widest text-text-muted">
+        Couldn't load this clip.
+      </span>
+      <button
+        class="cursor-pointer rounded-sm border border-border bg-surface-raised px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="router.go(0)"
+      >
+        Retry
+      </button>
+    </div>
+
+    <div v-else-if="clip">
+      <!-- Breadcrumb -->
+      <div
+        class="mb-5 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.08em] text-text-muted"
+      >
+        <router-link to="/" class="transition-colors hover:text-text-secondary">Feed</router-link>
+        <span>/</span>
+        <span>{{ clip.id.slice(0, 8) }}</span>
+      </div>
+
+      <!-- Video Player -->
+      <div class="overflow-hidden rounded-md border border-border bg-black">
+        <video ref="videoEl" controls playsinline class="block aspect-video w-full"></video>
+      </div>
+
+      <!-- Title + Meta Row -->
+      <div class="mt-5">
+        <h1
+          class="font-heading text-[34px] font-bold leading-[1.05] uppercase tracking-[0.01em] text-text-primary"
         >
-          <router-link to="/" class="transition-colors hover:text-text-secondary">Feed</router-link>
-          <span>/</span>
-          <span class="text-brand-light">{{ game.name }}</span>
-          <span>/</span>
-          <span>{{ clip.id }}</span>
-        </div>
+          {{ clip.title }}
+        </h1>
 
-        <!-- Video Player -->
-        <div class="relative aspect-video overflow-hidden rounded-md border border-border bg-black">
-          <!-- Thumbnail -->
-          <img
-            :src="clip.art"
-            alt="clip thumbnail"
-            class="absolute inset-0 h-full w-full object-cover opacity-85"
-          />
-
-          <!-- Top HUD -->
-          <div
-            class="absolute top-0 right-0 left-0 flex items-center justify-between bg-[linear-gradient(to_bottom,rgba(0,0,0,0.7),transparent)] px-4 py-3"
-          >
-            <div class="flex items-center gap-2">
-              <span
-                class="rounded bg-brand px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.12em]"
-                >{{ game.tag }}</span
+        <div class="mt-4 flex flex-wrap items-center gap-3">
+          <!-- Author info -->
+          <div class="flex items-center gap-2">
+            <span
+              class="inline-flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full font-mono text-xs font-semibold text-white"
+              :style="{
+                background: `linear-gradient(135deg, ${authorColor}, color-mix(in oklab, ${authorColor} 40%, #000))`,
+              }"
+            >
+              <img
+                v-if="clip.author.avatarUrl"
+                :src="clip.author.avatarUrl"
+                :alt="clip.author.username"
+                class="h-full w-full object-cover"
+              />
+              <span v-else>{{ initialsFor(clip.author.username) }}</span>
+            </span>
+            <div>
+              <router-link
+                :to="`/user/${clip.author.username}`"
+                class="font-mono text-[13px] font-semibold text-neon transition-opacity hover:opacity-80"
+                >@{{ clip.author.username }}</router-link
               >
-              <span class="font-mono text-[11px] tracking-[0.06em] text-white/55">{{
-                clip.id
-              }}</span>
+              <div class="font-mono text-[10px] tracking-[0.04em] text-text-muted">
+                Uploaded {{ timeAgo(clip.createdAt) }} ago
+              </div>
             </div>
+          </div>
+
+          <div class="flex-1" />
+
+          <!-- Action buttons -->
+          <div class="flex items-center gap-2">
             <button
-              class="flex h-7 w-7 items-center justify-center rounded text-white/70 transition-colors hover:bg-white/10"
+              class="flex items-center gap-1.5 rounded px-3 py-1.5 font-mono text-[12px] transition-all duration-150 disabled:opacity-60"
+              :class="
+                liked
+                  ? 'bg-brand text-white'
+                  : 'border border-border bg-surface-raised text-text-secondary'
+              "
+              :disabled="likeBusy"
+              @click="toggleLike"
+            >
+              <IconHeart :size="14" />
+              <span>{{ formatNum(likeCount) }}</span>
+            </button>
+
+            <button
+              class="flex items-center gap-1.5 rounded border border-border bg-surface-raised px-3 py-1.5 font-mono text-[12px] text-text-secondary transition-all duration-150"
+              disabled
+              title="Coming soon"
+            >
+              <IconBookmark :size="14" />
+              <span>Save</span>
+            </button>
+
+            <button
+              class="flex items-center gap-1.5 rounded border border-border bg-surface-raised px-3 py-1.5 font-mono text-[12px] text-text-secondary transition-all duration-150"
+              @click="handleShare"
+            >
+              <IconShare :size="14" />
+              <span>Share</span>
+            </button>
+
+            <button
+              class="flex h-7 w-7 items-center justify-center rounded text-text-secondary transition-colors hover:bg-surface-raised"
+              aria-label="More"
             >
               <IconMoreVertical :size="16" />
             </button>
           </div>
-
-          <!-- Center Play/Pause -->
-          <button
-            class="group absolute inset-0 flex items-center justify-center"
-            @click="togglePlay"
-          >
-            <div
-              class="flex h-16 w-16 items-center justify-center rounded-full border-2 border-white/25 bg-black/55 text-white backdrop-blur-xs transition-all duration-150 group-hover:scale-110"
-            >
-              <IconPlay v-if="!playing" :size="24" />
-              <IconPause v-else :size="24" />
-            </div>
-          </button>
-
-          <!-- Bottom Controls -->
-          <div
-            class="absolute right-0 bottom-0 left-0 bg-[linear-gradient(to_top,rgba(0,0,0,0.8),transparent)] px-4 pt-6 pb-3"
-          >
-            <!-- Progress bar -->
-            <div class="relative mb-3 h-1 cursor-pointer rounded-sm bg-white/15" @click="seek">
-              <div
-                class="absolute top-0 left-0 h-full rounded bg-brand-light"
-                :style="{ width: `${progress * 100}%` }"
-              />
-              <!-- Scrubber dot -->
-              <div
-                class="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-brand-light shadow-[0_0_6px_var(--color-brand-glow)]"
-                :style="{ left: `${progress * 100}%` }"
-              />
-            </div>
-
-            <div class="flex items-center gap-3">
-              <!-- Play/Pause mini -->
-              <button
-                class="text-white transition-colors hover:text-text-secondary"
-                @click="togglePlay"
-              >
-                <IconPlay v-if="!playing" :size="18" />
-                <IconPause v-else :size="18" />
-              </button>
-
-              <!-- Volume -->
-              <button
-                class="text-white transition-colors hover:text-text-secondary"
-                aria-label="Volume"
-              >
-                <IconVolume :size="18" />
-              </button>
-
-              <!-- Time -->
-              <span class="font-mono text-[11px] text-white/70">
-                {{ currentTime }} / {{ formatDuration(clip.duration) }}
-              </span>
-
-              <div class="flex-1" />
-
-              <!-- Speed badge -->
-              <span
-                class="rounded bg-white/12 px-1.5 py-0.5 font-mono text-[10px] tracking-wider text-white/70"
-                >1x</span
-              >
-
-              <!-- Fullscreen -->
-              <button
-                class="text-white transition-colors hover:text-text-secondary"
-                aria-label="Fullscreen"
-              >
-                <IconFullscreen :size="18" />
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Title + Meta Row -->
-        <div class="mt-5">
-          <h1
-            class="font-heading text-[34px] font-bold leading-[1.05] uppercase tracking-[0.01em] text-text-primary"
-          >
-            {{ clip.title }}
-          </h1>
-
-          <div class="mt-4 flex flex-wrap items-center gap-3">
-            <!-- User info -->
-            <div class="flex items-center gap-2">
-              <UserAvatar :user="clip.user" :size="36" />
-              <div>
-                <div class="flex items-center gap-1.5">
-                  <router-link
-                    :to="`/user/${user.username}`"
-                    class="font-mono text-[13px] font-semibold text-neon transition-opacity hover:opacity-80"
-                    >@{{ user.username }}</router-link
-                  >
-                  <IconVerifiedBadge v-if="user.verified" :size="14" />
-                </div>
-                <div class="font-mono text-[10px] tracking-[0.04em] text-text-muted">
-                  {{ formatNum(user.followers) }} followers · {{ user.clips }} clips
-                </div>
-              </div>
-            </div>
-
-            <!-- Follow button -->
-            <button
-              class="rounded px-4 py-1.5 font-mono text-[12px] font-semibold tracking-[0.04em] transition-all duration-150"
-              :class="
-                following
-                  ? 'border border-border-strong bg-transparent text-text-secondary'
-                  : 'border border-transparent bg-brand text-white'
-              "
-              @click="toggleFollow"
-            >
-              {{ following ? 'Following' : 'Follow' }}
-            </button>
-
-            <div class="flex-1" />
-
-            <!-- Action buttons right side -->
-            <div class="flex items-center gap-2">
-              <!-- Like -->
-              <button
-                class="flex items-center gap-1.5 rounded px-3 py-1.5 font-mono text-[12px] transition-all duration-150"
-                :class="
-                  liked
-                    ? 'bg-brand text-white'
-                    : 'border border-border bg-surface-raised text-text-secondary'
-                "
-                @click="toggleLike"
-              >
-                <IconHeart :size="14" />
-                <span>{{ formatNum(likeCount) }}</span>
-              </button>
-
-              <!-- Save -->
-              <button
-                class="flex items-center gap-1.5 rounded border border-border bg-surface-raised px-3 py-1.5 font-mono text-[12px] text-text-secondary transition-all duration-150"
-              >
-                <IconBookmark :size="14" />
-                <span>Save</span>
-              </button>
-
-              <!-- Share -->
-              <button
-                class="flex items-center gap-1.5 rounded border border-border bg-surface-raised px-3 py-1.5 font-mono text-[12px] text-text-secondary transition-all duration-150"
-                @click="handleShare"
-              >
-                <IconShare :size="14" />
-                <span>Share</span>
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Stat Block -->
-        <div class="mt-6 grid grid-cols-4 gap-px overflow-hidden rounded-md bg-border">
-          <div
-            v-for="stat in [
-              { label: 'Plays', value: formatNum(clip.views) },
-              { label: 'Likes', value: formatNum(likeCount) },
-              { label: 'Uploaded', value: clip.createdAt + ' ago' },
-              { label: 'Visibility', value: 'Public' },
-            ]"
-            :key="stat.label"
-            class="flex flex-col gap-1 bg-surface-raised px-4 py-3"
-          >
-            <span class="font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted">{{
-              stat.label
-            }}</span>
-            <span class="font-heading text-xl font-bold leading-[1.2] text-text-primary">{{
-              stat.value
-            }}</span>
-          </div>
-        </div>
-
-        <!-- Description Box -->
-        <div class="mt-4 rounded-md border border-border bg-surface-raised p-4">
-          <div class="mb-2 font-mono text-[10px] uppercase tracking-widest text-text-muted">
-            Description
-          </div>
-          <p class="mb-3 text-sm leading-[1.6] text-text-secondary">
-            {{ clip.title }}. Ranked match, prime time lobby. Everything was on the line. Check the
-            timestamp at peak action — the rotation read was insane.
-          </p>
-          <div class="flex flex-wrap gap-2">
-            <span
-              v-for="tag in [game.tag, '#clutch', '#ranked', '#highlights']"
-              :key="tag"
-              class="rounded border border-border bg-surface-overlay px-2 py-0.5 font-mono text-[11px] tracking-wider text-text-muted"
-              >#{{ tag.replace('#', '') }}</span
-            >
-          </div>
-        </div>
-
-        <!-- Comments (Chat) -->
-        <div class="mt-8">
-          <!-- Section title with brand bar -->
-          <div class="section-title-bar mb-5 flex items-center gap-3">
-            <span
-              class="font-heading text-lg font-bold uppercase tracking-[0.04em] text-text-primary"
-              >Chat</span
-            >
-            <span
-              class="rounded-full border border-border bg-surface-raised px-2 py-0.5 font-mono text-[11px] text-text-muted"
-              >{{ COMMENTS.length }}</span
-            >
-          </div>
-
-          <!-- Comment Input -->
-          <div class="mb-6 flex items-start gap-3">
-            <UserAvatar user="phantomveil" :size="32" />
-            <div class="flex flex-1 gap-2">
-              <input
-                v-model="comment"
-                type="text"
-                placeholder="Drop a comment..."
-                class="flex-1 rounded-md border border-border bg-surface-raised px-3 py-2 font-body text-sm text-text-primary outline-none transition-colors focus:border-border-strong"
-              />
-              <button
-                class="rounded-md px-4 py-2 text-sm font-semibold transition-all duration-150"
-                :class="
-                  comment.trim()
-                    ? 'bg-brand text-white opacity-100'
-                    : 'cursor-not-allowed border border-border bg-surface-raised text-text-muted opacity-60'
-                "
-                :disabled="!comment.trim()"
-                @click="postComment"
-              >
-                Post
-              </button>
-            </div>
-          </div>
-
-          <!-- Comment List -->
-          <div class="flex flex-col gap-5">
-            <div v-for="(c, i) in COMMENTS" :key="i" class="flex items-start gap-3">
-              <UserAvatar
-                :user="Object.keys(USERS).find((k) => USERS[k].username === c.user) ?? c.user"
-                :size="32"
-              />
-              <div class="flex-1">
-                <div class="mb-1 flex items-center gap-2">
-                  <span class="font-mono text-[12px] font-semibold text-neon">@{{ c.user }}</span>
-                  <span class="font-mono text-[11px] text-text-muted">{{ c.time }}</span>
-                </div>
-                <p class="mb-2 text-sm leading-normal text-text-secondary">
-                  {{ c.text }}
-                </p>
-                <div class="flex items-center gap-3">
-                  <button
-                    class="flex items-center gap-1 font-mono text-[11px] text-text-muted transition-colors hover:text-text-secondary"
-                  >
-                    <IconHeart :size="12" />
-                    {{ c.likes }}
-                  </button>
-                  <button
-                    class="font-mono text-[11px] text-text-muted transition-colors hover:text-text-secondary"
-                  >
-                    Reply
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
 
-      <!-- RIGHT RAIL (sidebar) -->
-      <div class="flex flex-col gap-6">
-        <!-- Up Next Panel -->
-        <div class="overflow-hidden rounded-md border border-border bg-surface-raised">
-          <div class="border-b border-border px-4 py-3">
-            <div class="flex items-center gap-2">
-              <span
-                class="inline-block h-1.75 w-1.75 rounded-full bg-neon animate-[pulse_2s_ease-in-out_infinite]"
-              />
-              <span class="font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted">
-                Up Next · Auto-playing in 00:04
-              </span>
-            </div>
-          </div>
-
-          <!-- Preview of next clip -->
-          <div v-if="relatedClips[0]" class="flex items-start gap-3 p-3">
-            <img
-              :src="relatedClips[0].art"
-              alt="next clip"
-              class="h-17 w-30 shrink-0 rounded object-cover"
-            />
-            <div class="min-w-0 flex-1">
-              <p
-                class="mb-1 line-clamp-2 font-body text-sm font-semibold leading-[1.35] text-text-primary"
-              >
-                {{ relatedClips[0].title }}
-              </p>
-              <router-link
-                :to="`/user/${USERS[relatedClips[0].user].username}`"
-                class="font-mono text-[11px] text-neon transition-opacity hover:opacity-80"
-                >@{{ USERS[relatedClips[0].user].username }}</router-link
-              >
-              <div class="mt-0.5 font-mono text-[11px] text-text-muted">
-                {{ formatNum(relatedClips[0].views) }} plays
-              </div>
-            </div>
-          </div>
+      <!-- Stat Block -->
+      <div class="mt-6 grid grid-cols-3 gap-px overflow-hidden rounded-md bg-border">
+        <div
+          v-for="stat in [
+            { label: 'Plays', value: formatNum(clip.viewCount) },
+            { label: 'Likes', value: formatNum(likeCount) },
+            { label: 'Uploaded', value: timeAgo(clip.createdAt) + ' ago' },
+          ]"
+          :key="stat.label"
+          class="flex flex-col gap-1 bg-surface-raised px-4 py-3"
+        >
+          <span class="font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted">{{
+            stat.label
+          }}</span>
+          <span class="font-heading text-xl font-bold leading-[1.2] text-text-primary">{{
+            stat.value
+          }}</span>
         </div>
+      </div>
 
-        <!-- More from [game] -->
-        <div>
-          <div class="section-title-bar mb-4 flex items-center gap-3">
-            <span
-              class="font-mono text-[14px] font-semibold uppercase tracking-[0.06em] text-text-primary"
-              >More from {{ game.name }}</span
-            >
-          </div>
-
-          <div class="flex flex-col gap-1">
-            <router-link
-              v-for="related in relatedClips.slice(1, 6)"
-              :key="related.id"
-              :to="`/clip/${related.id}`"
-              class="flex cursor-pointer items-start gap-3 rounded-md p-2 text-inherit no-underline transition-colors hover:bg-surface-raised"
-            >
-              <img
-                :src="related.art"
-                alt="related clip"
-                class="h-15.5 w-27.5 shrink-0 rounded object-cover"
-              />
-              <div class="min-w-0 flex-1">
-                <p
-                  class="mb-1 line-clamp-2 font-body text-[13px] font-semibold leading-[1.35] text-text-primary"
-                >
-                  {{ related.title }}
-                </p>
-                <span class="font-mono text-[11px] text-neon"
-                  >@{{ USERS[related.user].username }}</span
-                >
-                <div class="mt-0.5 font-mono text-[11px] text-text-muted">
-                  {{ formatNum(related.views) }} plays
-                </div>
-              </div>
-            </router-link>
-          </div>
+      <!-- Description -->
+      <div v-if="clip.description" class="mt-4 rounded-md border border-border bg-surface-raised p-4">
+        <div class="mb-2 font-mono text-[10px] uppercase tracking-widest text-text-muted">
+          Description
         </div>
+        <p class="text-sm leading-[1.6] text-text-secondary">{{ clip.description }}</p>
       </div>
     </div>
   </div>

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -298,7 +298,10 @@ onMounted(() => {
       </div>
 
       <!-- Description -->
-      <div v-if="clip.description" class="mt-4 rounded-md border border-border bg-surface-raised p-4">
+      <div
+        v-if="clip.description"
+        class="mt-4 rounded-md border border-border bg-surface-raised p-4"
+      >
         <div class="mb-2 font-mono text-[10px] uppercase tracking-widest text-text-muted">
           Description
         </div>

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -42,17 +42,21 @@ watch(
     teardownPlayer()
     try {
       const detail = await clips.getDetail(id)
+      // Bail if the user navigated to a different clip while we were loading;
+      // applying this response would corrupt the new clip's state.
+      if (clipId.value !== id) return
       clip.value = detail
       liked.value = detail.likedByMe
       likeCount.value = detail.likeCount
     } catch (err) {
+      if (clipId.value !== id) return
       if (err instanceof ApiError && err.status === 404) {
         router.replace({ name: 'not-found' })
         return
       }
       errored.value = true
     } finally {
-      loading.value = false
+      if (clipId.value === id) loading.value = false
     }
   },
   { immediate: true },
@@ -100,16 +104,21 @@ async function toggleLike() {
   }
   // Optimistic UI: flip locally first, roll back on error so a flaky network doesn't strand
   // the user on a wrong-looking counter.
+  const targetId = clip.value.id
   const wasLiked = liked.value
   liked.value = !wasLiked
   likeCount.value += wasLiked ? -1 : 1
   likeBusy.value = true
   try {
-    const res = wasLiked ? await clips.unlike(clip.value.id) : await clips.like(clip.value.id)
+    const res = wasLiked ? await clips.unlike(targetId) : await clips.like(targetId)
+    // If the user navigated to a different clip while the request was in flight,
+    // skip the apply so we don't stamp this clip's count onto the next one.
+    if (clip.value?.id !== targetId) return
     liked.value = res.liked
     likeCount.value = res.likeCount
     if (res.liked) fireToast('♥ Added to your liked clips')
   } catch {
+    if (clip.value?.id !== targetId) return
     liked.value = wasLiked
     likeCount.value += wasLiked ? 1 : -1
     fireToast('Could not update like — try again')

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -13,7 +13,12 @@ import IconLink from '@/components/icons/IconLink.vue'
 
 const router = useRouter()
 
-const MAX_UPLOAD_MB = Number(import.meta.env.VITE_MAX_UPLOAD_SIZE_MB ?? 500)
+// Guard against a missing/garbage env value: Number('foo') is NaN, and `f.size > NaN`
+// is always false — silently disabling the size cap. Fall back to a safe default instead.
+const MAX_UPLOAD_MB = (() => {
+  const parsed = Number(String(import.meta.env.VITE_MAX_UPLOAD_SIZE_MB ?? '').trim())
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 500
+})()
 const MAX_UPLOAD_BYTES = MAX_UPLOAD_MB * 1024 * 1024
 
 type Step = 1 | 2 | 3
@@ -134,6 +139,17 @@ const checklistDone = computed(() => ({
   upload: stage.value === 'completing' || stage.value === 'done',
   complete: stage.value === 'done',
 }))
+
+function goBackToDetails() {
+  // Drop the half-created clip id so the next attempt creates a fresh draft instead
+  // of re-using the failed one. The orphaned draft row is cleaned up server-side
+  // by the future scheduled-sweep job (Phase 2 maintenance).
+  stage.value = 'idle'
+  step.value = 2
+  createdClipId.value = null
+  uploadPct.value = 0
+  errorMsg.value = null
+}
 
 const STEPS = [
   { num: '1', label: 'Select file' },
@@ -443,7 +459,7 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
           {{ errorMsg }}
           <button
             class="mt-2 block cursor-pointer rounded-sm border border-border bg-surface-raised px-3 py-1.5 text-text-primary"
-            @click="((stage = 'idle'), (step = 2))"
+            @click="goBackToDetails"
           >
             Back to details
           </button>

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref, onUnmounted } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { GAMES } from '@/lib/mock-data'
-import UserAvatar from '@/components/UserAvatar.vue'
+import { ApiError } from '@/api/client'
+import { clips } from '@/api/clips'
 import IconUploadCloud from '@/components/icons/IconUploadCloud.vue'
 import IconFile from '@/components/icons/IconFile.vue'
 import IconFileText from '@/components/icons/IconFileText.vue'
@@ -13,66 +13,52 @@ import IconLink from '@/components/icons/IconLink.vue'
 
 const router = useRouter()
 
-// State
-const step = ref<1 | 2 | 3>(1)
-const file = ref<{ name: string; size: number; type: string } | null>(null)
+const MAX_UPLOAD_MB = Number(import.meta.env.VITE_MAX_UPLOAD_SIZE_MB ?? 500)
+const MAX_UPLOAD_BYTES = MAX_UPLOAD_MB * 1024 * 1024
+
+type Step = 1 | 2 | 3
+const step = ref<Step>(1)
+const file = ref<File | null>(null)
 const title = ref('')
 const desc = ref('')
-const game = ref('valorant')
 const visibility = ref<'public' | 'unlisted'>('public')
-const progress = ref(0)
 const dragging = ref(false)
 
-// Upload simulation
-let uploadInterval: ReturnType<typeof setInterval> | null = null
-// TODO: replace with the real created clip id once the upload API is wired
+// Upload state — granular so the checklist can light up step-by-step.
+type UploadStage = 'idle' | 'creating' | 'uploading' | 'completing' | 'done' | 'error'
+const stage = ref<UploadStage>('idle')
+const uploadPct = ref(0)
+const errorMsg = ref<string | null>(null)
 const createdClipId = ref<string | null>(null)
-
-// Checklist completion thresholds keyed to the simulated upload progress
-const CHECKLIST_THRESHOLDS = [30, 80, 100] as const
-
-function startUpload() {
-  if (uploadInterval) {
-    clearInterval(uploadInterval)
-    uploadInterval = null
-  }
-  step.value = 3
-  progress.value = 0
-  uploadInterval = setInterval(() => {
-    const increment = 5 + Math.random() * 5
-    progress.value = Math.min(100, progress.value + increment)
-    if (progress.value >= 100) {
-      if (uploadInterval) {
-        clearInterval(uploadInterval)
-        uploadInterval = null
-      }
-      // Mock: stand-in for the API-returned id; real wiring happens in #11/#12/#13/#14
-      createdClipId.value = 'clp_04'
-    }
-  }, 180)
-}
+let activeXhr: XMLHttpRequest | null = null
 
 onUnmounted(() => {
-  if (uploadInterval) clearInterval(uploadInterval)
+  if (activeXhr) activeXhr.abort()
 })
 
-// File handling
+function pickFile(f: File | null) {
+  if (!f) return
+  if (!f.type.startsWith('video/')) {
+    errorMsg.value = `Unsupported file type "${f.type || 'unknown'}" — pick a video.`
+    return
+  }
+  if (f.size > MAX_UPLOAD_BYTES) {
+    errorMsg.value = `File is ${formatSize(f.size)} — limit is ${MAX_UPLOAD_MB} MB.`
+    return
+  }
+  errorMsg.value = null
+  file.value = f
+}
+
 function handleFileSelect(e: Event) {
   const input = e.target as HTMLInputElement
-  if (input.files?.[0]) {
-    const f = input.files[0]
-    file.value = { name: f.name, size: f.size, type: f.type }
-  }
-  // Reset so picking the same file again still fires `change`
+  pickFile(input.files?.[0] ?? null)
   if (e.target instanceof HTMLInputElement) e.target.value = ''
 }
 
 function handleDrop(e: DragEvent) {
   dragging.value = false
-  const dropped = e.dataTransfer?.files?.[0]
-  if (dropped) {
-    file.value = { name: dropped.name, size: dropped.size, type: dropped.type }
-  }
+  pickFile(e.dataTransfer?.files?.[0] ?? null)
 }
 
 function formatSize(bytes: number): string {
@@ -81,19 +67,80 @@ function formatSize(bytes: number): string {
   return (bytes / 1024).toFixed(1) + ' KB'
 }
 
+function putWithProgress(url: string, body: File): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    activeXhr = xhr
+    xhr.open('PUT', url)
+    if (body.type) xhr.setRequestHeader('Content-Type', body.type)
+    xhr.upload.onprogress = (ev) => {
+      if (ev.lengthComputable) uploadPct.value = (ev.loaded / ev.total) * 100
+    }
+    xhr.onload = () => {
+      activeXhr = null
+      if (xhr.status >= 200 && xhr.status < 300) resolve()
+      else reject(new Error(`PUT failed: ${xhr.status}`))
+    }
+    xhr.onerror = () => {
+      activeXhr = null
+      reject(new Error('PUT network error'))
+    }
+    xhr.onabort = () => {
+      activeXhr = null
+      reject(new Error('PUT aborted'))
+    }
+    xhr.send(body)
+  })
+}
+
+async function startUpload() {
+  if (!file.value || !title.value.trim()) return
+  step.value = 3
+  stage.value = 'creating'
+  uploadPct.value = 0
+  errorMsg.value = null
+  try {
+    const created = await clips.create({
+      title: title.value.trim(),
+      description: desc.value.trim() || null,
+      gameId: null,
+      visibility: visibility.value,
+    })
+    createdClipId.value = created.id
+
+    stage.value = 'uploading'
+    const presigned = await clips.getUploadUrl(created.id)
+    await putWithProgress(presigned.url, file.value)
+
+    stage.value = 'completing'
+    await clips.complete(created.id)
+
+    stage.value = 'done'
+    uploadPct.value = 100
+  } catch (err) {
+    stage.value = 'error'
+    if (err instanceof ApiError) {
+      errorMsg.value = `Server error (${err.status}). Please try again.`
+    } else if (err instanceof Error) {
+      errorMsg.value = err.message
+    } else {
+      errorMsg.value = 'Upload failed.'
+    }
+  }
+}
+
+const checklistDone = computed(() => ({
+  create: stage.value !== 'idle' && stage.value !== 'creating',
+  upload: stage.value === 'completing' || stage.value === 'done',
+  complete: stage.value === 'done',
+}))
+
 const STEPS = [
   { num: '1', label: 'Select file' },
   { num: '2', label: 'Describe' },
   { num: '3', label: 'Upload' },
 ]
-
 const SOURCES = ['OBS', 'ShadowPlay', 'Medal', 'Xbox', 'PS5', 'Switch']
-
-const GAME_KEYS = Object.keys(GAMES)
-
-function checklistDone(index: number): boolean {
-  return progress.value >= (CHECKLIST_THRESHOLDS[index] ?? 100)
-}
 
 const inputClass =
   'w-full rounded-md border border-border bg-surface-raised px-3.5 py-3 font-body text-sm text-text-primary outline-none'
@@ -142,7 +189,6 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
 
     <!-- Step 1: File picker -->
     <div v-if="step === 1">
-      <!-- Drop zone -->
       <div
         @dragover.prevent="dragging = true"
         @dragleave.prevent="dragging = false"
@@ -152,7 +198,6 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
           dragging ? 'border-brand-light bg-brand-glow' : 'border-border-strong bg-transparent',
         ]"
       >
-        <!-- Upload icon circle -->
         <div
           class="flex h-16 w-16 items-center justify-center rounded-full border border-border-strong bg-surface-overlay text-brand-light"
         >
@@ -163,19 +208,19 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
           <div class="mb-1.5 font-heading text-[22px] font-bold uppercase text-text-primary">
             Drop your clip here
           </div>
-          <div class="font-body text-sm text-text-secondary">MP4, MOV, WebM — up to 4 GB</div>
+          <div class="font-body text-sm text-text-secondary">
+            MP4 or video — up to {{ MAX_UPLOAD_MB }} MB
+          </div>
         </div>
 
-        <!-- Choose file button -->
         <label
-          class="inline-flex cursor-pointer items-center gap-2 rounded-md bg-brand px-5.5 py-2.5 font-heading text-sm font-bold uppercase tracking-wider text-white transition-[background] duration-150"
+          class="inline-flex cursor-pointer items-center gap-2 rounded-md bg-brand px-5.5 py-2.5 font-heading text-sm font-bold uppercase tracking-wider text-white"
         >
           <IconFile :size="16" />
           Choose file
           <input type="file" accept="video/*" class="sr-only" @change="handleFileSelect" />
         </label>
 
-        <!-- Source badges -->
         <div class="mt-2 flex flex-wrap justify-center gap-2">
           <span
             v-for="src in SOURCES"
@@ -187,7 +232,13 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
         </div>
       </div>
 
-      <!-- File confirmation row -->
+      <p
+        v-if="errorMsg"
+        class="mt-4 rounded-md border border-brand bg-surface-overlay px-4 py-2 font-mono text-[12px] text-brand-light"
+      >
+        {{ errorMsg }}
+      </p>
+
       <div
         v-if="file"
         class="mt-5 flex items-center gap-4 rounded-md border border-neon bg-neon-dim px-5 py-4 text-neon"
@@ -216,9 +267,7 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
     <!-- Step 2: Metadata -->
     <div v-else-if="step === 2">
       <div class="grid gap-8 grid-cols-1 min-[761px]:grid-cols-[1fr_320px]">
-        <!-- Left: form -->
         <div class="flex flex-col gap-6">
-          <!-- Title -->
           <div>
             <div class="mb-1.5 flex items-baseline justify-between">
               <label :class="labelClass + ' mb-0'">Title</label>
@@ -232,27 +281,6 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
             />
           </div>
 
-          <!-- Game picker -->
-          <div>
-            <label :class="labelClass">Game</label>
-            <div class="flex flex-wrap gap-2">
-              <button
-                v-for="key in GAME_KEYS"
-                :key="key"
-                @click="game = key"
-                :class="[
-                  'cursor-pointer rounded-md border px-3.5 py-2 font-heading text-[13px] font-bold uppercase tracking-[0.04em] transition-all duration-150',
-                  game === key
-                    ? 'border-brand-light bg-brand text-white'
-                    : 'border-border bg-surface-raised text-text-secondary',
-                ]"
-              >
-                {{ GAMES[key].tag }}
-              </button>
-            </div>
-          </div>
-
-          <!-- Description -->
           <div>
             <div class="mb-1.5 flex items-baseline justify-between">
               <label :class="labelClass + ' mb-0'"
@@ -269,7 +297,6 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
             ></textarea>
           </div>
 
-          <!-- Visibility -->
           <div>
             <label :class="labelClass">Visibility</label>
             <div class="grid grid-cols-2 gap-2.5">
@@ -298,7 +325,6 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
             </div>
           </div>
 
-          <!-- Action buttons -->
           <div class="flex gap-3 pt-2">
             <button
               @click="step = 1"
@@ -323,25 +349,15 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
           </div>
         </div>
 
-        <!-- Right: preview card -->
         <div>
           <label :class="labelClass + ' mb-3'">Preview</label>
           <div class="overflow-hidden rounded-md border border-border bg-surface-raised">
-            <!-- Thumbnail -->
             <div class="relative aspect-video bg-surface-sunken">
-              <img
-                v-if="GAMES[game]?.art"
-                :src="GAMES[game].art"
-                :alt="GAMES[game].name"
-                class="h-full w-full object-cover"
-              />
-              <!-- Game tag -->
               <div
-                class="absolute top-2 left-2 rounded-sm bg-brand px-2 py-0.75 font-mono text-[10px] uppercase tracking-[0.08em] text-white"
+                class="absolute inset-0 flex items-center justify-center font-mono text-[10px] uppercase tracking-widest text-text-muted"
               >
-                {{ GAMES[game]?.tag }}
+                {{ file?.name ?? 'No file' }}
               </div>
-              <!-- Visibility badge -->
               <div
                 class="absolute top-2 right-2 rounded-sm bg-black/60 px-2 py-0.75 font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted"
               >
@@ -350,7 +366,6 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
             </div>
 
             <div class="p-3.5">
-              <!-- Title -->
               <div
                 :class="[
                   'mb-2.5 font-heading text-[15px] font-bold leading-[1.3]',
@@ -358,26 +373,6 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
                 ]"
               >
                 {{ title.trim() || 'Your clip title will appear here' }}
-              </div>
-
-              <!-- User row -->
-              <div class="flex items-center gap-2">
-                <UserAvatar user="phantomveil" :size="24" />
-                <span class="font-mono text-[11px] text-text-secondary"> @phantomveil </span>
-              </div>
-            </div>
-
-            <!-- Share URL preview -->
-            <div
-              class="mx-3.5 mb-3.5 rounded-sm border border-dashed border-border-strong px-3 py-2.5"
-            >
-              <div class="mb-1 font-mono text-[9px] uppercase tracking-[0.08em] text-text-muted">
-                Share URL preview
-              </div>
-              <div
-                class="overflow-hidden font-mono text-[11px] whitespace-nowrap text-ellipsis text-brand-light"
-              >
-                ganked.tv/clip/clp_new
               </div>
             </div>
           </div>
@@ -388,56 +383,46 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
     <!-- Step 3: Upload progress -->
     <div v-else-if="step === 3">
       <div class="mx-auto max-w-140">
-        <!-- Clip summary -->
         <div
           class="mb-8 flex gap-0 overflow-hidden rounded-md border border-border bg-surface-raised"
         >
-          <!-- Thumbnail -->
-          <div class="relative w-35 shrink-0">
-            <img
-              :src="GAMES[game]?.art"
-              :alt="GAMES[game]?.name"
-              class="block h-full w-full object-cover"
-            />
-          </div>
           <div class="min-w-0 flex-1 p-4">
-            <div class="mb-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-neon">
-              {{ GAMES[game]?.tag }}
-            </div>
             <div class="mb-2 font-heading text-base font-bold leading-[1.3] text-text-primary">
               {{ title }}
             </div>
             <div class="font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted">
-              {{ visibility }}
+              {{ visibility }} · {{ file ? formatSize(file.size) : '' }}
             </div>
           </div>
         </div>
 
-        <!-- Progress bar -->
         <div class="mb-2 flex items-baseline justify-between">
           <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-text-muted">
-            Uploading
+            {{ stage === 'uploading' ? 'Uploading' : stage === 'done' ? 'Done' : 'Preparing' }}
           </span>
-          <span class="font-mono text-[11px] text-neon"> {{ Math.round(progress) }}% </span>
+          <span class="font-mono text-[11px] text-neon"> {{ Math.round(uploadPct) }}% </span>
         </div>
         <div class="mb-7 h-1.5 w-full overflow-hidden rounded-full bg-surface-overlay">
           <div
             class="h-full rounded-full bg-[linear-gradient(90deg,var(--color-brand),var(--color-brand-light))] transition-[width] duration-180 ease"
-            :style="{ width: progress + '%' }"
+            :style="{ width: uploadPct + '%' }"
           ></div>
         </div>
 
-        <!-- Checklist -->
         <div class="mb-9 flex flex-col gap-3.5">
           <div
-            v-for="(item, i) in ['Create record', 'Upload video', 'Generate thumbnail']"
-            :key="item"
+            v-for="item in [
+              { label: '1. Create record', done: checklistDone.create },
+              { label: '2. Upload video', done: checklistDone.upload },
+              { label: '3. Finalize', done: checklistDone.complete },
+            ]"
+            :key="item.label"
             class="flex items-center gap-3"
           >
             <div
               :class="[
                 'h-2 w-2 shrink-0 rounded-full transition-[background,box-shadow] duration-300',
-                checklistDone(i)
+                item.done
                   ? 'bg-neon shadow-[0_0_8px_var(--color-neon)]'
                   : 'bg-border-strong',
               ]"
@@ -445,16 +430,28 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
             <span
               :class="[
                 'font-mono text-xs uppercase tracking-[0.08em] transition-colors duration-300',
-                checklistDone(i) ? 'text-text-primary' : 'text-text-muted',
+                item.done ? 'text-text-primary' : 'text-text-muted',
               ]"
             >
-              {{ i + 1 }}. {{ item }}
+              {{ item.label }}
             </span>
           </div>
         </div>
 
-        <!-- Done actions -->
-        <div v-if="progress >= 100" class="flex flex-col gap-2.5">
+        <div
+          v-if="stage === 'error'"
+          class="mb-6 rounded-md border border-brand bg-surface-overlay px-4 py-3 font-mono text-[12px] text-brand-light"
+        >
+          {{ errorMsg }}
+          <button
+            class="mt-2 block cursor-pointer rounded-sm border border-border bg-surface-raised px-3 py-1.5 text-text-primary"
+            @click="(stage = 'idle'), (step = 2)"
+          >
+            Back to details
+          </button>
+        </div>
+
+        <div v-if="stage === 'done'" class="flex flex-col gap-2.5">
           <button
             :disabled="!createdClipId"
             @click="createdClipId && router.push(`/clip/${createdClipId}`)"

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -80,13 +80,15 @@ function formatSize(bytes: number): string {
 // but bounded so a fully-stalled connection doesn't spin forever.
 const UPLOAD_TIMEOUT_MS = 10 * 60 * 1000
 
-function putWithProgress(url: string, body: File): Promise<void> {
+function putWithProgress(url: string, body: File, contentType: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
     activeXhr = xhr
     xhr.open('PUT', url)
     xhr.timeout = UPLOAD_TIMEOUT_MS
-    if (body.type) xhr.setRequestHeader('Content-Type', body.type)
+    // Must match the Content-Type the server signed for, NOT the browser-detected
+    // file MIME — S3 includes it in the signature and 403s on mismatch.
+    xhr.setRequestHeader('Content-Type', contentType)
     xhr.upload.onprogress = (ev) => {
       if (ev.lengthComputable) uploadPct.value = (ev.loaded / ev.total) * 100
     }
@@ -128,7 +130,7 @@ async function startUpload() {
 
     stage.value = 'uploading'
     const presigned = await clips.getUploadUrl(created.id)
-    await putWithProgress(presigned.url, file.value)
+    await putWithProgress(presigned.url, file.value, presigned.contentType)
 
     stage.value = 'completing'
     await clips.complete(created.id)
@@ -137,14 +139,28 @@ async function startUpload() {
     uploadPct.value = 100
   } catch (err) {
     stage.value = 'error'
-    if (err instanceof ApiError) {
-      errorMsg.value = `Server error (${err.status}). Please try again.`
-    } else if (err instanceof Error) {
-      errorMsg.value = err.message
-    } else {
-      errorMsg.value = 'Upload failed.'
-    }
+    errorMsg.value = friendlyUploadError(err)
   }
+}
+
+function friendlyUploadError(err: unknown): string {
+  if (err instanceof ApiError) {
+    return `Server error (${err.status}). Please try again.`
+  }
+  if (err instanceof Error) {
+    // Normalize the raw XHR errors from putWithProgress so users see actionable copy
+    // instead of `PUT failed: 403`. Pre-formatted messages (e.g. the timeout) are
+    // already user-friendly and pass through unchanged.
+    const m = err.message
+    if (m.startsWith('PUT failed') || m.startsWith('PUT network error')) {
+      return 'Upload was interrupted. Please try again.'
+    }
+    if (m.startsWith('PUT aborted')) {
+      return 'Upload cancelled.'
+    }
+    return m
+  }
+  return 'Upload failed.'
 }
 
 const checklistDone = computed(() => ({

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -72,11 +72,16 @@ function formatSize(bytes: number): string {
   return (bytes / 1024).toFixed(1) + ' KB'
 }
 
+// Generous ceiling so a 500 MB upload over a slow connection still finishes,
+// but bounded so a fully-stalled connection doesn't spin forever.
+const UPLOAD_TIMEOUT_MS = 10 * 60 * 1000
+
 function putWithProgress(url: string, body: File): Promise<void> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
     activeXhr = xhr
     xhr.open('PUT', url)
+    xhr.timeout = UPLOAD_TIMEOUT_MS
     if (body.type) xhr.setRequestHeader('Content-Type', body.type)
     xhr.upload.onprogress = (ev) => {
       if (ev.lengthComputable) uploadPct.value = (ev.loaded / ev.total) * 100
@@ -93,6 +98,10 @@ function putWithProgress(url: string, body: File): Promise<void> {
     xhr.onabort = () => {
       activeXhr = null
       reject(new Error('PUT aborted'))
+    }
+    xhr.ontimeout = () => {
+      activeXhr = null
+      reject(new Error('Upload timed out — check your connection and try again'))
     }
     xhr.send(body)
   })

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -422,9 +422,7 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
             <div
               :class="[
                 'h-2 w-2 shrink-0 rounded-full transition-[background,box-shadow] duration-300',
-                item.done
-                  ? 'bg-neon shadow-[0_0_8px_var(--color-neon)]'
-                  : 'bg-border-strong',
+                item.done ? 'bg-neon shadow-[0_0_8px_var(--color-neon)]' : 'bg-border-strong',
               ]"
             ></div>
             <span
@@ -445,7 +443,7 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
           {{ errorMsg }}
           <button
             class="mt-2 block cursor-pointer rounded-sm border border-border bg-surface-raised px-3 py-1.5 text-text-primary"
-            @click="(stage = 'idle'), (step = 2)"
+            @click="((stage = 'idle'), (step = 2))"
           >
             Back to details
           </button>

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -44,10 +44,14 @@ onUnmounted(() => {
 function pickFile(f: File | null) {
   if (!f) return
   if (!f.type.startsWith('video/')) {
+    // Clear any prior valid selection — leaving the old file as the "current"
+    // pick alongside an error about a different file is confusing.
+    file.value = null
     errorMsg.value = `Unsupported file type "${f.type || 'unknown'}" — pick a video.`
     return
   }
   if (f.size > MAX_UPLOAD_BYTES) {
+    file.value = null
     errorMsg.value = `File is ${formatSize(f.size)} — limit is ${MAX_UPLOAD_MB} MB.`
     return
   }

--- a/web/src/views/UserView.vue
+++ b/web/src/views/UserView.vue
@@ -1,114 +1,142 @@
 <script setup lang="ts">
-import { ref, computed, watchEffect } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { USERS, CLIPS, GAMES, formatNum, userByUsername } from '@/lib/mock-data'
-import UserAvatar from '@/components/UserAvatar.vue'
-import ClipCard from '@/components/ClipCard.vue'
-import IconVerifiedBadge from '@/components/icons/IconVerifiedBadge.vue'
+import { ApiError } from '@/api/client'
+import { users, type UserProfile } from '@/api/users'
 import IconShare from '@/components/icons/IconShare.vue'
 import IconMoreHorizontal from '@/components/icons/IconMoreHorizontal.vue'
 
 const route = useRoute()
 const router = useRouter()
 
-const resolved = computed(() => userByUsername(route.params.username as string))
+const profile = ref<UserProfile | null>(null)
+const loading = ref(false)
+const errored = ref(false)
 
-watchEffect(() => {
-  // Surface unknown usernames as a real 404 instead of silently rendering a placeholder.
-  if (route.params.username && resolved.value === undefined) {
-    router.replace({ name: 'not-found' })
-  }
+const username = computed(() => {
+  const u = route.params.username
+  return Array.isArray(u) ? u[0] : u
 })
 
-const userKey = computed(() => resolved.value?.[0] ?? '')
-const user = computed(() => resolved.value?.[1])
+watch(
+  username,
+  async (name) => {
+    if (!name) return
+    loading.value = true
+    errored.value = false
+    profile.value = null
+    try {
+      profile.value = await users.getByUsername(name)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        router.replace({ name: 'not-found' })
+        return
+      }
+      errored.value = true
+    } finally {
+      loading.value = false
+    }
+  },
+  { immediate: true },
+)
 
-const bannerGradient = computed(() => {
-  const avatar = user.value?.avatar ?? '#000'
-  return `linear-gradient(135deg, ${avatar}, color-mix(in oklab, ${avatar} 20%, #000))`
+// Derive a stable avatar color from the username so the banner/avatar render
+// even though the API doesn't return one yet (Phase 2 will store user-picked colors).
+const avatarColor = computed(() => {
+  const name = profile.value?.username ?? ''
+  let hash = 0
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0
+  return `hsl(${Math.abs(hash) % 360}, 65%, 45%)`
 })
 
-const avatarGradient = computed(() => {
-  const avatar = user.value?.avatar ?? '#000'
-  return `linear-gradient(135deg, ${avatar}, color-mix(in oklab, ${avatar} 20%, #000))`
-})
+const bannerGradient = computed(
+  () => `linear-gradient(135deg, ${avatarColor.value}, color-mix(in oklab, ${avatarColor.value} 20%, #000))`,
+)
 
-const initials = computed(
-  () =>
-    (user.value?.display ?? '')
+const initials = computed(() => {
+  const name = profile.value?.username ?? ''
+  return (
+    name
       .replace(/[^a-zA-Z]/g, '')
       .slice(0, 2)
-      .toUpperCase() || '??',
-)
-
-const userClips = computed(() => CLIPS.filter((c) => c.user === userKey.value))
-
-// Aggregate stats derived from clips
-const totalPlays = computed(() => userClips.value.reduce((s, c) => s + c.views, 0))
-const totalLikes = computed(() => userClips.value.reduce((s, c) => s + c.likes, 0))
-const avgLikes = computed(() =>
-  userClips.value.length ? Math.round(totalLikes.value / userClips.value.length) : 0,
-)
-
-// Games the user has clips in
-const userGameKeys = computed(() => {
-  const seen = new Set<string>()
-  for (const c of userClips.value) {
-    if (!seen.has(c.game)) seen.add(c.game)
-  }
-  return [...seen].slice(0, 5)
+      .toUpperCase() || '??'
+  )
 })
 
-const gameClipCount = computed(() => {
-  const counts: Record<string, number> = {}
-  for (const c of userClips.value) {
-    counts[c.game] = (counts[c.game] ?? 0) + 1
-  }
-  return counts
+const joinedDate = computed(() => {
+  if (!profile.value) return ''
+  return new Date(profile.value.createdAt).toLocaleString(undefined, {
+    month: 'short',
+    year: 'numeric',
+  })
 })
 
-type Tab = 'clips' | 'liked' | 'about' | 'followers'
+const totalPlays = computed(() =>
+  (profile.value?.clips ?? []).reduce((s, c) => s + c.viewCount, 0),
+)
+const totalLikes = computed(() =>
+  (profile.value?.clips ?? []).reduce((s, c) => s + c.likeCount, 0),
+)
+
+function formatNum(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K'
+  return String(n)
+}
+
+function formatDuration(s: number | null): string {
+  if (s === null) return '–'
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  return `${m}:${String(r).padStart(2, '0')}`
+}
+
+function timeAgo(iso: string): string {
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000
+  if (diff < 60) return `${Math.floor(diff)}s`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`
+  return `${Math.floor(diff / 86400)}d`
+}
+
+function copyShareUrl() {
+  navigator.clipboard?.writeText(window.location.href)
+}
+
+type Tab = 'clips' | 'liked'
 const tab = ref<Tab>('clips')
 
-const following = ref(false)
-
+// Followers/Following/About tabs depend on social-graph endpoints that don't exist yet
+// (Phase 3). Keep just Clips and Liked (Liked is a stub message).
 const TABS: { key: Tab; label: string }[] = [
   { key: 'clips', label: 'Clips' },
   { key: 'liked', label: 'Liked' },
-  { key: 'about', label: 'About' },
-  { key: 'followers', label: 'Followers' },
 ]
-
-const sort = ref('recent')
-
-// Follower cards — other users
-const followerUsers = computed(() =>
-  Object.entries(USERS)
-    .filter(([k]) => k !== userKey.value)
-    .slice(0, 8),
-)
-
-// Local follow toggle state (mock — no API yet)
-const followedUsers = ref(new Set<string>())
-function toggleFollowedUser(key: string) {
-  if (followedUsers.value.has(key)) followedUsers.value.delete(key)
-  else followedUsers.value.add(key)
-  // Force reactivity for Set mutations
-  followedUsers.value = new Set(followedUsers.value)
-}
-
-const joinedDate = 'Jan 2024'
 </script>
 
 <template>
-  <main v-if="user" class="relative">
+  <main v-if="loading" class="flex items-center justify-center py-30">
+    <span class="font-mono text-sm uppercase tracking-widest text-text-muted">Loading…</span>
+  </main>
+
+  <main v-else-if="errored" class="flex flex-col items-center justify-center gap-3 py-30">
+    <span class="font-mono text-sm uppercase tracking-widest text-text-muted">
+      Couldn't load this profile.
+    </span>
+    <button
+      class="cursor-pointer rounded-sm border border-border bg-surface-raised px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+      @click="router.go(0)"
+    >
+      Retry
+    </button>
+  </main>
+
+  <main v-else-if="profile" class="relative">
     <!-- ===================== BANNER ===================== -->
     <div class="relative h-70 overflow-hidden" :style="{ background: bannerGradient }">
-      <!-- Stripe texture -->
       <div
         class="absolute inset-0 bg-[repeating-linear-gradient(45deg,rgba(255,255,255,0.04)_0_12px,transparent_12px_24px)]"
       ></div>
-      <!-- Fade to base at bottom -->
       <div
         class="absolute inset-0 bg-[linear-gradient(0deg,var(--color-surface-base),transparent_60%)]"
       ></div>
@@ -120,7 +148,7 @@ const joinedDate = 'Jan 2024'
             class="flex cursor-pointer items-center gap-1.5 border-none bg-transparent p-0 font-mono text-[11px] uppercase tracking-[0.08em] text-white/55"
             @click="router.push({ name: 'home' })"
           >
-            ← Feed / @{{ user.username }}
+            ← Feed / @{{ profile.username }}
           </button>
         </div>
       </div>
@@ -133,64 +161,53 @@ const joinedDate = 'Jan 2024'
         <!-- Large avatar -->
         <div
           class="flex h-35 w-35 shrink-0 select-none items-center justify-center rounded-full border-4 border-surface-base font-heading text-[56px] font-bold tracking-[-0.02em] text-white"
-          :style="{ background: avatarGradient }"
+          :style="{ background: bannerGradient }"
         >
-          {{ initials }}
+          <img
+            v-if="profile.avatarUrl"
+            :src="profile.avatarUrl"
+            :alt="profile.username"
+            class="h-full w-full rounded-full object-cover"
+          />
+          <span v-else>{{ initials }}</span>
         </div>
 
         <!-- User info -->
         <div class="min-w-55 flex-1 pt-19">
-          <!-- Eyebrow -->
           <div class="mb-1.5 font-mono text-[11px] uppercase tracking-[0.08em] text-text-muted">
-            {{ user.verified ? 'Verified Creator / Player' : 'Player' }} · Joined {{ joinedDate }}
+            Player · Joined {{ joinedDate }}
           </div>
 
-          <!-- Display name + verified badge -->
           <div class="flex flex-wrap items-center gap-2.5">
             <h1
               class="m-0 font-heading text-[44px] font-bold leading-none uppercase tracking-[0.02em] text-text-primary"
             >
-              {{ user.display }}
+              {{ profile.username }}
             </h1>
-            <IconVerifiedBadge v-if="user.verified" :size="22" class="mt-1 shrink-0" />
           </div>
 
-          <!-- Handle -->
           <div class="mt-1.5 font-mono text-sm tracking-[0.04em] text-neon">
-            @{{ user.username }}
+            @{{ profile.username }}
           </div>
 
-          <!-- Bio -->
-          <p class="m-0 mt-2.5 max-w-130 text-sm leading-[1.55] text-text-secondary">
-            Grinding the ranked ladder one clip at a time. Content creator &amp; full-time gamer.
-            Clips, vods, and the occasional tutorial.
+          <p
+            v-if="profile.bio"
+            class="m-0 mt-2.5 max-w-130 text-sm leading-[1.55] text-text-secondary"
+          >
+            {{ profile.bio }}
           </p>
         </div>
 
-        <!-- Action buttons -->
+        <!-- Action buttons (follow + share + more) -->
+        <!-- Follow lives in Phase 3 (social-graph endpoints). Share is best-effort clipboard. -->
         <div class="flex flex-wrap items-center gap-2 pt-19">
-          <!-- Follow / Following -->
-          <button
-            :class="[
-              'cursor-pointer rounded-sm px-5.5 py-2.25 font-mono text-[11px] uppercase tracking-widest transition-all duration-150',
-              following
-                ? 'border border-border-strong bg-transparent text-text-primary'
-                : 'border border-transparent bg-brand text-white',
-            ]"
-            @click="following = !following"
-          >
-            {{ following ? 'Following' : 'Follow' }}
-          </button>
-
-          <!-- Share -->
           <button
             class="flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-border bg-surface-raised text-text-secondary transition-[border-color] duration-150 hover:border-border-hover"
             aria-label="Share profile"
+            @click="copyShareUrl"
           >
             <IconShare :size="14" />
           </button>
-
-          <!-- More -->
           <button
             class="flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-border bg-surface-raised text-text-secondary transition-[border-color] duration-150 hover:border-border-hover"
             aria-label="More options"
@@ -206,12 +223,9 @@ const joinedDate = 'Jan 2024'
       >
         <div
           v-for="stat in [
-            { label: 'Clips', value: formatNum(userClips.length) },
-            { label: 'Followers', value: formatNum(user.followers) },
-            { label: 'Following', value: '284' },
+            { label: 'Clips', value: formatNum(profile.clips.length) },
             { label: 'Total plays', value: formatNum(totalPlays) },
             { label: 'Total likes', value: formatNum(totalLikes) },
-            { label: 'Avg / clip', value: formatNum(avgLikes) },
           ]"
           :key="stat.label"
           class="flex flex-col gap-1 bg-surface-raised px-5 py-4"
@@ -225,37 +239,8 @@ const joinedDate = 'Jan 2024'
         </div>
       </div>
 
-      <!-- ---- Main arsenal ---- -->
-      <div class="mt-5 rounded-md border border-border bg-surface-raised px-5 py-4">
-        <div class="mb-3.5 font-mono text-[10px] uppercase tracking-widest text-text-muted">
-          Main Arsenal
-        </div>
-        <div class="flex flex-wrap gap-2.5">
-          <div
-            v-for="gk in userGameKeys"
-            :key="gk"
-            class="flex items-center gap-2.25 rounded-full border border-border bg-surface-overlay py-1.5 pr-3.5 pl-1.5"
-          >
-            <!-- Game circle thumb -->
-            <div
-              class="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full font-mono text-[9px] font-bold tracking-[0.04em] text-white"
-              :style="{ backgroundImage: `url(${GAMES[gk].art})`, backgroundSize: 'cover' }"
-            ></div>
-            <div class="flex flex-col gap-px leading-none">
-              <span class="font-mono text-[11px] font-medium text-text-primary">{{
-                GAMES[gk].name
-              }}</span>
-              <span class="font-mono text-[10px] text-text-muted"
-                >{{ gameClipCount[gk] }} clips</span
-              >
-            </div>
-          </div>
-        </div>
-      </div>
-
       <!-- ---- Tabs ---- -->
       <div class="mt-9">
-        <!-- Tab bar -->
         <div class="flex items-center border-b border-border">
           <div class="flex flex-1 gap-0">
             <button
@@ -272,109 +257,62 @@ const joinedDate = 'Jan 2024'
               {{ t.label }}
             </button>
           </div>
-
-          <!-- Sort -->
-          <div
-            v-if="tab === 'clips'"
-            class="flex items-center gap-2 pb-2 font-mono text-[11px] uppercase text-text-muted"
-          >
-            <span>Sort:</span>
-            <select
-              v-model="sort"
-              aria-label="Sort clips"
-              class="cursor-pointer rounded-sm border border-border bg-surface-raised px-2.5 py-1.25 font-mono text-[11px] text-text-primary outline-none focus-visible:border-brand focus-visible:ring-1 focus-visible:ring-brand"
-            >
-              <option value="recent">Recent</option>
-              <option value="top">Top</option>
-              <option value="views">Views</option>
-            </select>
-          </div>
         </div>
 
         <!-- Tab content -->
         <div class="mt-6">
           <!-- Clips tab -->
           <div v-if="tab === 'clips'">
-            <div class="feed-grid">
-              <ClipCard
-                v-for="clip in userClips"
+            <div
+              v-if="profile.clips.length === 0"
+              class="flex items-center justify-center py-20"
+            >
+              <p class="font-mono text-[13px] tracking-[0.06em] text-text-muted">
+                No clips yet.
+              </p>
+            </div>
+            <div v-else class="feed-grid">
+              <article
+                v-for="clip in profile.clips"
                 :key="clip.id"
-                :clip="clip"
+                role="button"
+                tabindex="0"
+                :aria-label="clip.title"
+                class="group relative flex cursor-pointer flex-col overflow-hidden rounded-md border border-border bg-surface-raised transition-all duration-200 outline-none hover:-translate-y-0.5 hover:border-brand hover:shadow-[0_14px_40px_-14px_var(--color-brand-glow)] focus-visible:border-brand focus-visible:shadow-[0_14px_40px_-14px_var(--color-brand-glow)]"
                 @click="router.push({ name: 'clip', params: { id: clip.id } })"
-              />
+                @keydown.enter.prevent="router.push({ name: 'clip', params: { id: clip.id } })"
+                @keydown.space.prevent="router.push({ name: 'clip', params: { id: clip.id } })"
+              >
+                <div class="relative aspect-video overflow-hidden bg-surface-sunken">
+                  <div
+                    class="absolute bottom-2 right-2 rounded-[3px] bg-black/75 px-1.75 py-1 font-mono text-[10px] tracking-wider leading-none text-white backdrop-blur-xs"
+                  >
+                    {{ formatDuration(clip.durationSecs) }}
+                  </div>
+                </div>
+                <div class="flex flex-col gap-2 px-3.5 pb-3.5 pt-3">
+                  <h3
+                    class="m-0 line-clamp-2 min-h-[2.7em] font-body text-sm font-medium leading-[1.35] text-text-primary"
+                  >
+                    {{ clip.title }}
+                  </h3>
+                  <div
+                    class="flex gap-2.5 border-t border-dashed border-border pt-1.5 font-mono text-[11px] text-text-muted"
+                  >
+                    <span>♥ {{ formatNum(clip.likeCount) }}</span>
+                    <span>▶ {{ formatNum(clip.viewCount) }}</span>
+                    <span class="ml-auto">{{ timeAgo(clip.createdAt) }} ago</span>
+                  </div>
+                </div>
+              </article>
             </div>
           </div>
 
-          <!-- Liked tab -->
+          <!-- Liked tab — placeholder until /me/liked exists (Phase 3) -->
           <div v-else-if="tab === 'liked'" class="flex items-center justify-center py-20">
             <p class="font-mono text-[13px] tracking-[0.06em] text-text-muted">
               Liked clips are private.
             </p>
-          </div>
-
-          <!-- About tab -->
-          <div v-else-if="tab === 'about'">
-            <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-3">
-              <div
-                v-for="card in [
-                  { label: 'Peak Rank', value: 'Diamond I', icon: '◆' },
-                  { label: 'Preferred Role', value: 'Duelist / Entry', icon: '⚡' },
-                  { label: 'Socials', value: 'twitch · youtube · x', icon: '🔗' },
-                  { label: 'Rig', value: 'RTX 4080 · i9-13900K', icon: '🖥' },
-                  { label: 'Joined', value: joinedDate, icon: '📅' },
-                  { label: 'Region', value: 'NA East', icon: '🌎' },
-                ]"
-                :key="card.label"
-                class="flex flex-col gap-2 rounded-md border border-border bg-surface-raised px-6 py-5"
-              >
-                <div class="text-xl leading-none">{{ card.icon }}</div>
-                <div class="font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted">
-                  {{ card.label }}
-                </div>
-                <div class="font-heading text-lg font-bold leading-[1.2] text-text-primary">
-                  {{ card.value }}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Followers tab -->
-          <div v-else-if="tab === 'followers'">
-            <div class="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-3">
-              <div
-                v-for="[fk, fu] in followerUsers"
-                :key="fk"
-                class="flex flex-col items-center gap-2.5 rounded-md border border-border bg-surface-raised p-5 text-center"
-              >
-                <button
-                  class="cursor-pointer border-none bg-transparent p-0"
-                  :aria-label="`Open ${fu.display}'s profile`"
-                  @click="router.push({ name: 'user', params: { username: fu.username } })"
-                >
-                  <UserAvatar :user="fk" :size="52" />
-                </button>
-                <div class="flex flex-col gap-0.75">
-                  <button
-                    class="cursor-pointer border-none bg-transparent p-0 font-heading text-base font-bold uppercase tracking-[0.04em] text-text-primary"
-                    @click="router.push({ name: 'user', params: { username: fu.username } })"
-                  >
-                    {{ fu.display }}
-                  </button>
-                  <span class="font-mono text-[11px] text-neon">@{{ fu.username }}</span>
-                </div>
-                <button
-                  class="mt-1 cursor-pointer rounded-sm border-none px-4.5 py-1.5 font-mono text-[10px] uppercase tracking-widest transition-colors duration-150"
-                  :class="
-                    followedUsers.has(fk)
-                      ? 'border border-border-strong bg-transparent text-text-primary'
-                      : 'bg-brand text-white hover:bg-brand-light'
-                  "
-                  @click="toggleFollowedUser(fk)"
-                >
-                  {{ followedUsers.has(fk) ? 'Following' : 'Follow' }}
-                </button>
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/web/src/views/UserView.vue
+++ b/web/src/views/UserView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ApiError } from '@/api/client'
 import { users, type UserProfile } from '@/api/users'
@@ -19,28 +19,36 @@ const username = computed(() => {
   return Array.isArray(u) ? u[0] : u
 })
 
+// Monotonic counter — guards A→B→A races where comparing `username.value === name`
+// would falsely accept the first A response after the second A request supersedes it.
+let latestLoadId = 0
+
+async function loadProfile(name: string) {
+  const myLoadId = ++latestLoadId
+  loading.value = true
+  errored.value = false
+  profile.value = null
+  try {
+    const result = await users.getByUsername(name)
+    if (myLoadId !== latestLoadId) return
+    profile.value = result
+  } catch (err) {
+    if (myLoadId !== latestLoadId) return
+    if (err instanceof ApiError && err.status === 404) {
+      router.replace({ name: 'not-found' })
+      return
+    }
+    errored.value = true
+  } finally {
+    if (myLoadId === latestLoadId) loading.value = false
+  }
+}
+
 watch(
   username,
-  async (name) => {
+  (name) => {
     if (!name) return
-    loading.value = true
-    errored.value = false
-    profile.value = null
-    try {
-      const result = await users.getByUsername(name)
-      // Bail if the user navigated to a different profile mid-request.
-      if (username.value !== name) return
-      profile.value = result
-    } catch (err) {
-      if (username.value !== name) return
-      if (err instanceof ApiError && err.status === 404) {
-        router.replace({ name: 'not-found' })
-        return
-      }
-      errored.value = true
-    } finally {
-      if (username.value === name) loading.value = false
-    }
+    loadProfile(name)
   },
   { immediate: true },
 )
@@ -61,13 +69,19 @@ const bannerGradient = computed(
 
 const initials = computed(() => {
   const name = profile.value?.username ?? ''
-  return (
-    name
-      .replace(/[^a-zA-Z]/g, '')
-      .slice(0, 2)
-      .toUpperCase() || '??'
-  )
+  // Unicode-aware: keep letters/digits across scripts (Cyrillic, CJK, Hangul,
+  // emoji-as-letter, etc.) and split on grapheme clusters so accented letters
+  // and multi-codepoint glyphs count as one. The old `[^a-zA-Z]` strip would
+  // hand a Korean or Cyrillic username an unhelpful `??` fallback.
+  const letters = Array.from(name.normalize('NFC'))
+    .filter((c) => /\p{L}|\p{N}/u.test(c))
+    .slice(0, 2)
+    .join('')
+  return letters.toUpperCase() || '??'
 })
+
+// Hoisted so the template doesn't re-parse the URL on every render.
+const avatarImageUrl = computed(() => safeImageUrl(profile.value?.avatarUrl))
 
 const joinedDate = computed(() => {
   if (!profile.value) return ''
@@ -121,6 +135,10 @@ async function copyShareUrl() {
   }, 1800)
 }
 
+onBeforeUnmount(() => {
+  if (copyTimer !== null) clearTimeout(copyTimer)
+})
+
 type Tab = 'clips' | 'liked'
 const tab = ref<Tab>('clips')
 
@@ -143,7 +161,7 @@ const TABS: { key: Tab; label: string }[] = [
     </span>
     <button
       class="cursor-pointer rounded-sm border border-border bg-surface-raised px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
-      @click="router.go(0)"
+      @click="username && loadProfile(username)"
     >
       Retry
     </button>
@@ -182,8 +200,8 @@ const TABS: { key: Tab; label: string }[] = [
           :style="{ background: bannerGradient }"
         >
           <img
-            v-if="safeImageUrl(profile.avatarUrl)"
-            :src="safeImageUrl(profile.avatarUrl) ?? ''"
+            v-if="avatarImageUrl"
+            :src="avatarImageUrl"
             :alt="profile.username"
             class="h-full w-full rounded-full object-cover"
           />

--- a/web/src/views/UserView.vue
+++ b/web/src/views/UserView.vue
@@ -26,15 +26,19 @@ watch(
     errored.value = false
     profile.value = null
     try {
-      profile.value = await users.getByUsername(name)
+      const result = await users.getByUsername(name)
+      // Bail if the user navigated to a different profile mid-request.
+      if (username.value !== name) return
+      profile.value = result
     } catch (err) {
+      if (username.value !== name) return
       if (err instanceof ApiError && err.status === 404) {
         router.replace({ name: 'not-found' })
         return
       }
       errored.value = true
     } finally {
-      loading.value = false
+      if (username.value === name) loading.value = false
     }
   },
   { immediate: true },
@@ -96,8 +100,24 @@ function timeAgo(iso: string): string {
   return `${Math.floor(diff / 86400)}d`
 }
 
-function copyShareUrl() {
-  navigator.clipboard?.writeText(window.location.href)
+const copyMessage = ref<string | null>(null)
+let copyTimer: ReturnType<typeof setTimeout> | null = null
+
+async function copyShareUrl() {
+  if (!navigator.clipboard) {
+    copyMessage.value = 'Copy not supported'
+  } else {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      copyMessage.value = 'Link copied'
+    } catch {
+      copyMessage.value = 'Copy failed'
+    }
+  }
+  if (copyTimer !== null) clearTimeout(copyTimer)
+  copyTimer = setTimeout(() => {
+    copyMessage.value = null
+  }, 1800)
 }
 
 type Tab = 'clips' | 'liked'
@@ -211,6 +231,13 @@ const TABS: { key: Tab; label: string }[] = [
           >
             <IconMoreHorizontal :size="14" />
           </button>
+          <span
+            v-if="copyMessage"
+            aria-live="polite"
+            class="font-mono text-[11px] uppercase tracking-widest text-neon"
+          >
+            {{ copyMessage }}
+          </span>
         </div>
       </div>
 

--- a/web/src/views/UserView.vue
+++ b/web/src/views/UserView.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ApiError } from '@/api/client'
 import { users, type UserProfile } from '@/api/users'
+import { safeImageUrl } from '@/lib/url'
 import IconShare from '@/components/icons/IconShare.vue'
 import IconMoreHorizontal from '@/components/icons/IconMoreHorizontal.vue'
 
@@ -181,8 +182,8 @@ const TABS: { key: Tab; label: string }[] = [
           :style="{ background: bannerGradient }"
         >
           <img
-            v-if="profile.avatarUrl"
-            :src="profile.avatarUrl"
+            v-if="safeImageUrl(profile.avatarUrl)"
+            :src="safeImageUrl(profile.avatarUrl) ?? ''"
             :alt="profile.username"
             class="h-full w-full rounded-full object-cover"
           />

--- a/web/src/views/UserView.vue
+++ b/web/src/views/UserView.vue
@@ -50,7 +50,8 @@ const avatarColor = computed(() => {
 })
 
 const bannerGradient = computed(
-  () => `linear-gradient(135deg, ${avatarColor.value}, color-mix(in oklab, ${avatarColor.value} 20%, #000))`,
+  () =>
+    `linear-gradient(135deg, ${avatarColor.value}, color-mix(in oklab, ${avatarColor.value} 20%, #000))`,
 )
 
 const initials = computed(() => {
@@ -71,12 +72,8 @@ const joinedDate = computed(() => {
   })
 })
 
-const totalPlays = computed(() =>
-  (profile.value?.clips ?? []).reduce((s, c) => s + c.viewCount, 0),
-)
-const totalLikes = computed(() =>
-  (profile.value?.clips ?? []).reduce((s, c) => s + c.likeCount, 0),
-)
+const totalPlays = computed(() => (profile.value?.clips ?? []).reduce((s, c) => s + c.viewCount, 0))
+const totalLikes = computed(() => (profile.value?.clips ?? []).reduce((s, c) => s + c.likeCount, 0))
 
 function formatNum(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
@@ -263,13 +260,8 @@ const TABS: { key: Tab; label: string }[] = [
         <div class="mt-6">
           <!-- Clips tab -->
           <div v-if="tab === 'clips'">
-            <div
-              v-if="profile.clips.length === 0"
-              class="flex items-center justify-center py-20"
-            >
-              <p class="font-mono text-[13px] tracking-[0.06em] text-text-muted">
-                No clips yet.
-              </p>
+            <div v-if="profile.clips.length === 0" class="flex items-center justify-center py-20">
+              <p class="font-mono text-[13px] tracking-[0.06em] text-text-muted">No clips yet.</p>
             </div>
             <div v-else class="feed-grid">
               <article

--- a/web/src/views/UserView.vue
+++ b/web/src/views/UserView.vue
@@ -193,7 +193,9 @@ const TABS: { key: Tab; label: string }[] = [
     <!-- ===================== INNER CONTENT ===================== -->
     <div class="mx-auto max-w-7xl px-6 pb-30">
       <!-- ---- Profile header ---- -->
-      <div class="-mt-17.5 flex flex-wrap items-start gap-7">
+      <!-- relative + z-10 lifts the avatar above the banner's fade overlay so the
+           negative-margin overlap actually paints on top instead of behind. -->
+      <div class="relative z-10 -mt-17.5 flex flex-wrap items-start gap-7">
         <!-- Large avatar -->
         <div
           class="flex h-35 w-35 shrink-0 select-none items-center justify-center rounded-full border-4 border-surface-base font-heading text-[56px] font-bold tracking-[-0.02em] text-white"


### PR DESCRIPTION
## Summary

Wires the three remaining Phase 1 views — clip detail, upload, and user profile — to the live API. The v1 design from #46 shipped beautiful UI shells against `mock-data.ts`; this PR replaces the mocks with real `clips` and `users` API calls, drops in Plyr for video playback, and switches the upload page to the real 3-step presigned-URL flow with `XMLHttpRequest` upload progress. Picked up a few server-side fixes along the way (S3 key namespacing, presign Content-Type bug, dev port alignment).

## What's here

**Web — wiring**

- New `web/src/api/clips.ts` (`getDetail`, `create`, `getUploadUrl`, `complete`, `like`, `unlike`) and `web/src/api/users.ts` (`getByUsername`), reusing the existing `apiFetch` wrapper. TDD'd; both modules at 100% line/branch/function coverage.
- `ClipView.vue`: Plyr-mounted `<video>` from the presigned URL on `ClipDetailResponse`; like/unlike with optimistic UI + rollback; monotonic-counter stale-response guard on the watcher and on `toggleLike`; loading / error / 404 states. Comments and Up-Next/Related panels removed (Phase 3).
- `UploadView.vue`: real `POST /clips` → `POST /clips/{id}/upload-url` → `PUT` to MinIO via `XMLHttpRequest` (real progress from `xhr.upload.onprogress`, 10 min timeout, abort on unmount) → `POST /clips/{id}/complete` → redirect to the new clip. Client-side MIME + size validation (with NaN-safe env parse for the size cap); per-stage checklist; friendly error mapping for raw XHR failures; `goBackToDetails()` clears the orphaned draft id so retries create a fresh clip.
- `UserView.vue`: fetches `/users/{username}`, renders `clips[]` as an inline grid; monotonic-counter race guard; aria-live feedback on the share-link copy; Unicode-aware initials (`\p{L}\|\p{N}` + grapheme split — Cyrillic / CJK / Hangul usernames now render real initials). Followers / Following / About tabs hidden (Phase 3).

**Web — security & infra**

- New `web/src/lib/url.ts` `safeImageUrl()` helper guarding `<img :src>` bindings against `javascript:`, non-image data URLs, and SVG data URLs (script-capable). Used in both ClipView and UserView avatar bindings.
- `plyr@^3.8.4` added; minimal Plyr `.d.ts` shim in `env.d.ts` because the upstream typings mix `export =` and `export default`, which trips our `verbatimModuleSyntax: true`.
- `web/src/api/client.ts` widened `body` type from `BodyInit` to `BodyInit | object | null` (runtime already JSON-stringified plain objects — type was just lying).
- Pre-push hook now auto-formats (write mode) instead of just verifying; aborts with a clear "commit and push again" message if the formatter touched anything. Skips `bun install` when no manifest changed.

**Server — fixes caught while QA-ing**

- `ClipUploadService.VideoKey` now namespaced by user: `clips/{userId}/{clipId}.mp4` (was `clips/{clipId}.mp4`). Existing rows keep working — keys are stored per-clip.
- `UploadUrlResponse` now exposes the signed `contentType`. The client previously sent `body.type` (browser-detected MIME) while the server signed for `video/mp4`, so any non-mp4 upload would have hit a 403 SignatureDoesNotMatch from MinIO. Client now sends exactly the type the server signed for.
- `launchSettings.json` port aligned to `5000` (was the .NET template default `5293`) so the documented API URL in [CLAUDE.md](CLAUDE.md) and the web client's default base URL actually match.
- `<UserSecretsId>` added to `GankedTV.Api.csproj` to support local `dotnet user-secrets` for `JWT_SECRET` etc. (The GUID is just a folder identifier — secrets live in `~/.microsoft/usersecrets/<id>/`, never committed.)

Closes #12
Closes #13
Closes #14

## How to test manually

```bash
make up                                                 # PostgreSQL + MinIO
cd server
dotnet user-secrets set "Jwt:Secret" "$(openssl rand -hex 32)" --project src/GankedTV.Api
dotnet ef database update --project src/GankedTV.Api    # first time only
make server                                             # API on :5000
cd ../web && bun dev                                    # Web on :5173
```

Skip OAuth via `/dev/token`:

```bash
curl -sX POST http://localhost:5000/dev/token -H 'Content-Type: application/json' \
  -d '{"username":"thijs"}' | tee /tmp/dev-token.json
TOKEN=$(jq -r .token /tmp/dev-token.json)
REFRESH=$(jq -r .refresh /tmp/dev-token.json)
echo "http://localhost:5173/auth/callback?token=$TOKEN&refresh=$REFRESH&returnTo=/"
```

Open that URL → you're authenticated. Then:

1. `/upload` → drop a small MP4 → real progress bar climbs under XHR → land on `/clip/:id`.
2. Plyr plays the clip; tap the heart → counter increments → reload → like state survives.
3. Click `@username` → see the just-uploaded clip on `/user/<username>` (avatar overlaps the banner).
4. Hit a bad ID like `/clip/00000000-0000-0000-0000-000000000000` → 404 view.
5. Verify in MinIO ([http://localhost:9001](http://localhost:9001) / `minioadmin` / `minioadmin`) that the blob landed at `clips/{your-userId}/{clipId}.mp4`.

CI checks (all green locally):
- `bun run lint:check && bun run type-check && bun run test:coverage && bun run build` — **82/82 web tests, 94.3% line coverage**
- `dotnet test server` — **286/286 server tests**

## Known trade-offs / follow-ups

- **Orphaned draft clips on upload failure** (#54). If `PUT` succeeds but `complete()` fails, the S3 blob is uploaded but the clip stays as `draft`; "Back to details" clears the id and the next attempt creates a fresh one. Server-side sweep job tracked separately.
- **`HomeView` / `TrendingView` / `GamesView` still on `mock-data.ts`** (#55). Regression introduced by #46.
- **No game picker on upload** (#56). Every clip uploads with `gameId: null` until the `/games` endpoint and selector land. The MinIO key layout will gain a `{game-slug}` segment at the same time.
- **No video thumbnails** (#57). FFmpeg background job tracked.

## Checklist

- [x] Manually verified upload → playback → like → profile end-to-end against local infra
- [x] CodeRabbit review feedback applied (race conditions, NaN guard, Unicode initials, SVG rejection, timer cleanup, Content-Type signature, friendly error mapping)
- [x] Security review — no high/medium findings introduced by this PR
