### PR TITLE
[server] Sweep orphaned draft clips + uploaded blobs

### DIFF
--- a/server/src/GankedTV.Api/Auth/Tokens/RefreshTokenService.cs
+++ b/server/src/GankedTV.Api/Auth/Tokens/RefreshTokenService.cs
@@ -3,6 +3,7 @@ using System.Text;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace GankedTV.Api.Auth.Tokens;
@@ -11,17 +12,27 @@ public sealed class RefreshTokenService : IRefreshTokenService
 {
     private const int TokenBytes = 32;
 
+    // Treat "token revoked within the last N seconds" as a concurrent legit rotation rather than
+    // a replay. Without this, two browser tabs racing to refresh would trip family revocation:
+    // the winner revokes the row, the loser's lookup sees RevokedAt set, and the loser would
+    // (wrongly) revoke the freshly-issued successor. A real replay typically arrives many
+    // seconds-to-hours after the original was rotated.
+    private static readonly TimeSpan ReplayGrace = TimeSpan.FromSeconds(30);
+
     private readonly GankedTvDbContext _db;
     private readonly TimeProvider _clock;
+    private readonly ILogger<RefreshTokenService> _logger;
     private readonly TimeSpan _ttl;
 
     public RefreshTokenService(
         GankedTvDbContext db,
         IOptions<RefreshTokenOptions> options,
+        ILogger<RefreshTokenService>? logger = null,
         TimeProvider? clock = null)
     {
         _db = db;
         _clock = clock ?? TimeProvider.System;
+        _logger = logger ?? NullLogger<RefreshTokenService>.Instance;
         _ttl = TimeSpan.FromDays(options.Value.ExpiryDays);
     }
 
@@ -32,6 +43,7 @@ public sealed class RefreshTokenService : IRefreshTokenService
         {
             UserId = userId,
             TokenHash = Hash(raw),
+            FamilyId = Guid.NewGuid(),
             ExpiresAt = _clock.GetUtcNow().Add(_ttl),
         });
         await _db.SaveChangesAsync(ct);
@@ -44,14 +56,15 @@ public sealed class RefreshTokenService : IRefreshTokenService
         var now = _clock.GetUtcNow();
 
         // Atomic CAS: only one concurrent caller wins the revocation. Others see 0 rows
-        // affected and throw, so a replayed / race-duplicated rotation cannot succeed twice.
-        // TODO: detect reuse + revoke the whole token family per PLAN.md follow-up (#5 scope).
+        // affected and we fall through to the replay-detection path below — a replayed /
+        // race-duplicated rotation cannot succeed twice.
         var affected = await _db.RefreshTokens
             .Where(t => t.TokenHash == hash && t.RevokedAt == null && t.ExpiresAt > now)
             .ExecuteUpdateAsync(s => s.SetProperty(t => t.RevokedAt, now), ct);
 
         if (affected == 0)
         {
+            await HandleRotateMissAsync(hash, now, ct);
             throw new InvalidRefreshTokenException("Refresh token is invalid, revoked, or expired.");
         }
 
@@ -65,6 +78,7 @@ public sealed class RefreshTokenService : IRefreshTokenService
         {
             UserId = row.UserId,
             TokenHash = Hash(newRaw),
+            FamilyId = row.FamilyId,
             ExpiresAt = now.Add(_ttl),
         });
         await _db.SaveChangesAsync(ct);
@@ -96,6 +110,40 @@ public sealed class RefreshTokenService : IRefreshTokenService
         Span<byte> bytes = stackalloc byte[TokenBytes];
         RandomNumberGenerator.Fill(bytes);
         return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    // The CAS update above failed. Three possible reasons: token unknown, token expired,
+    // or token already revoked. Only the third is a strong theft signal — a previously-valid
+    // token is being replayed after it was rotated/revoked. In that case revoke every live
+    // token in the same family so a thief who rotated once cannot keep using their chain.
+    // Unknown/expired hashes are silently ignored (caller throws InvalidRefreshTokenException).
+    private async Task HandleRotateMissAsync(string hash, DateTimeOffset now, CancellationToken ct)
+    {
+        var existing = await _db.RefreshTokens
+            .AsNoTracking()
+            .Where(t => t.TokenHash == hash)
+            .Select(t => new { t.FamilyId, t.RevokedAt })
+            .SingleOrDefaultAsync(ct);
+
+        if (existing is null || existing.RevokedAt is null)
+        {
+            return;
+        }
+
+        if (now - existing.RevokedAt.Value < ReplayGrace)
+        {
+            // Concurrent legitimate rotation; the winner already revoked the row a moment ago.
+            // Don't kill the user's freshly-issued successor.
+            return;
+        }
+
+        var revoked = await _db.RefreshTokens
+            .Where(t => t.FamilyId == existing.FamilyId && t.RevokedAt == null)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.RevokedAt, now), ct);
+
+        _logger.LogWarning(
+            "Refresh token replay detected; revoked {Revoked} live token(s) in family {FamilyId}.",
+            revoked, existing.FamilyId);
     }
 }
 

--- a/server/src/GankedTV.Api/Data/Entities/RefreshToken.cs
+++ b/server/src/GankedTV.Api/Data/Entities/RefreshToken.cs
@@ -5,6 +5,10 @@ public class RefreshToken
     public Guid Id { get; set; }
     public Guid UserId { get; set; }
     public required string TokenHash { get; set; }
+    // All tokens descended from a single login share one FamilyId, so when reuse of a revoked
+    // token is detected (a strong theft signal) every live token in the family can be revoked
+    // in a single bulk update. See RefreshTokenService.RotateAsync.
+    public Guid FamilyId { get; set; }
     public DateTimeOffset ExpiresAt { get; set; }
     public DateTimeOffset? RevokedAt { get; set; }
     public DateTimeOffset CreatedAt { get; set; }

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -72,6 +72,12 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             e.HasIndex(c => c.GameId).HasDatabaseName("idx_clips_game_id");
             e.HasIndex(c => c.CreatedAt).IsDescending().HasDatabaseName("idx_clips_created_at");
             e.HasIndex(c => c.Status).HasFilter("status = 'ready'").HasDatabaseName("idx_clips_status");
+            // Drives the orphan-clip sweep query (status = 'draft' AND created_at < cutoff).
+            // Composite key so EF distinguishes it from idx_clips_created_at; partial filter
+            // keeps the index tiny — only a transient minority of rows are ever 'draft'.
+            e.HasIndex(c => new { c.Status, c.CreatedAt })
+                .HasFilter("status = 'draft'")
+                .HasDatabaseName("idx_clips_draft_created_at");
         });
 
         modelBuilder.Entity<Like>(e =>
@@ -95,6 +101,7 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             e.HasKey(t => t.Id);
             e.Property(t => t.Id).HasDefaultValueSql("gen_random_uuid()");
             e.Property(t => t.TokenHash).IsRequired();
+            e.Property(t => t.FamilyId).IsRequired();
             e.Property(t => t.CreatedAt).HasDefaultValueSql("now()");
 
             e.HasOne(t => t.User)
@@ -104,6 +111,7 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
 
             e.HasIndex(t => t.UserId).HasDatabaseName("idx_refresh_tokens_user_id");
             e.HasIndex(t => t.TokenHash).IsUnique().HasDatabaseName("idx_refresh_tokens_token_hash");
+            e.HasIndex(t => t.FamilyId).HasDatabaseName("idx_refresh_tokens_family_id");
         });
     }
 }

--- a/server/src/GankedTV.Api/Data/Migrations/20260429065030_AddRefreshTokenFamilyId.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260429065030_AddRefreshTokenFamilyId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429065030_AddRefreshTokenFamilyId")]
+    partial class AddRefreshTokenFamilyId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -129,10 +132,6 @@ namespace GankedTV.Api.Data.Migrations
 
                     b.HasIndex("UserId")
                         .HasDatabaseName("idx_clips_user_id");
-
-                    b.HasIndex("Status", "CreatedAt")
-                        .HasDatabaseName("idx_clips_draft_created_at")
-                        .HasFilter("status = 'draft'");
 
                     b.ToTable("clips", (string)null);
                 });

--- a/server/src/GankedTV.Api/Data/Migrations/20260429065030_AddRefreshTokenFamilyId.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260429065030_AddRefreshTokenFamilyId.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenFamilyId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Add the column with a per-row random uuid default so existing rows each become
+            // their own single-member family. A blanket Guid.Empty would group every legacy
+            // token into one family, letting a single replay revoke them all — exactly the
+            // damage radius family revocation is supposed to bound.
+            migrationBuilder.AddColumn<Guid>(
+                name: "family_id",
+                table: "refresh_tokens",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "gen_random_uuid()");
+
+            // Drop the default so future inserts must supply FamilyId explicitly (RefreshTokenService
+            // sets it on Issue and copies it on Rotate). Keeps the source-of-truth in C#.
+            migrationBuilder.AlterColumn<Guid>(
+                name: "family_id",
+                table: "refresh_tokens",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "gen_random_uuid()");
+
+            migrationBuilder.CreateIndex(
+                name: "idx_refresh_tokens_family_id",
+                table: "refresh_tokens",
+                column: "family_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_refresh_tokens_family_id",
+                table: "refresh_tokens");
+
+            migrationBuilder.DropColumn(
+                name: "family_id",
+                table: "refresh_tokens");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Data/Migrations/20260429072302_AddDraftClipIndex.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260429072302_AddDraftClipIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429072302_AddDraftClipIndex")]
+    partial class AddDraftClipIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/GankedTV.Api/Data/Migrations/20260429072302_AddDraftClipIndex.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260429072302_AddDraftClipIndex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDraftClipIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "idx_clips_draft_created_at",
+                table: "clips",
+                columns: new[] { "status", "created_at" },
+                filter: "status = 'draft'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_clips_draft_created_at",
+                table: "clips");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Maintenance;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Mvc;
@@ -145,30 +146,17 @@ public static class ClipsMutateEndpoints
             return ProblemResults.Forbidden("forbidden");
         }
 
-        var videoKey = clip.VideoKey;
-        var thumbnailKey = clip.ThumbnailKey;
-
         db.Clips.Remove(clip);
         await db.SaveChangesAsync(ct);
 
         // S3 cleanup is best-effort: the DB row is already gone, so a cleanup failure must not
         // surface as 500 (that would mislead the client into retrying a non-existent row).
-        // Orphaned S3 objects are cheap; a future reaper can sweep them.
-        try
-        {
-            await storage.DeleteObjectAsync(minio.Value.ClipsBucket, videoKey, ct);
-            if (!string.IsNullOrEmpty(thumbnailKey))
-            {
-                await storage.DeleteObjectAsync(minio.Value.ThumbnailsBucket, thumbnailKey, ct);
-            }
-        }
-        catch (Exception ex)
-        {
-            loggerFactory.CreateLogger(LogCategory).LogWarning(
-                ex,
-                "Failed to delete S3 objects for clip {ClipId} (video={VideoKey}, thumb={ThumbKey})",
-                id, videoKey, thumbnailKey);
-        }
+        await ClipBlobCleanup.TryDeleteAsync(
+            storage,
+            minio.Value,
+            clip,
+            loggerFactory.CreateLogger(LogCategory),
+            ct);
 
         return Results.NoContent();
     }

--- a/server/src/GankedTV.Api/GankedTV.Api.csproj
+++ b/server/src/GankedTV.Api/GankedTV.Api.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="GankedTV.Api.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.21.2" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -9,6 +9,7 @@ using GankedTV.Api.Data;
 using GankedTV.Api.Endpoints;
 using GankedTV.Api.Middleware;
 using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Services.Maintenance;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tools;
 using GankedTV.Api.Validation;
@@ -75,6 +76,28 @@ builder.Services.AddSingleton<IAmazonS3>(sp =>
 
 builder.Services.AddSingleton<IObjectStorageService, MinioObjectStorageService>();
 builder.Services.AddHostedService<BucketBootstrapHostedService>();
+
+builder.Services.AddOptions<MaintenanceOptions>()
+    .Configure(opts =>
+    {
+        builder.Configuration.GetSection("Maintenance").Bind(opts);
+        var enabled = Environment.GetEnvironmentVariable("MAINTENANCE_ENABLED");
+        if (bool.TryParse(enabled, out var e)) opts.Enabled = e;
+        var interval = Environment.GetEnvironmentVariable("MAINTENANCE_SWEEP_INTERVAL_MINUTES");
+        if (int.TryParse(interval, out var im) && im > 0) opts.SweepInterval = TimeSpan.FromMinutes(im);
+        var clipHours = Environment.GetEnvironmentVariable("MAINTENANCE_CLIP_THRESHOLD_HOURS");
+        if (int.TryParse(clipHours, out var ch) && ch > 0) opts.ClipStaleThreshold = TimeSpan.FromHours(ch);
+        var rtDays = Environment.GetEnvironmentVariable("MAINTENANCE_REFRESH_TOKEN_RETENTION_DAYS");
+        if (int.TryParse(rtDays, out var rd) && rd > 0) opts.RefreshTokenRetention = TimeSpan.FromDays(rd);
+        var batch = Environment.GetEnvironmentVariable("MAINTENANCE_CLIP_BATCH_SIZE");
+        if (int.TryParse(batch, out var bs) && bs > 0) opts.ClipBatchSize = bs;
+    })
+    .Validate(o => o.SweepInterval > TimeSpan.Zero, "Maintenance.SweepInterval must be positive.")
+    .Validate(o => o.ClipStaleThreshold > TimeSpan.Zero, "Maintenance.ClipStaleThreshold must be positive.")
+    .Validate(o => o.RefreshTokenRetention > TimeSpan.Zero, "Maintenance.RefreshTokenRetention must be positive.")
+    .Validate(o => o.ClipBatchSize > 0, "Maintenance.ClipBatchSize must be positive.")
+    .ValidateOnStart();
+builder.Services.AddHostedService<MaintenanceHostedService>();
 
 builder.Services.AddOptions<ClipValidationOptions>()
     .Configure(opts =>

--- a/server/src/GankedTV.Api/Services/Maintenance/ClipBlobCleanup.cs
+++ b/server/src/GankedTV.Api/Services/Maintenance/ClipBlobCleanup.cs
@@ -7,8 +7,8 @@ public static class ClipBlobCleanup
 {
     // Best-effort delete of a clip's video and thumbnail objects. Each delete is wrapped
     // independently so a thumbnail failure cannot suppress the video delete (and vice versa).
-    // Callers must already have removed (or be about to remove) the DB row — orphaned blobs
-    // are cheap; orphaned rows pointing at missing blobs are not.
+    // Callers must remove the DB row first — orphaned blobs are cheap to garbage-collect later;
+    // orphaned rows pointing at missing blobs would surface as 404s on every read attempt.
     public static async Task TryDeleteAsync(
         IObjectStorageService storage,
         MinioOptions buckets,
@@ -19,6 +19,11 @@ public static class ClipBlobCleanup
         try
         {
             await storage.DeleteObjectAsync(buckets.ClipsBucket, clip.VideoKey, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Cooperative cancellation must propagate; only swallow real S3 errors.
+            throw;
         }
         catch (Exception ex)
         {
@@ -36,6 +41,10 @@ public static class ClipBlobCleanup
         try
         {
             await storage.DeleteObjectAsync(buckets.ThumbnailsBucket, clip.ThumbnailKey, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/server/src/GankedTV.Api/Services/Maintenance/ClipBlobCleanup.cs
+++ b/server/src/GankedTV.Api/Services/Maintenance/ClipBlobCleanup.cs
@@ -1,0 +1,48 @@
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+
+namespace GankedTV.Api.Services.Maintenance;
+
+public static class ClipBlobCleanup
+{
+    // Best-effort delete of a clip's video and thumbnail objects. Each delete is wrapped
+    // independently so a thumbnail failure cannot suppress the video delete (and vice versa).
+    // Callers must already have removed (or be about to remove) the DB row — orphaned blobs
+    // are cheap; orphaned rows pointing at missing blobs are not.
+    public static async Task TryDeleteAsync(
+        IObjectStorageService storage,
+        MinioOptions buckets,
+        Clip clip,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            await storage.DeleteObjectAsync(buckets.ClipsBucket, clip.VideoKey, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to delete S3 video object for clip {ClipId} (video={VideoKey})",
+                clip.Id, clip.VideoKey);
+        }
+
+        if (string.IsNullOrEmpty(clip.ThumbnailKey))
+        {
+            return;
+        }
+
+        try
+        {
+            await storage.DeleteObjectAsync(buckets.ThumbnailsBucket, clip.ThumbnailKey, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to delete S3 thumbnail object for clip {ClipId} (thumb={ThumbKey})",
+                clip.Id, clip.ThumbnailKey);
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Services/Maintenance/MaintenanceHostedService.cs
+++ b/server/src/GankedTV.Api/Services/Maintenance/MaintenanceHostedService.cs
@@ -122,10 +122,13 @@ public sealed class MaintenanceHostedService : BackgroundService
             orphans.RemoveAt(orphans.Count - 1);
         }
 
+        // Mark the DB row for deletion first, then attempt the blob cleanup — same row-first
+        // ordering as DELETE /clips/{id}. SaveChangesAsync below commits all queued removes
+        // in one transaction.
         foreach (var clip in orphans)
         {
-            await ClipBlobCleanup.TryDeleteAsync(storage, buckets, clip, _logger, ct);
             db.Clips.Remove(clip);
+            await ClipBlobCleanup.TryDeleteAsync(storage, buckets, clip, _logger, ct);
         }
 
         await db.SaveChangesAsync(ct);

--- a/server/src/GankedTV.Api/Services/Maintenance/MaintenanceHostedService.cs
+++ b/server/src/GankedTV.Api/Services/Maintenance/MaintenanceHostedService.cs
@@ -1,0 +1,166 @@
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Services.Maintenance;
+
+public sealed class MaintenanceHostedService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptionsMonitor<MaintenanceOptions> _options;
+    private readonly IOptionsMonitor<MinioOptions> _minio;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<MaintenanceHostedService> _logger;
+
+    public MaintenanceHostedService(
+        IServiceScopeFactory scopeFactory,
+        IOptionsMonitor<MaintenanceOptions> options,
+        IOptionsMonitor<MinioOptions> minio,
+        TimeProvider clock,
+        ILogger<MaintenanceHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _minio = minio;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var snapshot = _options.CurrentValue;
+        if (!snapshot.Enabled)
+        {
+            _logger.LogInformation("Maintenance hosted service disabled by configuration; exiting.");
+            return;
+        }
+
+        // SweepInterval is captured at startup and frozen for the life of the process.
+        // The other thresholds are read fresh from IOptionsMonitor each tick, so config
+        // reload affects them; changing the interval requires a restart.
+        using var timer = new PeriodicTimer(snapshot.SweepInterval);
+        _logger.LogInformation(
+            "Maintenance hosted service started (interval={Interval}, clipThreshold={ClipThreshold}, refreshTokenRetention={Retention}).",
+            snapshot.SweepInterval, snapshot.ClipStaleThreshold, snapshot.RefreshTokenRetention);
+
+        try
+        {
+            // Run an immediate sweep on startup, then on each tick.
+            do
+            {
+                await RunTickAsync(stoppingToken);
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown — not an error.
+        }
+    }
+
+    private async Task RunTickAsync(CancellationToken ct)
+    {
+        // Each sweep gets its own scope so a half-failed clip sweep cannot leave a dirty
+        // change tracker for the refresh-token sweep that runs after it.
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            await SweepOrphanedClipsAsync(scope, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Orphaned clip sweep failed");
+        }
+
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            await SweepExpiredRefreshTokensAsync(scope, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Refresh token sweep failed");
+        }
+    }
+
+    internal async Task SweepOrphanedClipsAsync(IServiceScope scope, CancellationToken ct)
+    {
+        var db = scope.ServiceProvider.GetRequiredService<GankedTvDbContext>();
+        var storage = scope.ServiceProvider.GetRequiredService<IObjectStorageService>();
+        var buckets = _minio.CurrentValue;
+        var opts = _options.CurrentValue;
+        var threshold = opts.ClipStaleThreshold;
+        var cutoff = _clock.GetUtcNow() - threshold;
+        // +1 so we can tell whether more remain beyond the cap without a second query.
+        var fetchLimit = opts.ClipBatchSize + 1;
+
+        var orphans = await db.Clips
+            .Where(c => c.Status == ClipStatuses.Draft && c.CreatedAt < cutoff)
+            .OrderBy(c => c.CreatedAt)
+            .Take(fetchLimit)
+            .ToListAsync(ct);
+
+        if (orphans.Count == 0)
+        {
+            _logger.LogDebug("No orphaned draft clips older than {Threshold} found.", threshold);
+            return;
+        }
+
+        var moreRemaining = orphans.Count > opts.ClipBatchSize;
+        if (moreRemaining)
+        {
+            orphans.RemoveAt(orphans.Count - 1);
+        }
+
+        foreach (var clip in orphans)
+        {
+            await ClipBlobCleanup.TryDeleteAsync(storage, buckets, clip, _logger, ct);
+            db.Clips.Remove(clip);
+        }
+
+        await db.SaveChangesAsync(ct);
+        if (moreRemaining)
+        {
+            _logger.LogInformation(
+                "Swept {Count} orphaned draft clips (older than {Threshold}); batch cap reached, remainder will be picked up next tick.",
+                orphans.Count, threshold);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Swept {Count} orphaned draft clips (older than {Threshold}).",
+                orphans.Count, threshold);
+        }
+    }
+
+    internal async Task SweepExpiredRefreshTokensAsync(IServiceScope scope, CancellationToken ct)
+    {
+        var db = scope.ServiceProvider.GetRequiredService<GankedTvDbContext>();
+        var retention = _options.CurrentValue.RefreshTokenRetention;
+        var cutoff = _clock.GetUtcNow() - retention;
+
+        var deleted = await db.RefreshTokens
+            .Where(t => t.ExpiresAt < cutoff)
+            .ExecuteDeleteAsync(ct);
+
+        if (deleted == 0)
+        {
+            _logger.LogDebug("No refresh token rows older than {Retention} past expiry.", retention);
+            return;
+        }
+
+        _logger.LogInformation(
+            "Swept {Count} refresh token rows expired more than {Retention} ago.",
+            deleted, retention);
+    }
+}

--- a/server/src/GankedTV.Api/Services/Maintenance/MaintenanceOptions.cs
+++ b/server/src/GankedTV.Api/Services/Maintenance/MaintenanceOptions.cs
@@ -1,0 +1,13 @@
+namespace GankedTV.Api.Services.Maintenance;
+
+public sealed class MaintenanceOptions
+{
+    public bool Enabled { get; set; } = true;
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromMinutes(15);
+    public TimeSpan ClipStaleThreshold { get; set; } = TimeSpan.FromHours(1);
+    public TimeSpan RefreshTokenRetention { get; set; } = TimeSpan.FromDays(30);
+    // Hard cap on rows the orphan-clip sweep loads in one tick. Protects memory if a
+    // backlog accumulates (e.g. the sweep silently fails for days, then the bug is fixed).
+    // The remainder is picked up on the next tick.
+    public int ClipBatchSize { get; set; } = 1000;
+}

--- a/server/src/GankedTV.Api/appsettings.json
+++ b/server/src/GankedTV.Api/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Maintenance": {
+    "Enabled": true,
+    "SweepInterval": "00:15:00",
+    "ClipStaleThreshold": "01:00:00",
+    "RefreshTokenRetention": "30.00:00:00",
+    "ClipBatchSize": 1000
+  }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Auth/RefreshTokenServiceTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Auth/RefreshTokenServiceTests.cs
@@ -52,6 +52,7 @@ public class RefreshTokenServiceTests
         rows[0].TokenHash.Should().NotBe(raw);
         rows[0].TokenHash.Should().Be(RefreshTokenService.Hash(raw));
         rows[0].RevokedAt.Should().BeNull();
+        rows[0].FamilyId.Should().NotBe(Guid.Empty);
         rows[0].ExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow.AddDays(29));
     }
 
@@ -103,6 +104,49 @@ public class RefreshTokenServiceTests
         await using var rotateDb = _fx.CreateContext();
         var act = () => new RefreshTokenService(rotateDb, DefaultOpts()).RotateAsync(raw);
         await act.Should().ThrowAsync<InvalidRefreshTokenException>();
+    }
+
+    [Fact]
+    public async Task RotateAsync_ExpiredToken_DoesNotTouchLiveFamilySiblings()
+    {
+        // An expired-but-never-revoked token presented for rotation must not trigger family
+        // revocation — it's not a theft signal, just an unlucky user with a stale token.
+        // Live siblings (e.g. another tab that is still within TTL) must remain usable.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("mona");
+
+        var family = Guid.NewGuid();
+        const string expiredRaw = "manual-expired-token";
+        string liveRaw;
+        await using (var db = _fx.CreateContext())
+        {
+            db.RefreshTokens.Add(new RefreshToken
+            {
+                UserId = userId,
+                TokenHash = RefreshTokenService.Hash(expiredRaw),
+                FamilyId = family,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            });
+            liveRaw = await new RefreshTokenService(db, DefaultOpts()).IssueAsync(userId);
+        }
+        // Force the live token into the same family as the expired one.
+        await using (var db = _fx.CreateContext())
+        {
+            await db.RefreshTokens
+                .Where(t => t.TokenHash == RefreshTokenService.Hash(liveRaw))
+                .ExecuteUpdateAsync(s => s.SetProperty(t => t.FamilyId, family));
+        }
+
+        await using (var db = _fx.CreateContext())
+        {
+            var act = () => new RefreshTokenService(db, DefaultOpts()).RotateAsync(expiredRaw);
+            await act.Should().ThrowAsync<InvalidRefreshTokenException>();
+        }
+
+        // Sibling must still be rotatable.
+        await using var rotateDb = _fx.CreateContext();
+        var rotated = await new RefreshTokenService(rotateDb, DefaultOpts()).RotateAsync(liveRaw);
+        rotated.NewRawToken.Should().NotBeNullOrEmpty();
     }
 
     [Fact]
@@ -207,6 +251,168 @@ public class RefreshTokenServiceTests
         await using var verify = _fx.CreateContext();
         var row = await verify.RefreshTokens.AsNoTracking().SingleAsync();
         row.RevokedAt.Should().Be(firstRevokedAt);
+    }
+
+    [Fact]
+    public async Task RotateAsync_CopiesFamilyIdFromParent()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("hugo");
+
+        string raw;
+        await using (var db = _fx.CreateContext())
+        {
+            raw = await new RefreshTokenService(db, DefaultOpts()).IssueAsync(userId);
+        }
+
+        Guid parentFamily;
+        await using (var db = _fx.CreateContext())
+        {
+            parentFamily = (await db.RefreshTokens.AsNoTracking().SingleAsync()).FamilyId;
+        }
+
+        RotateResult result;
+        await using (var db = _fx.CreateContext())
+        {
+            result = await new RefreshTokenService(db, DefaultOpts()).RotateAsync(raw);
+        }
+
+        await using var verify = _fx.CreateContext();
+        var families = await verify.RefreshTokens.AsNoTracking().Select(t => t.FamilyId).Distinct().ToListAsync();
+        families.Should().ContainSingle().Which.Should().Be(parentFamily);
+    }
+
+    [Fact]
+    public async Task RotateAsync_RotationChain_SharesOneFamily()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("ivan");
+
+        string current;
+        await using (var db = _fx.CreateContext())
+        {
+            current = await new RefreshTokenService(db, DefaultOpts()).IssueAsync(userId);
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            await using var db = _fx.CreateContext();
+            current = (await new RefreshTokenService(db, DefaultOpts()).RotateAsync(current)).NewRawToken;
+        }
+
+        await using var verify = _fx.CreateContext();
+        var rows = await verify.RefreshTokens.AsNoTracking().ToListAsync();
+        rows.Should().HaveCount(4);
+        rows.Select(r => r.FamilyId).Distinct().Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RotateAsync_ReplayOfRevokedToken_RevokesEntireFamily()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("judy");
+        var clock = new FakeClock(DateTimeOffset.UtcNow);
+
+        string tokenA;
+        await using (var db = _fx.CreateContext())
+        {
+            tokenA = await new RefreshTokenService(db, DefaultOpts(), clock: clock).IssueAsync(userId);
+        }
+
+        // Legitimate rotation: A -> B. A is now revoked.
+        string tokenB;
+        await using (var db = _fx.CreateContext())
+        {
+            tokenB = (await new RefreshTokenService(db, DefaultOpts(), clock: clock).RotateAsync(tokenA)).NewRawToken;
+        }
+
+        // Advance past the replay grace window so the next presentation of A is treated as theft.
+        clock.Set(clock.GetUtcNow().AddMinutes(5));
+
+        await using (var rotateDb = _fx.CreateContext())
+        {
+            var act = () => new RefreshTokenService(rotateDb, DefaultOpts(), clock: clock).RotateAsync(tokenA);
+            await act.Should().ThrowAsync<InvalidRefreshTokenException>();
+        }
+
+        await using var verify = _fx.CreateContext();
+        var rows = await verify.RefreshTokens.AsNoTracking().ToListAsync();
+        rows.Should().HaveCount(2);
+        rows.Should().OnlyContain(r => r.RevokedAt != null);
+
+        // Token B (the previously-live successor) cannot be rotated either.
+        await using var rotateB = _fx.CreateContext();
+        var rotateActB = () => new RefreshTokenService(rotateB, DefaultOpts(), clock: clock).RotateAsync(tokenB);
+        await rotateActB.Should().ThrowAsync<InvalidRefreshTokenException>();
+    }
+
+    [Fact]
+    public async Task RotateAsync_ConcurrentRotationDoesNotTriggerFamilyRevoke()
+    {
+        // The CAS-loser path is reachable in legitimate flows (multiple tabs racing to refresh).
+        // Fresh revocations within the grace window must NOT trigger family revoke, otherwise
+        // the user's just-issued successor token would be killed on every concurrent refresh.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("liam");
+
+        string tokenA;
+        await using (var db = _fx.CreateContext())
+        {
+            tokenA = await new RefreshTokenService(db, DefaultOpts()).IssueAsync(userId);
+        }
+
+        // Legitimate rotation A -> B.
+        await using (var db = _fx.CreateContext())
+        {
+            await new RefreshTokenService(db, DefaultOpts()).RotateAsync(tokenA);
+        }
+
+        // Immediately replay A — should throw (token revoked) but leave B live.
+        await using (var db = _fx.CreateContext())
+        {
+            var act = () => new RefreshTokenService(db, DefaultOpts()).RotateAsync(tokenA);
+            await act.Should().ThrowAsync<InvalidRefreshTokenException>();
+        }
+
+        await using var verify = _fx.CreateContext();
+        var liveRows = await verify.RefreshTokens.AsNoTracking().Where(t => t.RevokedAt == null).ToListAsync();
+        liveRows.Should().ContainSingle("the freshly-issued successor must remain live during a concurrent rotation race");
+    }
+
+    [Fact]
+    public async Task RotateAsync_ReplayDoesNotTouchOtherFamilies()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("kim");
+        var clock = new FakeClock(DateTimeOffset.UtcNow);
+
+        // Two independent login sessions = two families.
+        string tokenF1, tokenF2;
+        await using (var db = _fx.CreateContext())
+        {
+            tokenF1 = await new RefreshTokenService(db, DefaultOpts(), clock: clock).IssueAsync(userId);
+        }
+        await using (var db = _fx.CreateContext())
+        {
+            tokenF2 = await new RefreshTokenService(db, DefaultOpts(), clock: clock).IssueAsync(userId);
+        }
+
+        // Rotate F1 to revoke its only token, then replay it past the grace window.
+        await using (var db = _fx.CreateContext())
+        {
+            await new RefreshTokenService(db, DefaultOpts(), clock: clock).RotateAsync(tokenF1);
+        }
+        clock.Set(clock.GetUtcNow().AddMinutes(5));
+        await using (var db = _fx.CreateContext())
+        {
+            var act = () => new RefreshTokenService(db, DefaultOpts(), clock: clock).RotateAsync(tokenF1);
+            await act.Should().ThrowAsync<InvalidRefreshTokenException>();
+        }
+
+        // F2 must still be live and rotatable.
+        await using var rotateF2 = _fx.CreateContext();
+        var rotated = await new RefreshTokenService(rotateF2, DefaultOpts(), clock: clock).RotateAsync(tokenF2);
+        rotated.NewRawToken.Should().NotBeNullOrEmpty();
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Maintenance/MaintenanceHostedServiceIntegrationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Maintenance/MaintenanceHostedServiceIntegrationTests.cs
@@ -1,0 +1,270 @@
+using FluentAssertions;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Maintenance;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Maintenance;
+
+[Collection("Postgres")]
+public class MaintenanceHostedServiceIntegrationTests
+{
+    private readonly PostgresFixture _fx;
+
+    public MaintenanceHostedServiceIntegrationTests(PostgresFixture fx) => _fx = fx;
+
+    private (MaintenanceHostedService svc, IServiceScope scope, IObjectStorageService storage, FakeClock clock)
+        Build(MaintenanceOptions options, DateTimeOffset now)
+    {
+        var clock = new FakeClock(now);
+        var storage = Substitute.For<IObjectStorageService>();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<GankedTvDbContext>(opts =>
+            opts.UseNpgsql(_fx.ConnectionString).UseSnakeCaseNamingConvention());
+        services.AddSingleton(storage);
+        var sp = services.BuildServiceProvider();
+
+        var optsMonitor = Substitute.For<IOptionsMonitor<MaintenanceOptions>>();
+        optsMonitor.CurrentValue.Returns(options);
+        var minioMonitor = Substitute.For<IOptionsMonitor<MinioOptions>>();
+        minioMonitor.CurrentValue.Returns(new MinioOptions { ClipsBucket = "clips", ThumbnailsBucket = "thumbnails" });
+
+        var svc = new MaintenanceHostedService(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            optsMonitor,
+            minioMonitor,
+            clock,
+            NullLogger<MaintenanceHostedService>.Instance);
+
+        return (svc, sp.CreateScope(), storage, clock);
+    }
+
+    private async Task<Guid> SeedUserAsync(string username)
+    {
+        await using var db = _fx.CreateContext();
+        var u = new User
+        {
+            Username = username,
+            Email = $"{username}@example.com",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.Users.Add(u);
+        await db.SaveChangesAsync();
+        return u.Id;
+    }
+
+    [Fact]
+    public async Task SweepOrphanedClipsAsync_DeletesOnlyOldDrafts_AndCallsStorage()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("alice");
+        var now = DateTimeOffset.UtcNow;
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Clips.AddRange(
+                new Clip
+                {
+                    UserId = userId,
+                    Title = "stale-draft",
+                    VideoKey = "user/stale.mp4",
+                    ThumbnailKey = "user/stale.jpg",
+                    Status = ClipStatuses.Draft,
+                    CreatedAt = now.AddHours(-2),
+                    UpdatedAt = now.AddHours(-2),
+                },
+                new Clip
+                {
+                    UserId = userId,
+                    Title = "fresh-draft",
+                    VideoKey = "user/fresh.mp4",
+                    Status = ClipStatuses.Draft,
+                    CreatedAt = now.AddMinutes(-5),
+                    UpdatedAt = now.AddMinutes(-5),
+                },
+                new Clip
+                {
+                    UserId = userId,
+                    Title = "old-ready",
+                    VideoKey = "user/ready.mp4",
+                    Status = ClipStatuses.Ready,
+                    CreatedAt = now.AddHours(-2),
+                    UpdatedAt = now.AddHours(-2),
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var (svc, scope, storage, _) = Build(
+            new MaintenanceOptions { ClipStaleThreshold = TimeSpan.FromHours(1) },
+            now);
+
+        await svc.SweepOrphanedClipsAsync(scope, CancellationToken.None);
+
+        await using var verify = _fx.CreateContext();
+        var remainingTitles = await verify.Clips.AsNoTracking().Select(c => c.Title).ToListAsync();
+        remainingTitles.Should().BeEquivalentTo("fresh-draft", "old-ready");
+
+        await storage.Received(1).DeleteObjectAsync("clips", "user/stale.mp4", Arg.Any<CancellationToken>());
+        await storage.Received(1).DeleteObjectAsync("thumbnails", "user/stale.jpg", Arg.Any<CancellationToken>());
+        await storage.DidNotReceive().DeleteObjectAsync("clips", "user/fresh.mp4", Arg.Any<CancellationToken>());
+        await storage.DidNotReceive().DeleteObjectAsync("clips", "user/ready.mp4", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SweepOrphanedClipsAsync_NoCandidates_NoStorageCalls()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("bob");
+        var now = DateTimeOffset.UtcNow;
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Clips.Add(new Clip
+            {
+                UserId = userId,
+                Title = "fresh",
+                VideoKey = "u/v.mp4",
+                Status = ClipStatuses.Draft,
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var (svc, scope, storage, _) = Build(
+            new MaintenanceOptions { ClipStaleThreshold = TimeSpan.FromHours(1) },
+            now);
+
+        await svc.SweepOrphanedClipsAsync(scope, CancellationToken.None);
+
+        await storage.DidNotReceive().DeleteObjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunTick_ClipSweepFailure_DoesNotSkipRefreshTokenSweep()
+    {
+        // Independent try/catch around each sweep — sweep 1 throwing must not starve sweep 2.
+        // Drive ExecuteAsync once via StartAsync/StopAsync with a long interval so only the
+        // immediate-startup tick runs, then assert the token sweep still ran.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("noah");
+        var now = DateTimeOffset.UtcNow;
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.RefreshTokens.Add(new RefreshToken
+            {
+                UserId = userId,
+                TokenHash = "hash-ancient",
+                FamilyId = Guid.NewGuid(),
+                ExpiresAt = now.AddDays(-90),
+            });
+            await db.SaveChangesAsync();
+        }
+
+        // Storage substitute that throws on the clip-sweep path. Even though no draft clips
+        // exist (so the sweep returns early on count == 0), we make the DbContext throw by
+        // poisoning the IObjectStorageService resolution: register a factory that throws.
+        var services = new ServiceCollection();
+        services.AddDbContext<GankedTvDbContext>(opts =>
+            opts.UseNpgsql(_fx.ConnectionString).UseSnakeCaseNamingConvention());
+        services.AddScoped<IObjectStorageService>(_ => throw new InvalidOperationException("storage poisoned"));
+        var sp = services.BuildServiceProvider();
+
+        // Seed a stale draft clip so SweepOrphanedClipsAsync resolves IObjectStorageService and throws.
+        await using (var db = _fx.CreateContext())
+        {
+            db.Clips.Add(new Clip
+            {
+                UserId = userId,
+                Title = "stale",
+                VideoKey = "k.mp4",
+                Status = ClipStatuses.Draft,
+                CreatedAt = now.AddHours(-2),
+                UpdatedAt = now.AddHours(-2),
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var optsMonitor = Substitute.For<IOptionsMonitor<MaintenanceOptions>>();
+        optsMonitor.CurrentValue.Returns(new MaintenanceOptions
+        {
+            Enabled = true,
+            SweepInterval = TimeSpan.FromHours(1),
+            ClipStaleThreshold = TimeSpan.FromHours(1),
+            RefreshTokenRetention = TimeSpan.FromDays(30),
+        });
+        var minioMonitor = Substitute.For<IOptionsMonitor<MinioOptions>>();
+        minioMonitor.CurrentValue.Returns(new MinioOptions { ClipsBucket = "clips", ThumbnailsBucket = "thumbnails" });
+
+        var svc = new MaintenanceHostedService(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            optsMonitor,
+            minioMonitor,
+            new FakeClock(now),
+            NullLogger<MaintenanceHostedService>.Instance);
+
+        await svc.StartAsync(CancellationToken.None);
+        // Give the immediate tick a moment to execute both sweeps.
+        await Task.Delay(500);
+        await svc.StopAsync(CancellationToken.None);
+
+        // Token sweep ran despite clip sweep throwing on storage resolution.
+        await using var verify = _fx.CreateContext();
+        (await verify.RefreshTokens.AsNoTracking().AnyAsync(t => t.TokenHash == "hash-ancient"))
+            .Should().BeFalse("the refresh-token sweep must run even when the clip sweep fails");
+    }
+
+    [Fact]
+    public async Task SweepExpiredRefreshTokensAsync_DeletesOnlyRowsBeyondRetention()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("carol");
+        var now = DateTimeOffset.UtcNow;
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.RefreshTokens.AddRange(
+                new RefreshToken
+                {
+                    UserId = userId,
+                    TokenHash = "hash-old",
+                    FamilyId = Guid.NewGuid(),
+                    ExpiresAt = now.AddDays(-60),
+                },
+                new RefreshToken
+                {
+                    UserId = userId,
+                    TokenHash = "hash-recent-expired",
+                    FamilyId = Guid.NewGuid(),
+                    ExpiresAt = now.AddDays(-5),
+                },
+                new RefreshToken
+                {
+                    UserId = userId,
+                    TokenHash = "hash-live",
+                    FamilyId = Guid.NewGuid(),
+                    ExpiresAt = now.AddDays(20),
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var (svc, scope, _, _) = Build(
+            new MaintenanceOptions { RefreshTokenRetention = TimeSpan.FromDays(30) },
+            now);
+
+        await svc.SweepExpiredRefreshTokensAsync(scope, CancellationToken.None);
+
+        await using var verify = _fx.CreateContext();
+        var hashes = await verify.RefreshTokens.AsNoTracking().Select(t => t.TokenHash).ToListAsync();
+        hashes.Should().BeEquivalentTo("hash-recent-expired", "hash-live");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Maintenance/MaintenanceHostedServiceIntegrationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Maintenance/MaintenanceHostedServiceIntegrationTests.cs
@@ -19,8 +19,22 @@ public class MaintenanceHostedServiceIntegrationTests
 
     public MaintenanceHostedServiceIntegrationTests(PostgresFixture fx) => _fx = fx;
 
-    private (MaintenanceHostedService svc, IServiceScope scope, IObjectStorageService storage, FakeClock clock)
-        Build(MaintenanceOptions options, DateTimeOffset now)
+    private sealed class Harness : IAsyncDisposable
+    {
+        public required MaintenanceHostedService Service { get; init; }
+        public required IServiceScope Scope { get; init; }
+        public required IObjectStorageService Storage { get; init; }
+        public required FakeClock Clock { get; init; }
+        public required ServiceProvider Provider { get; init; }
+
+        public async ValueTask DisposeAsync()
+        {
+            Scope.Dispose();
+            await Provider.DisposeAsync();
+        }
+    }
+
+    private Harness Build(MaintenanceOptions options, DateTimeOffset now)
     {
         var clock = new FakeClock(now);
         var storage = Substitute.For<IObjectStorageService>();
@@ -43,7 +57,14 @@ public class MaintenanceHostedServiceIntegrationTests
             clock,
             NullLogger<MaintenanceHostedService>.Instance);
 
-        return (svc, sp.CreateScope(), storage, clock);
+        return new Harness
+        {
+            Service = svc,
+            Scope = sp.CreateScope(),
+            Storage = storage,
+            Clock = clock,
+            Provider = sp,
+        };
     }
 
     private async Task<Guid> SeedUserAsync(string username)
@@ -102,20 +123,20 @@ public class MaintenanceHostedServiceIntegrationTests
             await db.SaveChangesAsync();
         }
 
-        var (svc, scope, storage, _) = Build(
+        await using var harness = Build(
             new MaintenanceOptions { ClipStaleThreshold = TimeSpan.FromHours(1) },
             now);
 
-        await svc.SweepOrphanedClipsAsync(scope, CancellationToken.None);
+        await harness.Service.SweepOrphanedClipsAsync(harness.Scope, CancellationToken.None);
 
         await using var verify = _fx.CreateContext();
         var remainingTitles = await verify.Clips.AsNoTracking().Select(c => c.Title).ToListAsync();
         remainingTitles.Should().BeEquivalentTo("fresh-draft", "old-ready");
 
-        await storage.Received(1).DeleteObjectAsync("clips", "user/stale.mp4", Arg.Any<CancellationToken>());
-        await storage.Received(1).DeleteObjectAsync("thumbnails", "user/stale.jpg", Arg.Any<CancellationToken>());
-        await storage.DidNotReceive().DeleteObjectAsync("clips", "user/fresh.mp4", Arg.Any<CancellationToken>());
-        await storage.DidNotReceive().DeleteObjectAsync("clips", "user/ready.mp4", Arg.Any<CancellationToken>());
+        await harness.Storage.Received(1).DeleteObjectAsync("clips", "user/stale.mp4", Arg.Any<CancellationToken>());
+        await harness.Storage.Received(1).DeleteObjectAsync("thumbnails", "user/stale.jpg", Arg.Any<CancellationToken>());
+        await harness.Storage.DidNotReceive().DeleteObjectAsync("clips", "user/fresh.mp4", Arg.Any<CancellationToken>());
+        await harness.Storage.DidNotReceive().DeleteObjectAsync("clips", "user/ready.mp4", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -139,13 +160,13 @@ public class MaintenanceHostedServiceIntegrationTests
             await db.SaveChangesAsync();
         }
 
-        var (svc, scope, storage, _) = Build(
+        await using var harness = Build(
             new MaintenanceOptions { ClipStaleThreshold = TimeSpan.FromHours(1) },
             now);
 
-        await svc.SweepOrphanedClipsAsync(scope, CancellationToken.None);
+        await harness.Service.SweepOrphanedClipsAsync(harness.Scope, CancellationToken.None);
 
-        await storage.DidNotReceive().DeleteObjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await harness.Storage.DidNotReceive().DeleteObjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -170,16 +191,14 @@ public class MaintenanceHostedServiceIntegrationTests
             await db.SaveChangesAsync();
         }
 
-        // Storage substitute that throws on the clip-sweep path. Even though no draft clips
-        // exist (so the sweep returns early on count == 0), we make the DbContext throw by
-        // poisoning the IObjectStorageService resolution: register a factory that throws.
+        // Storage factory that throws so the clip sweep fails. Seed a stale draft clip so
+        // SweepOrphanedClipsAsync actually resolves IObjectStorageService and hits the throw.
         var services = new ServiceCollection();
         services.AddDbContext<GankedTvDbContext>(opts =>
             opts.UseNpgsql(_fx.ConnectionString).UseSnakeCaseNamingConvention());
         services.AddScoped<IObjectStorageService>(_ => throw new InvalidOperationException("storage poisoned"));
-        var sp = services.BuildServiceProvider();
+        await using var sp = services.BuildServiceProvider();
 
-        // Seed a stale draft clip so SweepOrphanedClipsAsync resolves IObjectStorageService and throws.
         await using (var db = _fx.CreateContext())
         {
             db.Clips.Add(new Clip
@@ -201,6 +220,7 @@ public class MaintenanceHostedServiceIntegrationTests
             SweepInterval = TimeSpan.FromHours(1),
             ClipStaleThreshold = TimeSpan.FromHours(1),
             RefreshTokenRetention = TimeSpan.FromDays(30),
+            ClipBatchSize = 1000,
         });
         var minioMonitor = Substitute.For<IOptionsMonitor<MinioOptions>>();
         minioMonitor.CurrentValue.Returns(new MinioOptions { ClipsBucket = "clips", ThumbnailsBucket = "thumbnails" });
@@ -213,11 +233,22 @@ public class MaintenanceHostedServiceIntegrationTests
             NullLogger<MaintenanceHostedService>.Instance);
 
         await svc.StartAsync(CancellationToken.None);
-        // Give the immediate tick a moment to execute both sweeps.
-        await Task.Delay(500);
+
+        // Poll deterministically until the token sweep has run (or the budget elapses).
+        // The sweep deletes hash-ancient — when it's gone, sweep 2 has executed.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            await using var poll = _fx.CreateContext();
+            if (!await poll.RefreshTokens.AsNoTracking().AnyAsync(t => t.TokenHash == "hash-ancient"))
+            {
+                break;
+            }
+            await Task.Delay(50);
+        }
+
         await svc.StopAsync(CancellationToken.None);
 
-        // Token sweep ran despite clip sweep throwing on storage resolution.
         await using var verify = _fx.CreateContext();
         (await verify.RefreshTokens.AsNoTracking().AnyAsync(t => t.TokenHash == "hash-ancient"))
             .Should().BeFalse("the refresh-token sweep must run even when the clip sweep fails");
@@ -257,11 +288,11 @@ public class MaintenanceHostedServiceIntegrationTests
             await db.SaveChangesAsync();
         }
 
-        var (svc, scope, _, _) = Build(
+        await using var harness = Build(
             new MaintenanceOptions { RefreshTokenRetention = TimeSpan.FromDays(30) },
             now);
 
-        await svc.SweepExpiredRefreshTokensAsync(scope, CancellationToken.None);
+        await harness.Service.SweepExpiredRefreshTokensAsync(harness.Scope, CancellationToken.None);
 
         await using var verify = _fx.CreateContext();
         var hashes = await verify.RefreshTokens.AsNoTracking().Select(t => t.TokenHash).ToListAsync();

--- a/server/tests/GankedTV.Api.Tests/Services/Maintenance/ClipBlobCleanupTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Maintenance/ClipBlobCleanupTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Maintenance;
+using GankedTV.Api.Services.ObjectStorage;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Services.Maintenance;
+
+public class ClipBlobCleanupTests
+{
+    private static readonly MinioOptions Buckets = new()
+    {
+        ClipsBucket = "clips",
+        ThumbnailsBucket = "thumbnails",
+    };
+
+    private static Clip MakeClip(string videoKey = "v.mp4", string? thumbnailKey = "t.jpg") => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = "title",
+        VideoKey = videoKey,
+        ThumbnailKey = thumbnailKey,
+    };
+
+    [Fact]
+    public async Task DeletesBothObjects_WhenThumbnailPresent()
+    {
+        var storage = Substitute.For<IObjectStorageService>();
+        var clip = MakeClip();
+
+        await ClipBlobCleanup.TryDeleteAsync(storage, Buckets, clip, NullLogger.Instance, CancellationToken.None);
+
+        await storage.Received(1).DeleteObjectAsync("clips", "v.mp4", Arg.Any<CancellationToken>());
+        await storage.Received(1).DeleteObjectAsync("thumbnails", "t.jpg", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SkipsThumbnail_WhenKeyIsNull()
+    {
+        var storage = Substitute.For<IObjectStorageService>();
+        var clip = MakeClip(thumbnailKey: null);
+
+        await ClipBlobCleanup.TryDeleteAsync(storage, Buckets, clip, NullLogger.Instance, CancellationToken.None);
+
+        await storage.Received(1).DeleteObjectAsync("clips", "v.mp4", Arg.Any<CancellationToken>());
+        await storage.DidNotReceive().DeleteObjectAsync("thumbnails", Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task VideoFailure_DoesNotSkipThumbnail()
+    {
+        var storage = Substitute.For<IObjectStorageService>();
+        storage.DeleteObjectAsync("clips", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => Task.FromException(new InvalidOperationException("s3 down")));
+
+        var logger = Substitute.For<ILogger>();
+        var clip = MakeClip();
+
+        await ClipBlobCleanup.TryDeleteAsync(storage, Buckets, clip, logger, CancellationToken.None);
+
+        await storage.Received(1).DeleteObjectAsync("thumbnails", "t.jpg", Arg.Any<CancellationToken>());
+        logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<InvalidOperationException>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task ThumbnailFailure_LogsWarning()
+    {
+        var storage = Substitute.For<IObjectStorageService>();
+        storage.DeleteObjectAsync("thumbnails", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => Task.FromException(new InvalidOperationException("s3 down")));
+
+        var logger = Substitute.For<ILogger>();
+        var clip = MakeClip();
+
+        await ClipBlobCleanup.TryDeleteAsync(storage, Buckets, clip, logger, CancellationToken.None);
+
+        logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<InvalidOperationException>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task BothSucceed_NoWarnings()
+    {
+        var storage = Substitute.For<IObjectStorageService>();
+        var logger = Substitute.For<ILogger>();
+        var clip = MakeClip();
+
+        await ClipBlobCleanup.TryDeleteAsync(storage, Buckets, clip, logger, CancellationToken.None);
+
+        logger.DidNotReceive().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Maintenance/MaintenanceHostedServiceTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Maintenance/MaintenanceHostedServiceTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using GankedTV.Api.Services.Maintenance;
+using GankedTV.Api.Services.ObjectStorage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Services.Maintenance;
+
+public class MaintenanceHostedServiceTests
+{
+    private static MaintenanceHostedService Build(
+        IServiceScopeFactory scopeFactory,
+        MaintenanceOptions options)
+    {
+        var optsMonitor = Substitute.For<IOptionsMonitor<MaintenanceOptions>>();
+        optsMonitor.CurrentValue.Returns(options);
+        var minioMonitor = Substitute.For<IOptionsMonitor<MinioOptions>>();
+        minioMonitor.CurrentValue.Returns(new MinioOptions { ClipsBucket = "clips", ThumbnailsBucket = "thumbnails" });
+
+        return new MaintenanceHostedService(
+            scopeFactory,
+            optsMonitor,
+            minioMonitor,
+            TimeProvider.System,
+            NullLogger<MaintenanceHostedService>.Instance);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisabledOption_ReturnsImmediately()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        var svc = Build(scopeFactory, new MaintenanceOptions { Enabled = false });
+
+        await svc.StartAsync(CancellationToken.None);
+        // BackgroundService.StopAsync waits for ExecuteAsync to finish; with Enabled=false it
+        // exits the loop immediately.
+        await svc.StopAsync(CancellationToken.None);
+
+        scopeFactory.DidNotReceive().CreateScope();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancellationDuringWait_ExitsCleanly()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        // Long interval so the timer doesn't fire before we cancel.
+        var svc = Build(scopeFactory, new MaintenanceOptions
+        {
+            Enabled = true,
+            SweepInterval = TimeSpan.FromHours(1),
+        });
+
+        // Start with a dummy scope to avoid NRE on the immediate-startup tick.
+        var scope = Substitute.For<IServiceScope>();
+        var sp = Substitute.For<IServiceProvider>();
+        scope.ServiceProvider.Returns(sp);
+        // Without a real DbContext registered, the immediate sweep will throw — caught and logged.
+        scopeFactory.CreateScope().Returns(scope);
+
+        using var cts = new CancellationTokenSource();
+        await svc.StartAsync(cts.Token);
+        cts.Cancel();
+        // StopAsync should observe cancellation and return without throwing.
+        var act = async () => await svc.StopAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/TestSupport/FakeClock.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/FakeClock.cs
@@ -2,11 +2,28 @@ namespace GankedTV.Api.Tests.TestSupport;
 
 // Minimal frozen clock for tests. Returns the same UTC instant on every call until Set is called.
 // Avoids pulling in Microsoft.Extensions.TimeProvider.Testing for what is a one-method need.
+//
+// Thread-safe: the hosted-service tests read the clock from a thread-pool worker while the test
+// body may call Set on its own thread. DateTimeOffset is wider than 8 bytes, so unsynchronized
+// reads can tear; a small lock keeps reads/writes atomic.
 public sealed class FakeClock(DateTimeOffset start) : TimeProvider
 {
+    private readonly object _sync = new();
     private DateTimeOffset _now = start;
 
-    public override DateTimeOffset GetUtcNow() => _now;
+    public override DateTimeOffset GetUtcNow()
+    {
+        lock (_sync)
+        {
+            return _now;
+        }
+    }
 
-    public void Set(DateTimeOffset now) => _now = now;
+    public void Set(DateTimeOffset now)
+    {
+        lock (_sync)
+        {
+            _now = now;
+        }
+    }
 }

--- a/server/tests/GankedTV.Api.Tests/TestSupport/FakeClock.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/FakeClock.cs
@@ -1,0 +1,12 @@
+namespace GankedTV.Api.Tests.TestSupport;
+
+// Minimal frozen clock for tests. Returns the same UTC instant on every call until Set is called.
+// Avoids pulling in Microsoft.Extensions.TimeProvider.Testing for what is a one-method need.
+public sealed class FakeClock(DateTimeOffset start) : TimeProvider
+{
+    private DateTimeOffset _now = start;
+
+    public override DateTimeOffset GetUtcNow() => _now;
+
+    public void Set(DateTimeOffset now) => _now = now;
+}


### PR DESCRIPTION
## Summary

Adds a periodic `MaintenanceHostedService` that sweeps orphaned `draft` clips (plus their MinIO video/thumbnail objects) and prunes long-expired `refresh_tokens` rows. Bundled with a refresh-token replay-detection patch that closes the `RotateAsync` reuse-detection TODO — same branch because the scope is small and the work is naturally co-located.

## What's here

**Orphan clip sweep** ([server/src/GankedTV.Api/Services/Maintenance/](server/src/GankedTV.Api/Services/Maintenance/))
- `MaintenanceHostedService` (`BackgroundService` + `PeriodicTimer`, default 15-min cadence). Two independent sweeps per tick, each in its own `IServiceScope` and `try/catch` so one failing cannot starve the other.
- `ClipBlobCleanup.TryDeleteAsync` extracted from `DELETE /clips/{id}` so the endpoint and the reaper share one definition of "best-effort delete this clip's blobs".
- Batch cap (`ClipBatchSize`, default 1000) with a `+1` peek so a backlog logs "remainder will be picked up next tick" instead of OOMing.
- Partial index `idx_clips_draft_created_at` on `(status, created_at) WHERE status = 'draft'` — drives the sweep query and stays tiny because only a transient minority of rows are ever `draft`.

**Refresh-token replay detection** ([RefreshTokenService.cs](server/src/GankedTV.Api/Auth/Tokens/RefreshTokenService.cs))
- New `family_id` column on `refresh_tokens`, backfilled `gen_random_uuid()` per row so legacy tokens become single-member families (a single replay can't blast across users).
- `IssueAsync` mints a new family; `RotateAsync` copies the family onto the rotated child.
- On the CAS-miss path, presenting an already-revoked token now bulk-revokes every live token in that family (RFC 6819 §5.2.2.3). 30 s grace window prevents legitimate multi-tab refresh races from tripping family revocation.
- Periodic sweep of `refresh_tokens` rows expired more than 30 days ago (configurable) lives in the same hosted service.

**Configuration**
- `Maintenance` section in `appsettings.json` with env-var overrides (`MAINTENANCE_ENABLED`, `MAINTENANCE_SWEEP_INTERVAL_MINUTES`, `MAINTENANCE_CLIP_THRESHOLD_HOURS`, `MAINTENANCE_REFRESH_TOKEN_RETENTION_DAYS`, `MAINTENANCE_CLIP_BATCH_SIZE`). All `.ValidateOnStart`-gated.

**Tests** — 18 new tests across unit + Postgres-backed integration. 303/303 pass; coverage 93.89% line / 85.1% branch (above the 85/85 gate).

Closes #58

## How to test manually

```bash
# Build, run full suite, gate coverage
dotnet build server
dotnet test server /p:CollectCoverage=true /p:Threshold=85%2C85

# Apply the new migrations locally
cd server && dotnet ef database update --project src/GankedTV.Api && cd -

# Orphan-clip sweep — spin up infra, run API with aggressive sweep cadence, leak a draft
make up
MAINTENANCE_CLIP_THRESHOLD_HOURS=1 \
MAINTENANCE_SWEEP_INTERVAL_MINUTES=1 \
dotnet watch --project server/src/GankedTV.Api
# In another terminal: POST /clips, do NOT call /complete.
# Backdate the row in psql so the sweep picks it up:
#   UPDATE clips SET created_at = now() - interval '2 hours' WHERE status = 'draft';
# Watch logs for "Swept N orphaned draft clips" and verify the row + MinIO object are gone.

# Refresh-token replay detection
# 1. Login → get refresh token A.
# 2. POST /auth/refresh with A → get B (A is now revoked).
# 3. Wait >30 s (past the grace window), POST /auth/refresh with A again →
#    expect 401 and server log "Refresh token replay detected, revoked family <guid>".
# 4. POST /auth/refresh with B → expect 401 (B was revoked as part of the family).
```

## Checklist

- [ ] Verified manually
- [ ] Migrations applied cleanly against a non-empty `refresh_tokens` table (per-row `gen_random_uuid()` backfill)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic maintenance service that periodically cleans up expired refresh tokens and orphaned draft clips to reclaim storage.
  * Enhanced refresh token security with automatic revocation of all tokens from a login session if token reuse is detected, protecting against compromised credentials.

* **Configuration**
  * New maintenance settings available via environment variables to control cleanup frequency, retention thresholds, and batch sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->