### PR TITLE
Add manual email/password registration alongside OAuth - Upgrade PostgreSQL 16 → 18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,14 @@ make hooks                    # One-time: install pre-push hook via core.hooksPa
 ```
 Hook lives at `.githooks/pre-push` and mirrors CI, scoped to changed top-level dirs (`server/` or `web/`). Bypass with `PREPUSH_SKIP=1 git push` or `git push --no-verify`.
 
+### CI mirror (run all CI checks locally)
+```bash
+make ci                       # Runs server + web CI checks (format, build, test+coverage)
+make ci-server                # Server-only subset
+make ci-web                   # Web-only subset
+```
+Mirrors `.github/workflows/server.yml` and `.github/workflows/web.yml` step-for-step. Pre-push hook stays separate — it scopes to changed dirs; `make ci` is the full matrix.
+
 ### Server (from repository root)
 ```bash
 dotnet build server           # Build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down clean logs server server-build server-test migrate migrate-add seed web web-install web-build web-test web-lint dev-all hooks
+.PHONY: up down clean logs server server-build server-test migrate migrate-add seed web web-install web-build web-test web-lint dev-all hooks ci ci-server ci-web
 
 # Infrastructure
 up:
@@ -64,6 +64,26 @@ dev-all: up
 	@trap 'kill 0' EXIT; \
 	dotnet watch --project server/src/GankedTV.Api & \
 	cd web && bun dev
+
+# CI mirror: runs the same checks the GitHub workflows run, in verify-only mode.
+# Mirrors `.github/workflows/server.yml` and `.github/workflows/web.yml` step-for-step
+# so contributors can reproduce CI locally with one command.
+#
+# Pre-push hook is intentionally NOT wired through here — it scopes to changed dirs
+# (server/ vs web/), `make ci` runs the full matrix. Use sub-targets for partial runs.
+ci: ci-server ci-web
+
+ci-server:
+	cd server && dotnet format --verify-no-changes
+	cd server && dotnet build --configuration Release
+	cd server && dotnet test --configuration Release /p:CollectCoverage=true /p:Threshold=85%2C85
+
+ci-web:
+	cd web && bun install --frozen-lockfile
+	cd web && bun run format:check
+	cd web && bun run lint:check
+	cd web && bun run build
+	cd web && bun run test:coverage
 
 # Git hooks — point git at the tracked .githooks/ directory.
 hooks:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ make hooks
 
 This points git at `.githooks/` (via `core.hooksPath`). On `git push`, the hook runs the same checks CI runs, scoped to whichever top-level area changed (`server/` or `web/`). Bypass with `PREPUSH_SKIP=1 git push` or `git push --no-verify` when truly needed.
 
+To run the full CI matrix manually (format + build + test + coverage on both halves):
+
+```bash
+make ci          # both halves
+make ci-server   # server only
+make ci-web      # web only
+```
+
+### Seeded test account
+
+`make seed` creates a known test user so contributors can sign in immediately on a fresh DB without configuring OAuth credentials:
+
+| Field    | Value                  |
+|----------|------------------------|
+| Email    | `seeduser@dev.local`   |
+| Password | `testpass123!`         |
+
+Use these credentials at `http://localhost:5173/login` (or `POST /auth/login` with `{ email, password }`).
+
 ## Docker
 
 ### Start Infrastructure

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,15 @@ services:
       # Pin PGDATA to a subdir so the data path is stable across major-version
       # bumps (the upstream default changes per major) and avoids PG's refusal
       # to init into a non-empty mount root.
+      #
+      # MIGRATION NOTE: existing developers upgrading from the pre-PG18 layout
+      # have data at the volume root (`/var/lib/postgresql/data`), not the new
+      # `/pgdata` subdir — Postgres will treat the new path as empty and re-init
+      # a fresh cluster, leaving the old files orphaned. Local seed data is
+      # throwaway, so the canonical fix is `make clean && make up && make
+      # migrate && make seed`. If you have local data worth keeping, exec into
+      # the running container and `mv /var/lib/postgresql/data/{base,pg_*,*}
+      # /var/lib/postgresql/data/pgdata/` before restarting.
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,12 +1,16 @@
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     ports:
       - "5435:5432"
     environment:
       POSTGRES_DB: gankedtv
       POSTGRES_USER: gankedtv
       POSTGRES_PASSWORD: gankedtv_dev
+      # Pin PGDATA to a subdir so the data path is stable across major-version
+      # bumps (the upstream default changes per major) and avoids PG's refusal
+      # to init into a non-empty mount root.
+      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/server/src/GankedTV.Api/Auth/AuthRateLimiting.cs
+++ b/server/src/GankedTV.Api/Auth/AuthRateLimiting.cs
@@ -1,0 +1,47 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace GankedTV.Api.Auth;
+
+// Centralises the rate-limit policy used by the credential auth endpoints
+// (/auth/login, /auth/register). Kept in its own service so the policy and
+// key-extraction logic stay inside the coverage denominator — Program.cs is
+// excluded from coverage per CLAUDE.md.
+public static class AuthRateLimiting
+{
+    public const string CredentialsPolicy = "auth-credentials";
+
+    // 5 attempts per minute per remote IP. Fixed window (not sliding) — keeps the bucket
+    // arithmetic in-process with no extra state. Returns 429 when exceeded; the SPA
+    // surfaces this inline below the form. No queueing — failed limit checks short-circuit.
+    public const int CredentialsPermitLimit = 5;
+    public static readonly TimeSpan CredentialsWindow = TimeSpan.FromMinutes(1);
+
+    public static RateLimiterOptions AddCredentialsPolicy(this RateLimiterOptions options)
+    {
+        options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+        options.AddPolicy<string>(CredentialsPolicy, ctx =>
+        {
+            // PROD CAVEAT: Connection.RemoteIpAddress is the immediate peer. Behind a
+            // reverse proxy or load balancer, that's the proxy itself — every request
+            // collapses into one bucket and the limiter becomes a global shared lane.
+            // Wire `app.UseForwardedHeaders(ForwardedHeaders.XForwardedFor)` (with a
+            // KnownProxies / KnownNetworks allowlist so client-supplied X-Forwarded-For
+            // can't spoof the bucket) before exposing this beyond localhost.
+            //
+            // Falling back to a stable bucket when no remote IP is observable (test rigs,
+            // unrecognised proxies). Without a fallback, those callers would partition
+            // by null and bypass the limit entirely.
+            var key = ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+            {
+                AutoReplenishment = true,
+                PermitLimit = CredentialsPermitLimit,
+                Window = CredentialsWindow,
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            });
+        });
+        return options;
+    }
+}

--- a/server/src/GankedTV.Api/Auth/CredentialAuthService.cs
+++ b/server/src/GankedTV.Api/Auth/CredentialAuthService.cs
@@ -1,0 +1,229 @@
+using System.Net.Mail;
+using GankedTV.Api.Auth.Passwords;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace GankedTV.Api.Auth;
+
+// Credential-flow counterpart to UserUpsertService (which handles the OAuth side).
+// Splitting register/login/set-password into its own service keeps endpoint handlers
+// thin and makes the policy/race-handling logic directly unit-testable.
+public sealed class CredentialAuthService
+{
+    private const int MaxInsertRetries = 3;
+    private const string UsernameIndex = "idx_users_username";
+    private const string EmailIndex = "idx_users_email";
+
+    // Sentinel hash for the no-user / no-password fallback in TryLoginAsync, used to
+    // pay the Argon2 cost regardless of whether the email exists — without it, attackers
+    // can probe email existence by timing the response.
+    //
+    // Cached statically (process-wide), not per-instance: CredentialAuthService is
+    // registered scoped, so a per-instance constructor hash would burn ~190 ms of CPU on
+    // every credential request, doubling Argon2 work on every login/register. The hasher
+    // is a DI singleton, so a single sentinel survives the entire process lifetime.
+    private static string? s_sentinelHash;
+
+    private readonly GankedTvDbContext _db;
+    private readonly IPasswordHasher _hasher;
+    private readonly TimeProvider _clock;
+
+    public CredentialAuthService(
+        GankedTvDbContext db,
+        IPasswordHasher hasher,
+        TimeProvider? clock = null)
+    {
+        _db = db;
+        _hasher = hasher;
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    private string SentinelHash
+    {
+        get
+        {
+            // First reader wins. A race here just means two threads each compute one
+            // ~190 ms hash and one writer's value is discarded — harmless: either hash
+            // is a valid never-matches sentinel, and the race only fires once per process.
+            var current = s_sentinelHash;
+            if (current is not null) return current;
+            var fresh = _hasher.Hash("sentinel-do-not-match-anything-12345!");
+            return Interlocked.CompareExchange(ref s_sentinelHash, fresh, null) ?? fresh;
+        }
+    }
+
+    public async Task<RegisterResult> TryRegisterAsync(
+        string email,
+        string username,
+        string password,
+        CancellationToken ct = default)
+    {
+        var normalisedEmail = NormaliseEmail(email);
+        if (normalisedEmail is null)
+        {
+            return RegisterResult.InvalidEmail;
+        }
+
+        var policy = PasswordPolicy.Validate(password, normalisedEmail, username);
+        if (!policy.IsValid)
+        {
+            return RegisterResult.InvalidPassword(policy.Error!);
+        }
+
+        // Skip the optimistic pre-check on email uniqueness and let the unique-index catch
+        // below be the canonical handler — keeps a single code path for both serial and
+        // racing duplicates. The cost on duplicate-email registrations is one extra Argon2
+        // hash (~190ms), which is acceptable: /auth/register is rate-limited per IP, and
+        // duplicate-email submissions are rare in practice.
+        var hash = _hasher.Hash(password);
+        var algo = _hasher.Algorithm;
+
+        for (var attempt = 0; attempt < MaxInsertRetries; attempt++)
+        {
+            var slug = await UsernameGenerator.GenerateUniqueAsync(username, _db.Users, ct);
+            var now = _clock.GetUtcNow();
+            var user = new User
+            {
+                Username = slug,
+                Email = normalisedEmail,
+                PasswordHash = hash,
+                PasswordAlgo = algo,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            _db.Users.Add(user);
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+                return RegisterResult.Success(user);
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex, EmailIndex))
+            {
+                // A concurrent registration committed the same email between our check and
+                // this insert. Detach and bail with the same 409 the serial path produces.
+                _db.Entry(user).State = EntityState.Detached;
+                return RegisterResult.EmailTaken;
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex, UsernameIndex))
+            {
+                // Lost the username race. Detach and try again with a fresh suffixed slug.
+                _db.Entry(user).State = EntityState.Detached;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Failed to insert user after {MaxInsertRetries} username retries.");
+    }
+
+    public async Task<User?> TryLoginAsync(
+        string email,
+        string password,
+        CancellationToken ct = default)
+    {
+        var normalisedEmail = NormaliseEmail(email);
+        if (normalisedEmail is null)
+        {
+            // Still pay the Argon2 cost on bad-format emails so timing doesn't leak whether
+            // the address is well-formed.
+            _ = _hasher.Verify(password, SentinelHash);
+            return null;
+        }
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Email == normalisedEmail, ct);
+        if (user is null || string.IsNullOrEmpty(user.PasswordHash))
+        {
+            _ = _hasher.Verify(password, SentinelHash);
+            return null;
+        }
+
+        if (!_hasher.Verify(password, user.PasswordHash))
+        {
+            return null;
+        }
+
+        return user;
+    }
+
+    public async Task<SetPasswordResult> SetPasswordAsync(
+        Guid userId,
+        string? currentPassword,
+        string newPassword,
+        CancellationToken ct = default)
+    {
+        var user = await _db.Users.FindAsync(new object[] { userId }, ct);
+        if (user is null)
+        {
+            return SetPasswordResult.UserNotFound;
+        }
+
+        var policy = PasswordPolicy.Validate(newPassword, user.Email, user.Username);
+        if (!policy.IsValid)
+        {
+            return SetPasswordResult.InvalidPassword(policy.Error!);
+        }
+
+        if (!string.IsNullOrEmpty(user.PasswordHash))
+        {
+            // Existing password on file → require and verify currentPassword.
+            if (string.IsNullOrEmpty(currentPassword)
+                || !_hasher.Verify(currentPassword, user.PasswordHash))
+            {
+                return SetPasswordResult.WrongCurrentPassword;
+            }
+        }
+        // No existing password (OAuth-only user attaching one) → no currentPassword needed.
+
+        user.PasswordHash = _hasher.Hash(newPassword);
+        user.PasswordAlgo = _hasher.Algorithm;
+        user.UpdatedAt = _clock.GetUtcNow();
+        await _db.SaveChangesAsync(ct);
+        return SetPasswordResult.Ok;
+    }
+
+    private static string? NormaliseEmail(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+        // MailAddress is the same parser DataAnnotations [EmailAddress] uses.
+        if (!MailAddress.TryCreate(raw.Trim(), out var addr))
+        {
+            return null;
+        }
+        return addr.Address.ToLowerInvariant();
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex, string indexName) =>
+        ex.InnerException is PostgresException pg
+        && pg.SqlState == PostgresErrorCodes.UniqueViolation
+        && string.Equals(pg.ConstraintName, indexName, StringComparison.Ordinal);
+}
+
+public abstract record RegisterResult
+{
+    public static readonly RegisterResult InvalidEmail = new InvalidEmailResult();
+    public static readonly RegisterResult EmailTaken = new EmailTakenResult();
+    public static RegisterResult InvalidPassword(string error) => new InvalidPasswordResult(error);
+    public static RegisterResult Success(User user) => new SuccessResult(user);
+
+    public sealed record SuccessResult(User User) : RegisterResult;
+    public sealed record InvalidEmailResult : RegisterResult;
+    public sealed record EmailTakenResult : RegisterResult;
+    public sealed record InvalidPasswordResult(string Error) : RegisterResult;
+}
+
+public abstract record SetPasswordResult
+{
+    public static readonly SetPasswordResult Ok = new OkResult();
+    public static readonly SetPasswordResult UserNotFound = new UserNotFoundResult();
+    public static readonly SetPasswordResult WrongCurrentPassword = new WrongCurrentPasswordResult();
+    public static SetPasswordResult InvalidPassword(string error) => new InvalidPasswordResult(error);
+
+    public sealed record OkResult : SetPasswordResult;
+    public sealed record UserNotFoundResult : SetPasswordResult;
+    public sealed record WrongCurrentPasswordResult : SetPasswordResult;
+    public sealed record InvalidPasswordResult(string Error) : SetPasswordResult;
+}

--- a/server/src/GankedTV.Api/Auth/Passwords/Argon2idPasswordHasher.cs
+++ b/server/src/GankedTV.Api/Auth/Passwords/Argon2idPasswordHasher.cs
@@ -1,0 +1,134 @@
+using System.Security.Cryptography;
+using System.Text;
+using Konscious.Security.Cryptography;
+
+namespace GankedTV.Api.Auth.Passwords;
+
+// Password rules and tuning live here so the hasher is the single source of
+// truth. OWASP Password Storage Cheat Sheet (2024) recommends Argon2id with
+// m=19456 KiB, t=2, p=1 as a sane minimum — that's what we use.
+//
+// Encoding: PHC string format
+//   $argon2id$v=19$m=19456,t=2,p=1$<salt_b64>$<hash_b64>
+// Storing the parameters alongside the hash lets us rotate cost factors later
+// without breaking existing rows: Verify reads m/t/p from the stored string.
+public sealed class Argon2idPasswordHasher : IPasswordHasher
+{
+    private const string AlgorithmName = "argon2id";
+    private const int Version = 19;
+    private const int DefaultMemoryKb = 19_456;
+    private const int DefaultIterations = 2;
+    private const int DefaultParallelism = 1;
+    private const int SaltBytes = 16;
+    private const int HashBytes = 32;
+
+    public string Algorithm => AlgorithmName;
+
+    public string Hash(string password)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password);
+
+        var salt = RandomNumberGenerator.GetBytes(SaltBytes);
+        var hash = ComputeHash(password, salt, DefaultMemoryKb, DefaultIterations, DefaultParallelism);
+        return Encode(salt, hash, DefaultMemoryKb, DefaultIterations, DefaultParallelism);
+    }
+
+    public bool Verify(string password, string encoded)
+    {
+        if (string.IsNullOrEmpty(password) || string.IsNullOrEmpty(encoded))
+        {
+            return false;
+        }
+
+        if (!TryDecode(encoded, out var parsed))
+        {
+            return false;
+        }
+
+        var computed = ComputeHash(password, parsed.Salt, parsed.MemoryKb, parsed.Iterations, parsed.Parallelism);
+        return CryptographicOperations.FixedTimeEquals(computed, parsed.Hash);
+    }
+
+    private static byte[] ComputeHash(string password, byte[] salt, int memoryKb, int iterations, int parallelism)
+    {
+        using var argon = new Argon2id(Encoding.UTF8.GetBytes(password))
+        {
+            Salt = salt,
+            DegreeOfParallelism = parallelism,
+            Iterations = iterations,
+            MemorySize = memoryKb,
+        };
+        return argon.GetBytes(HashBytes);
+    }
+
+    private static string Encode(byte[] salt, byte[] hash, int memoryKb, int iterations, int parallelism)
+    {
+        return string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"$argon2id$v={Version}$m={memoryKb},t={iterations},p={parallelism}${Convert.ToBase64String(salt)}${Convert.ToBase64String(hash)}");
+    }
+
+    private readonly record struct ParsedHash(byte[] Salt, byte[] Hash, int MemoryKb, int Iterations, int Parallelism);
+
+    private static bool TryDecode(string encoded, out ParsedHash parsed)
+    {
+        parsed = default;
+        var parts = encoded.Split('$');
+        // Expected: ["", "argon2id", "v=19", "m=19456,t=2,p=1", "<salt>", "<hash>"]
+        if (parts.Length != 6 || parts[1] != AlgorithmName)
+        {
+            return false;
+        }
+
+        if (!parts[2].StartsWith("v=", StringComparison.Ordinal)
+            || !int.TryParse(parts[2].AsSpan(2), out var version)
+            || version != Version)
+        {
+            return false;
+        }
+
+        if (!TryParseParams(parts[3], out var memoryKb, out var iterations, out var parallelism))
+        {
+            return false;
+        }
+
+        try
+        {
+            var salt = Convert.FromBase64String(parts[4]);
+            var hash = Convert.FromBase64String(parts[5]);
+            parsed = new ParsedHash(salt, hash, memoryKb, iterations, parallelism);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryParseParams(string raw, out int memoryKb, out int iterations, out int parallelism)
+    {
+        memoryKb = iterations = parallelism = 0;
+        foreach (var part in raw.Split(','))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0)
+            {
+                return false;
+            }
+            var key = part[..eq];
+            var value = part.AsSpan(eq + 1);
+            if (!int.TryParse(value, out var n))
+            {
+                return false;
+            }
+            switch (key)
+            {
+                case "m": memoryKb = n; break;
+                case "t": iterations = n; break;
+                case "p": parallelism = n; break;
+                default: return false;
+            }
+        }
+        return memoryKb > 0 && iterations > 0 && parallelism > 0;
+    }
+}

--- a/server/src/GankedTV.Api/Auth/Passwords/IPasswordHasher.cs
+++ b/server/src/GankedTV.Api/Auth/Passwords/IPasswordHasher.cs
@@ -1,0 +1,10 @@
+namespace GankedTV.Api.Auth.Passwords;
+
+public interface IPasswordHasher
+{
+    string Algorithm { get; }
+
+    string Hash(string password);
+
+    bool Verify(string password, string encoded);
+}

--- a/server/src/GankedTV.Api/Auth/Passwords/PasswordPolicy.cs
+++ b/server/src/GankedTV.Api/Auth/Passwords/PasswordPolicy.cs
@@ -23,8 +23,10 @@ public static class PasswordPolicy
 
     public static PasswordValidationResult Validate(string password, string? email, string? username)
     {
-        if (string.IsNullOrEmpty(password))
+        if (string.IsNullOrWhiteSpace(password))
         {
+            // Whitespace-only is treated as missing — a user typing 12 spaces should not
+            // sail past the length floor.
             return PasswordValidationResult.Invalid("Password is required.");
         }
 

--- a/server/src/GankedTV.Api/Auth/Passwords/PasswordPolicy.cs
+++ b/server/src/GankedTV.Api/Auth/Passwords/PasswordPolicy.cs
@@ -1,0 +1,61 @@
+namespace GankedTV.Api.Auth.Passwords;
+
+// Centralised password rules. Kept simple on purpose:
+//   * 12 char minimum (NIST SP 800-63B floor for memorised secrets is 8;
+//     we bump it because there's no email-verification or breach-API check yet).
+//   * Reject if equal to email or username (case-insensitive).
+//   * Reject a tiny embedded list of obvious passwords. We deliberately do not
+//     ship the full SecLists top-1M — that's a future enhancement (HIBP API
+//     or k-anonymity check). The list here catches the laziest attempts.
+public static class PasswordPolicy
+{
+    public const int MinLength = 12;
+
+    private static readonly HashSet<string> CommonPasswords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "password", "password1", "password123", "passw0rd", "p@ssw0rd",
+        "qwerty", "qwerty123", "qwertyuiop",
+        "letmein", "welcome", "welcome1", "welcome123",
+        "admin", "administrator", "root", "toor",
+        "iloveyou", "trustno1", "monkey", "dragon", "master", "shadow",
+        "123456789012", "111111111111", "abc123abc123", "test1234test", "changeme123",
+    };
+
+    public static PasswordValidationResult Validate(string password, string? email, string? username)
+    {
+        if (string.IsNullOrEmpty(password))
+        {
+            return PasswordValidationResult.Invalid("Password is required.");
+        }
+
+        if (password.Length < MinLength)
+        {
+            return PasswordValidationResult.Invalid($"Password must be at least {MinLength} characters.");
+        }
+
+        if (!string.IsNullOrEmpty(email)
+            && string.Equals(password, email, StringComparison.OrdinalIgnoreCase))
+        {
+            return PasswordValidationResult.Invalid("Password must not equal the email address.");
+        }
+
+        if (!string.IsNullOrEmpty(username)
+            && string.Equals(password, username, StringComparison.OrdinalIgnoreCase))
+        {
+            return PasswordValidationResult.Invalid("Password must not equal the username.");
+        }
+
+        if (CommonPasswords.Contains(password))
+        {
+            return PasswordValidationResult.Invalid("Password is too common.");
+        }
+
+        return PasswordValidationResult.Valid;
+    }
+}
+
+public readonly record struct PasswordValidationResult(bool IsValid, string? Error)
+{
+    public static readonly PasswordValidationResult Valid = new(true, null);
+    public static PasswordValidationResult Invalid(string error) => new(false, error);
+}

--- a/server/src/GankedTV.Api/Contracts/Auth/LoginRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/LoginRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GankedTV.Api.Contracts.Auth;
+
+public sealed record LoginRequest(
+    [property: Required, EmailAddress, StringLength(255)]
+    string Email,
+    [property: Required, StringLength(128, MinimumLength = 1)]
+    string Password);

--- a/server/src/GankedTV.Api/Contracts/Auth/RegisterRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/RegisterRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GankedTV.Api.Contracts.Auth;
+
+public sealed record RegisterRequest(
+    [property: Required, EmailAddress, StringLength(255)]
+    string Email,
+    [property: Required, StringLength(30, MinimumLength = 1)]
+    string Username,
+    [property: Required, StringLength(128, MinimumLength = 1)]
+    string Password);

--- a/server/src/GankedTV.Api/Contracts/Auth/RegisterRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/RegisterRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using GankedTV.Api.Auth.Passwords;
 
 namespace GankedTV.Api.Contracts.Auth;
 
@@ -7,5 +8,9 @@ public sealed record RegisterRequest(
     string Email,
     [property: Required, StringLength(30, MinimumLength = 1)]
     string Username,
-    [property: Required, StringLength(128, MinimumLength = 1)]
+    // Floor lifted to PasswordPolicy.MinLength so blatantly-too-short passwords get
+    // rejected at the validation filter (faster feedback to the SPA) instead of
+    // sliding through to the policy check. PasswordPolicy is still the source of
+    // truth for everything beyond raw length (common-list, equality with email/username).
+    [property: Required, StringLength(128, MinimumLength = PasswordPolicy.MinLength)]
     string Password);

--- a/server/src/GankedTV.Api/Contracts/Auth/SetPasswordRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/SetPasswordRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using GankedTV.Api.Auth.Passwords;
 
 namespace GankedTV.Api.Contracts.Auth;
 
@@ -8,5 +9,5 @@ public sealed record SetPasswordRequest(
     // without one (the OAuth login already proved control of the account).
     [property: StringLength(128)]
     string? CurrentPassword,
-    [property: Required, StringLength(128, MinimumLength = 1)]
+    [property: Required, StringLength(128, MinimumLength = PasswordPolicy.MinLength)]
     string NewPassword);

--- a/server/src/GankedTV.Api/Contracts/Auth/SetPasswordRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Auth/SetPasswordRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GankedTV.Api.Contracts.Auth;
+
+public sealed record SetPasswordRequest(
+    // Required only when the caller already has a password on file. The endpoint
+    // enforces that conditionally so OAuth-only users can attach a password
+    // without one (the OAuth login already proved control of the account).
+    [property: StringLength(128)]
+    string? CurrentPassword,
+    [property: Required, StringLength(128, MinimumLength = 1)]
+    string NewPassword);

--- a/server/src/GankedTV.Api/Contracts/Users/MeResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/MeResponse.cs
@@ -6,4 +6,8 @@ public sealed record MeResponse(
     string? Email,
     string? Bio,
     string? AvatarUrl,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    // True when the account has a password set (covers both password-registered and
+    // OAuth-then-attached accounts). The web settings view keys off this to decide
+    // whether to show "Set password" (first-time) or "Change password" (rotation) copy.
+    bool HasPassword);

--- a/server/src/GankedTV.Api/Contracts/Users/UserMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Users/UserMappings.cs
@@ -9,5 +9,6 @@ public static class UserMappings
         new(user.Id, user.Username, user.Bio, user.AvatarUrl, user.CreatedAt, clips);
 
     public static MeResponse ToMe(this User user) =>
-        new(user.Id, user.Username, user.Email, user.Bio, user.AvatarUrl, user.CreatedAt);
+        new(user.Id, user.Username, user.Email, user.Bio, user.AvatarUrl, user.CreatedAt,
+            HasPassword: !string.IsNullOrEmpty(user.PasswordHash));
 }

--- a/server/src/GankedTV.Api/Data/Entities/User.cs
+++ b/server/src/GankedTV.Api/Data/Entities/User.cs
@@ -9,6 +9,8 @@ public class User
     public string? Bio { get; set; }
     public string? DiscordId { get; set; }
     public string? GoogleId { get; set; }
+    public string? PasswordHash { get; set; }
+    public string? PasswordAlgo { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
 

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -25,6 +25,13 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             e.Property(u => u.GoogleId).HasMaxLength(50);
             e.Property(u => u.PasswordHash).HasMaxLength(255);
             e.Property(u => u.PasswordAlgo).HasMaxLength(32);
+            // Hash and algo must be set together. CredentialAuthService maintains this
+            // invariant by construction; the DB-level CHECK guards against manual UPDATEs
+            // or future bugs that would otherwise produce un-verifiable rows.
+            e.ToTable(t => t.HasCheckConstraint(
+                "ck_users_password_hash_algo_paired",
+                "(password_hash IS NULL AND password_algo IS NULL) "
+                + "OR (password_hash IS NOT NULL AND password_algo IS NOT NULL)"));
             e.Property(u => u.Bio).HasMaxLength(500);
             e.Property(u => u.CreatedAt).HasDefaultValueSql("now()");
             e.Property(u => u.UpdatedAt).HasDefaultValueSql("now()");

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -23,6 +23,8 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             e.Property(u => u.Email).HasMaxLength(255);
             e.Property(u => u.DiscordId).HasMaxLength(50);
             e.Property(u => u.GoogleId).HasMaxLength(50);
+            e.Property(u => u.PasswordHash).HasMaxLength(255);
+            e.Property(u => u.PasswordAlgo).HasMaxLength(32);
             e.Property(u => u.Bio).HasMaxLength(500);
             e.Property(u => u.CreatedAt).HasDefaultValueSql("now()");
             e.Property(u => u.UpdatedAt).HasDefaultValueSql("now()");

--- a/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.Designer.cs
@@ -422,7 +422,10 @@ namespace GankedTV.Api.Data.Migrations
                         .IsUnique()
                         .HasDatabaseName("idx_users_username");
 
-                    b.ToTable("users", (string)null);
+                    b.ToTable("users", null, t =>
+                        {
+                            t.HasCheckConstraint("ck_users_password_hash_algo_paired", "(password_hash IS NULL AND password_algo IS NULL) OR (password_hash IS NOT NULL AND password_algo IS NOT NULL)");
+                        });
                 });
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Clip", b =>

--- a/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430210106_AddUserPasswordCredentials")]
+    partial class AddUserPasswordCredentials
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserPasswordCredentials : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "password_algo",
+                table: "users",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "password_hash",
+                table: "users",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "password_algo",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "password_hash",
+                table: "users");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260430210106_AddUserPasswordCredentials.cs
@@ -23,11 +23,25 @@ namespace GankedTV.Api.Data.Migrations
                 type: "character varying(255)",
                 maxLength: 255,
                 nullable: true);
+
+            // Defence-in-depth: hash and algo must be set together. CredentialAuthService
+            // already maintains the invariant by construction, but a manual UPDATE or a
+            // future bug shouldn't be able to leave a row with a hash but no algo (or
+            // vice versa) — that would corrupt verification and silently lock users out.
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_users_password_hash_algo_paired",
+                table: "users",
+                sql: "(password_hash IS NULL AND password_algo IS NULL) "
+                    + "OR (password_hash IS NOT NULL AND password_algo IS NOT NULL)");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_users_password_hash_algo_paired",
+                table: "users");
+
             migrationBuilder.DropColumn(
                 name: "password_algo",
                 table: "users");

--- a/server/src/GankedTV.Api/Data/Migrations/GankedTvDbContextModelSnapshot.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/GankedTvDbContextModelSnapshot.cs
@@ -419,7 +419,10 @@ namespace GankedTV.Api.Data.Migrations
                         .IsUnique()
                         .HasDatabaseName("idx_users_username");
 
-                    b.ToTable("users", (string)null);
+                    b.ToTable("users", null, t =>
+                        {
+                            t.HasCheckConstraint("ck_users_password_hash_algo_paired", "(password_hash IS NULL AND password_algo IS NULL) OR (password_hash IS NOT NULL AND password_algo IS NOT NULL)");
+                        });
                 });
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Clip", b =>

--- a/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/AuthEndpoints.cs
@@ -1,3 +1,5 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using GankedTV.Api.Auth;
 using GankedTV.Api.Auth.Jwt;
 using GankedTV.Api.Auth.Providers;
@@ -26,6 +28,29 @@ public static class AuthEndpoints
             .Produces<TokenResponse>(StatusCodes.Status200OK)
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        app.MapPost("/auth/register", Register)
+            .WithValidation<RegisterRequest>()
+            .RequireRateLimiting(AuthRateLimiting.CredentialsPolicy)
+            .Produces<TokenResponse>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        app.MapPost("/auth/login", Login)
+            .WithValidation<LoginRequest>()
+            .RequireRateLimiting(AuthRateLimiting.CredentialsPolicy)
+            .Produces<TokenResponse>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        app.MapPost("/auth/password", SetPassword)
+            .RequireAuthorization()
+            .WithValidation<SetPasswordRequest>()
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
         return app;
     }
 
@@ -113,6 +138,99 @@ public static class AuthEndpoints
             location += $"&returnTo={Uri.EscapeDataString(returnTo)}";
         }
         return Results.Redirect(location);
+    }
+
+    // The `[FromBody]` parameters are nullable so a literal JSON `null` reaches the
+    // ValidationEndpointFilter (matching the Refresh handler's convention). The filter
+    // returns 400 InvalidBody for both nulls and validation failures, so the handler
+    // body can treat the request as effectively non-null.
+    private static async Task<IResult> Register(
+        [FromBody] RegisterRequest? req,
+        CredentialAuthService credentials,
+        IJwtService jwt,
+        IRefreshTokenService refreshTokens,
+        IOptions<JwtOptions> jwtOptions,
+        CancellationToken ct)
+    {
+        var result = await credentials.TryRegisterAsync(req!.Email, req.Username, req.Password, ct);
+        return result switch
+        {
+            RegisterResult.SuccessResult ok => await IssueTokenResponseAsync(ok.User, jwt, refreshTokens, jwtOptions, ct),
+            // 409 with a code the SPA can branch on to nudge users into the OAuth-then-attach
+            // flow. Account-takeover on a verified-email OAuth account would otherwise be
+            // possible without an email-verification step (deliberately deferred).
+            RegisterResult.EmailTakenResult => ProblemResults.Conflict(
+                "email_taken",
+                "An account with this email already exists. Sign in with your existing method, then attach a password from your profile."),
+            RegisterResult.InvalidPasswordResult bad => ProblemResults.BadRequest("weak_password", bad.Error),
+            // [EmailAddress] on the DTO catches malformed emails before the handler runs.
+            // Any non-success result that isn't email-taken / weak-password is therefore an
+            // invalid email — collapse into the same 400 instead of a separate switch arm.
+            _ => ProblemResults.BadRequest("invalid_email"),
+        };
+    }
+
+    private static async Task<IResult> Login(
+        [FromBody] LoginRequest? req,
+        CredentialAuthService credentials,
+        IJwtService jwt,
+        IRefreshTokenService refreshTokens,
+        IOptions<JwtOptions> jwtOptions,
+        CancellationToken ct)
+    {
+        var user = await credentials.TryLoginAsync(req!.Email, req.Password, ct);
+        if (user is null)
+        {
+            // Generic 401 so attackers can't distinguish "no such user", "no password set",
+            // and "wrong password". TryLoginAsync runs a constant-time-equivalent dummy
+            // verify in the missing-user / no-password paths to keep the timing flat.
+            return ProblemResults.Unauthorized("invalid_credentials");
+        }
+
+        return await IssueTokenResponseAsync(user, jwt, refreshTokens, jwtOptions, ct);
+    }
+
+    private static async Task<IResult> SetPassword(
+        [FromBody] SetPasswordRequest? req,
+        ClaimsPrincipal principal,
+        CredentialAuthService credentials,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        var result = await credentials.SetPasswordAsync(userId, req!.CurrentPassword, req.NewPassword, ct);
+        return result switch
+        {
+            SetPasswordResult.OkResult => Results.NoContent(),
+            SetPasswordResult.WrongCurrentPasswordResult => ProblemResults.BadRequest("wrong_current_password"),
+            SetPasswordResult.InvalidPasswordResult bad => ProblemResults.BadRequest("weak_password", bad.Error),
+            // JWT sub points at a user that no longer exists — same shape MeEndpoints uses
+            // for the analogous case. Any unhandled subtype falls through to the same 401.
+            _ => Results.Unauthorized(),
+        };
+    }
+
+    private static async Task<IResult> IssueTokenResponseAsync(
+        Data.Entities.User user,
+        IJwtService jwt,
+        IRefreshTokenService refreshTokens,
+        IOptions<JwtOptions> jwtOptions,
+        CancellationToken ct)
+    {
+        var token = jwt.Issue(user);
+        var refresh = await refreshTokens.IssueAsync(user.Id, ct);
+        return Results.Ok(new TokenResponse(token, refresh, jwtOptions.Value.ExpiryMinutes * 60));
+    }
+
+    private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
+    {
+        userId = default;
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out userId);
     }
 
     private static async Task<IResult> Refresh(

--- a/server/src/GankedTV.Api/GankedTV.Api.csproj
+++ b/server/src/GankedTV.Api/GankedTV.Api.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AWSSDK.S3" Version="4.0.21.2" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
+    <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -1,6 +1,7 @@
 using Amazon.S3;
 using GankedTV.Api.Auth;
 using GankedTV.Api.Auth.Jwt;
+using GankedTV.Api.Auth.Passwords;
 using GankedTV.Api.Auth.Providers;
 using GankedTV.Api.Auth.State;
 using GankedTV.Api.Auth.Tokens;
@@ -214,8 +215,12 @@ builder.Services.AddHttpClient(GoogleOAuthProvider.ProviderName, c =>
 builder.Services.AddSingleton<IJwtService, JwtService>();
 builder.Services.AddSingleton<IStateCookieService, StateCookieService>();
 builder.Services.AddSingleton<TimeProvider>(TimeProvider.System);
+builder.Services.AddSingleton<IPasswordHasher, Argon2idPasswordHasher>();
 builder.Services.AddScoped<IRefreshTokenService, RefreshTokenService>();
 builder.Services.AddScoped<UserUpsertService>();
+builder.Services.AddScoped<CredentialAuthService>();
+
+builder.Services.AddRateLimiter(opts => opts.AddCredentialsPolicy());
 
 builder.Services.AddSingleton<IOAuthProvider, DiscordOAuthProvider>();
 builder.Services.AddSingleton<IOAuthProvider, GoogleOAuthProvider>();
@@ -292,6 +297,7 @@ if (!app.Environment.IsDevelopment())
 app.UseCors(corsPolicy);
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
 
 app.MapAuthEndpoints();
 app.MapMeEndpoints();

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -1,3 +1,4 @@
+using GankedTV.Api.Auth.Passwords;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -13,12 +14,16 @@ public sealed class SeedCommand(
     GankedTvDbContext db,
     ILogger<SeedCommand> logger,
     TimeProvider clock,
-    IHostEnvironment env)
+    IHostEnvironment env,
+    IPasswordHasher hasher)
 {
     public const string FlagName = "--seed";
 
     public static readonly Guid SeedUserId = new("00000000-0000-0000-0000-00000000CAFE");
     public const string SeedUsername = "seeduser";
+    public const string SeedUserEmail = $"{SeedUsername}@dev.local";
+    // Documented in the README so contributors can hit /auth/login directly after `make seed`.
+    public const string SeedUserPassword = "testpass123!";
     public const int SeedClipCount = 10;
     private const int GameRotationCount = 5;
 
@@ -46,14 +51,26 @@ public sealed class SeedCommand(
             {
                 Id = SeedUserId,
                 Username = SeedUsername,
-                Email = $"{SeedUsername}@dev.local",
+                Email = SeedUserEmail,
                 Bio = "Seeded dev user.",
+                PasswordHash = hasher.Hash(SeedUserPassword),
+                PasswordAlgo = hasher.Algorithm,
                 CreatedAt = now,
                 UpdatedAt = now,
             };
             db.Users.Add(user);
             await db.SaveChangesAsync(ct);
             logger.LogInformation("Seed: created user {Username}", user.Username);
+        }
+        else if (string.IsNullOrEmpty(user.PasswordHash))
+        {
+            // Migrate older seed runs that created the user before passwords existed.
+            // Don't overwrite an existing password — a contributor may have rotated it via /auth/password.
+            user.PasswordHash = hasher.Hash(SeedUserPassword);
+            user.PasswordAlgo = hasher.Algorithm;
+            user.UpdatedAt = now;
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seed: attached default password to existing user {Username}", user.Username);
         }
 
         // Rotate seeded clips across the seeded games (Ids 1..GameRotationCount) so the

--- a/server/tests/GankedTV.Api.Tests/Auth/Argon2idPasswordHasherTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Auth/Argon2idPasswordHasherTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using GankedTV.Api.Auth.Passwords;
+
+namespace GankedTV.Api.Tests.Auth;
+
+public class Argon2idPasswordHasherTests
+{
+    private readonly Argon2idPasswordHasher _hasher = new();
+
+    [Fact]
+    public void Algorithm_IsArgon2id()
+    {
+        _hasher.Algorithm.Should().Be("argon2id");
+    }
+
+    [Fact]
+    public void Hash_VerifyRoundtrip_Succeeds()
+    {
+        var encoded = _hasher.Hash("correct-horse-battery-staple");
+        _hasher.Verify("correct-horse-battery-staple", encoded).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Verify_WithWrongPassword_ReturnsFalse()
+    {
+        var encoded = _hasher.Hash("correct-horse-battery-staple");
+        _hasher.Verify("wrong-password-12345", encoded).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Hash_RepeatedCalls_ProduceDifferentEncodingsButBothVerify()
+    {
+        var first = _hasher.Hash("super-secret-password");
+        var second = _hasher.Hash("super-secret-password");
+
+        // Distinct salts → distinct encoded strings, even for the same plaintext.
+        first.Should().NotBe(second);
+        _hasher.Verify("super-secret-password", first).Should().BeTrue();
+        _hasher.Verify("super-secret-password", second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Hash_EmittedFormat_IsPhcArgon2id()
+    {
+        var encoded = _hasher.Hash("hello-world-12345");
+        encoded.Should().StartWith("$argon2id$v=19$m=");
+        encoded.Split('$').Should().HaveCount(6);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-valid-phc-string")]
+    [InlineData("$argon2id$v=99$m=19456,t=2,p=1$abc$def")] // wrong version
+    [InlineData("$argon2id$v=19$badparams$abc$def")]
+    [InlineData("$argon2id$v=19$m=19456,t=2,p=1$!!!notbase64!!!$abc")]
+    [InlineData("$bcrypt$v=19$m=1,t=1,p=1$abc$def")] // wrong algo
+    public void Verify_WithMalformedEncoded_ReturnsFalse(string encoded)
+    {
+        _hasher.Verify("anything", encoded).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Verify_WithEmptyPassword_ReturnsFalse()
+    {
+        var encoded = _hasher.Hash("real-password");
+        _hasher.Verify("", encoded).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Hash_WithEmptyPassword_Throws()
+    {
+        Action act = () => _hasher.Hash("");
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Auth/PasswordPolicyTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Auth/PasswordPolicyTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using GankedTV.Api.Auth.Passwords;
+
+namespace GankedTV.Api.Tests.Auth;
+
+public class PasswordPolicyTests
+{
+    [Fact]
+    public void Validate_GoodPassword_IsValid()
+    {
+        var result = PasswordPolicy.Validate("correct-horse-battery", "user@example.com", "user");
+        result.IsValid.Should().BeTrue();
+        result.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_TooShort_IsInvalid()
+    {
+        var result = PasswordPolicy.Validate("short1", "user@example.com", "user");
+        result.IsValid.Should().BeFalse();
+        result.Error.Should().Contain("12");
+    }
+
+    [Fact]
+    public void Validate_NullOrEmpty_IsInvalid()
+    {
+        PasswordPolicy.Validate("", "user@example.com", "user").IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EqualToEmail_IsInvalid()
+    {
+        var result = PasswordPolicy.Validate("user@example.com", "user@example.com", "user");
+        result.IsValid.Should().BeFalse();
+        result.Error.Should().Contain("email");
+    }
+
+    [Fact]
+    public void Validate_EqualToEmail_IsCaseInsensitive()
+    {
+        var result = PasswordPolicy.Validate("USER@example.com", "user@example.com", "user");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EqualToUsername_IsInvalid()
+    {
+        // Username equal-to check fires when the password text matches the username verbatim;
+        // pad the username so it's >= 12 chars and the length floor doesn't pre-empt the rule.
+        var result = PasswordPolicy.Validate("longusername123", "user@example.com", "longusername123");
+        result.IsValid.Should().BeFalse();
+        result.Error.Should().Contain("username");
+    }
+
+    [Theory]
+    [InlineData("password1234")]
+    [InlineData("passw0rdpass")] // bumped to >= 12
+    [InlineData("welcome12345")]
+    [InlineData("changeme123")]
+    public void Validate_CommonPassword_IsInvalid_WhenInList(string pw)
+    {
+        // Sample the known list — the actual common-password list is small and centralised
+        // in PasswordPolicy. Adding a few short canonical entries to that list catches the
+        // intent: easy passwords get rejected even when long enough.
+        var listed = new[] { "password123", "password1", "qwertyuiop", "welcome123", "changeme123" };
+        if (Array.Exists(listed, p => string.Equals(p, pw, StringComparison.OrdinalIgnoreCase)))
+        {
+            PasswordPolicy.Validate(pw, "u@e.com", "u").IsValid.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void Validate_KnownCommonPasswordExactMatch_IsInvalid()
+    {
+        // Confirms the policy rejects an entry from the embedded list.
+        PasswordPolicy.Validate("changeme123", "u@e.com", "u").IsValid.Should().BeFalse();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Auth/PasswordPolicyTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Auth/PasswordPolicyTests.cs
@@ -53,26 +53,26 @@ public class PasswordPolicyTests
     }
 
     [Theory]
-    [InlineData("password1234")]
-    [InlineData("passw0rdpass")] // bumped to >= 12
-    [InlineData("welcome12345")]
-    [InlineData("changeme123")]
-    public void Validate_CommonPassword_IsInvalid_WhenInList(string pw)
+    // All inputs are entries from PasswordPolicy.CommonPasswords AND >= 12 chars,
+    // so the length check passes and execution actually reaches the common-password
+    // branch. Shorter "common" entries (e.g. "password123" at 11 chars) are rejected
+    // by the length floor first and don't exercise this code path.
+    [InlineData("123456789012")]
+    [InlineData("111111111111")]
+    [InlineData("abc123abc123")]
+    [InlineData("test1234test")]
+    public void Validate_CommonPassword_IsInvalidWithCommonError(string pw)
     {
-        // Sample the known list — the actual common-password list is small and centralised
-        // in PasswordPolicy. Adding a few short canonical entries to that list catches the
-        // intent: easy passwords get rejected even when long enough.
-        var listed = new[] { "password123", "password1", "qwertyuiop", "welcome123", "changeme123" };
-        if (Array.Exists(listed, p => string.Equals(p, pw, StringComparison.OrdinalIgnoreCase)))
-        {
-            PasswordPolicy.Validate(pw, "u@e.com", "u").IsValid.Should().BeFalse();
-        }
+        var result = PasswordPolicy.Validate(pw, "u@e.com", "u");
+        result.IsValid.Should().BeFalse();
+        result.Error.Should().Contain("common");
     }
 
     [Fact]
-    public void Validate_KnownCommonPasswordExactMatch_IsInvalid()
+    public void Validate_WhitespaceOnly_IsInvalid()
     {
-        // Confirms the policy rejects an entry from the embedded list.
-        PasswordPolicy.Validate("changeme123", "u@e.com", "u").IsValid.Should().BeFalse();
+        // A 12-space password used to slip past IsNullOrEmpty + the length floor;
+        // the policy now uses IsNullOrWhiteSpace to treat blank input as missing.
+        PasswordPolicy.Validate("            ", "u@e.com", "u").IsValid.Should().BeFalse();
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Auth/CredentialAuthServiceTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Auth/CredentialAuthServiceTests.cs
@@ -1,0 +1,251 @@
+using FluentAssertions;
+using GankedTV.Api.Auth;
+using GankedTV.Api.Auth.Passwords;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Tests.Integration.Auth;
+
+// Direct service-level tests for branches the endpoint can't reach in practice
+// (DataAnnotations [EmailAddress] intercepts malformed emails before the handler
+// runs, but the service must still handle them defensively for unit consumers).
+[Collection("Postgres")]
+public class CredentialAuthServiceTests
+{
+    private readonly PostgresFixture _fx;
+
+    public CredentialAuthServiceTests(PostgresFixture fx) => _fx = fx;
+
+    private CredentialAuthService NewService(GankedTV.Api.Data.GankedTvDbContext db) =>
+        new(db, new Argon2idPasswordHasher(), TimeProvider.System);
+
+    [Fact]
+    public async Task TryRegisterAsync_WithExplicitClock_StampsCreatedAtFromClock()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var clock = new FakeClock(new DateTimeOffset(2026, 4, 30, 12, 0, 0, TimeSpan.Zero));
+        var svc = new CredentialAuthService(db, new Argon2idPasswordHasher(), clock);
+
+        var result = await svc.TryRegisterAsync("clock@example.com", "clockuser", "long-fine-password");
+
+        ((RegisterResult.SuccessResult)result).User.CreatedAt.Should().Be(clock.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task TryRegisterAsync_HappyPath_ReturnsSuccessWithUser()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var svc = NewService(db);
+
+        var result = await svc.TryRegisterAsync("alice@example.com", "alice", "long-fine-password");
+
+        result.Should().BeOfType<RegisterResult.SuccessResult>();
+        var user = ((RegisterResult.SuccessResult)result).User;
+        user.Email.Should().Be("alice@example.com");
+        user.Username.Should().Be("alice");
+        user.PasswordHash.Should().NotBeNullOrEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-email")]
+    [InlineData("@example.com")]
+    public async Task TryRegisterAsync_BadEmail_ReturnsInvalidEmail(string email)
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var svc = NewService(db);
+
+        var result = await svc.TryRegisterAsync(email, "user", "long-fine-password");
+
+        result.Should().BeOfType<RegisterResult.InvalidEmailResult>();
+    }
+
+    [Fact]
+    public async Task TryRegisterAsync_WeakPassword_ReturnsInvalidPasswordWithError()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var svc = NewService(db);
+
+        var result = await svc.TryRegisterAsync("e@example.com", "user", "tiny");
+
+        result.Should().BeOfType<RegisterResult.InvalidPasswordResult>();
+        ((RegisterResult.InvalidPasswordResult)result).Error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task TryRegisterAsync_NormalisesEmailToLowercase()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var svc = NewService(db);
+
+        await svc.TryRegisterAsync("Alice@Example.COM", "alice", "long-fine-password");
+
+        await using var verify = _fx.CreateContext();
+        var user = await verify.Users.SingleAsync();
+        user.Email.Should().Be("alice@example.com");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-an-email")]
+    public async Task TryLoginAsync_BadEmailFormat_ReturnsNullAfterDummyVerify(string email)
+    {
+        // Important behaviour: bad-format emails still pay the Argon2 cost (constant-time
+        // equivalent) so attackers can't probe address shape via response timing.
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var svc = NewService(db);
+
+        var user = await svc.TryLoginAsync(email, "any-password");
+
+        user.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryLoginAsync_UnknownEmail_ReturnsNull()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var svc = NewService(db);
+
+        var user = await svc.TryLoginAsync("nobody@example.com", "any-password-12345");
+
+        user.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryLoginAsync_OAuthOnlyUser_ReturnsNull()
+    {
+        await _fx.ResetAsync();
+        await using (var db = _fx.CreateContext())
+        {
+            db.Users.Add(new User
+            {
+                Username = "oauthonly",
+                Email = "oauthonly@example.com",
+                DiscordId = "d-oauth-only",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await using var queryDb = _fx.CreateContext();
+        var svc = NewService(queryDb);
+
+        var user = await svc.TryLoginAsync("oauthonly@example.com", "anything-12345");
+
+        user.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetPasswordAsync_UserNotFound_ReturnsUserNotFound()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateContext();
+        var svc = NewService(db);
+
+        var result = await svc.SetPasswordAsync(Guid.NewGuid(), null, "fresh-strong-password");
+
+        result.Should().BeOfType<SetPasswordResult.UserNotFoundResult>();
+    }
+
+    [Fact]
+    public async Task SetPasswordAsync_OAuthOnlyUser_DoesNotRequireCurrentPassword()
+    {
+        await _fx.ResetAsync();
+        Guid userId;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = "merger",
+                Email = "merger@example.com",
+                DiscordId = "d-merger",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            userId = user.Id;
+        }
+
+        await using var ctx = _fx.CreateContext();
+        var svc = NewService(ctx);
+
+        var result = await svc.SetPasswordAsync(userId, currentPassword: null, "new-strong-password");
+
+        result.Should().BeOfType<SetPasswordResult.OkResult>();
+
+        await using var verify = _fx.CreateContext();
+        var after = await verify.Users.SingleAsync();
+        after.PasswordHash.Should().NotBeNullOrEmpty();
+        after.PasswordAlgo.Should().Be("argon2id");
+    }
+
+    [Fact]
+    public async Task SetPasswordAsync_WithExistingPassword_RejectsMissingCurrent()
+    {
+        await _fx.ResetAsync();
+        var hasher = new Argon2idPasswordHasher();
+        Guid userId;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = "rotator",
+                Email = "rotator@example.com",
+                PasswordHash = hasher.Hash("original-strong-password"),
+                PasswordAlgo = "argon2id",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            userId = user.Id;
+        }
+
+        await using var ctx = _fx.CreateContext();
+        var svc = NewService(ctx);
+
+        // No currentPassword supplied → 400-equivalent.
+        var result = await svc.SetPasswordAsync(userId, currentPassword: null, "new-strong-password");
+
+        result.Should().BeOfType<SetPasswordResult.WrongCurrentPasswordResult>();
+    }
+
+    [Fact]
+    public async Task SetPasswordAsync_WeakNewPassword_ReturnsInvalidPasswordWithError()
+    {
+        await _fx.ResetAsync();
+        Guid userId;
+        await using (var db = _fx.CreateContext())
+        {
+            var user = new User
+            {
+                Username = "weakset",
+                Email = "weakset@example.com",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            userId = user.Id;
+        }
+
+        await using var ctx = _fx.CreateContext();
+        var svc = NewService(ctx);
+
+        var result = await svc.SetPasswordAsync(userId, null, "tiny");
+
+        result.Should().BeOfType<SetPasswordResult.InvalidPasswordResult>();
+        ((SetPasswordResult.InvalidPasswordResult)result).Error.Should().NotBeNullOrEmpty();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Auth/UserUpsertServiceTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Auth/UserUpsertServiceTests.cs
@@ -300,6 +300,47 @@ public class UserUpsertServiceTests
     }
 
     [Fact]
+    public async Task UpsertFromOAuthAsync_AgainstExistingPasswordOnlyUser_LinksProviderIdWithoutDroppingPassword()
+    {
+        // Regression test for the OAuth→password-account merge direction (issue #62 spec).
+        // The OAuth provider asserts a verified email matching an existing password-only
+        // account: the provider id should attach to the existing row, and the password
+        // hash must NOT be wiped. Without email verification on the password side, this
+        // is the only direction where an automatic merge is safe.
+        await _fx.ResetAsync();
+        var now = DateTimeOffset.UtcNow;
+        Guid id;
+        const string PreservedHash = "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAAAAA==$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        await using (var db = _fx.CreateContext())
+        {
+            db.Users.Add(new User
+            {
+                Username = "merge-target",
+                Email = "merge@example.com",
+                PasswordHash = PreservedHash,
+                PasswordAlgo = "argon2id",
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            await db.SaveChangesAsync();
+            id = (await db.Users.SingleAsync()).Id;
+        }
+
+        await using (var db = _fx.CreateContext())
+        {
+            await new UserUpsertService(db).UpsertFromOAuthAsync(
+                DiscordOAuthProvider.ProviderName,
+                new OAuthUserInfo("d-merge", "merge@example.com", "Whatever", null, EmailVerified: true));
+        }
+
+        await using var verify = _fx.CreateContext();
+        var user = await verify.Users.SingleAsync(u => u.Id == id);
+        user.DiscordId.Should().Be("d-merge");
+        user.PasswordHash.Should().Be(PreservedHash);
+        user.PasswordAlgo.Should().Be("argon2id");
+    }
+
+    [Fact]
     public async Task UpsertFromOAuthAsync_UsernameCollision_AppendsSuffix()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsCredentialsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsCredentialsTests.cs
@@ -123,11 +123,15 @@ public class AuthEndpointsCredentialsTests : IAsyncLifetime
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
 
         await using var db = _fx.CreateContext();
-        var users = await db.Users.AsNoTracking().OrderBy(u => u.CreatedAt).ToListAsync();
+        // Order by Email (unique) rather than CreatedAt, which can tie at high-precision-clock
+        // resolution when two registrations happen back-to-back inside the same test.
+        var users = await db.Users.AsNoTracking().OrderBy(u => u.Email).ToListAsync();
         users.Should().HaveCount(2);
-        users[0].Username.Should().Be("bob");
-        users[1].Username.Should().NotBe("bob");
-        users[1].Username.Should().StartWith("bob-");
+        var first = users.Single(u => u.Email == "bob@example.com");
+        var second = users.Single(u => u.Email == "bob2@example.com");
+        first.Username.Should().Be("bob");
+        second.Username.Should().NotBe("bob");
+        second.Username.Should().StartWith("bob-");
     }
 
     [Fact]
@@ -136,11 +140,15 @@ public class AuthEndpointsCredentialsTests : IAsyncLifetime
         await _fx.ResetAsync();
         using var client = BuildClient();
 
+        // 12+ chars (so the DataAnnotation filter doesn't pre-empt) but on the
+        // policy's common-password list — exercises the endpoint's InvalidPasswordResult
+        // arm rather than the validation-filter short-circuit.
         var resp = await client.PostAsJsonAsync(
             "/auth/register",
-            new RegisterRequest("c@example.com", "carol", "tiny"));
+            new RegisterRequest("c@example.com", "carol", "abc123abc123"));
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("weak_password");
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsCredentialsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsCredentialsTests.cs
@@ -1,0 +1,442 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth.Passwords;
+using GankedTV.Api.Contracts.Auth;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class AuthEndpointsCredentialsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+
+    public AuthEndpointsCredentialsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+            _factory = null;
+        }
+    }
+
+    private HttpClient BuildClient()
+    {
+        Assert.Null(_factory);
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+        return _factory.CreateClient();
+    }
+
+    private static RegisterRequest GoodRegister(string email = "alice@example.com", string username = "alice", string password = "correct-horse-battery") =>
+        new(email, username, password);
+
+    [Fact]
+    public async Task Register_HappyPath_ReturnsTokenAndPersistsUser()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        var resp = await client.PostAsJsonAsync("/auth/register", GoodRegister());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var token = await resp.Content.ReadFromJsonAsync<TokenResponse>();
+        token!.Token.Should().NotBeNullOrEmpty();
+        token.Refresh.Should().NotBeNullOrEmpty();
+        token.ExpiresIn.Should().BeGreaterThan(0);
+
+        await using var db = _fx.CreateContext();
+        var user = await db.Users.AsNoTracking().SingleAsync();
+        user.Email.Should().Be("alice@example.com");
+        user.Username.Should().Be("alice");
+        user.PasswordHash.Should().NotBeNullOrEmpty();
+        user.PasswordAlgo.Should().Be("argon2id");
+    }
+
+    [Fact]
+    public async Task Register_WithDuplicateEmail_Returns409()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        (await client.PostAsJsonAsync("/auth/register", GoodRegister())).EnsureSuccessStatusCode();
+
+        var resp = await client.PostAsJsonAsync("/auth/register", GoodRegister(username: "alice2"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("email_taken");
+    }
+
+    [Fact]
+    public async Task Register_AgainstExistingOAuthOnlyAccount_Returns409()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        // Seed an OAuth-only user (no PasswordHash).
+        await using (var db = _fx.CreateContext())
+        {
+            db.Users.Add(new User
+            {
+                Username = "oauthonly",
+                Email = "oauthonly@example.com",
+                DiscordId = "d-1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/register",
+            new RegisterRequest("oauthonly@example.com", "stealer", "long-and-fine-password"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("email_taken");
+    }
+
+    [Fact]
+    public async Task Register_WithCollidingUsername_AutoSuffixes()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        // First user takes "bob".
+        (await client.PostAsJsonAsync(
+            "/auth/register",
+            new RegisterRequest("bob@example.com", "bob", "long-and-fine-password"))).EnsureSuccessStatusCode();
+
+        // Second registration with the same desired username + a different email — auto-suffix.
+        var resp = await client.PostAsJsonAsync(
+            "/auth/register",
+            new RegisterRequest("bob2@example.com", "bob", "another-fine-password"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = _fx.CreateContext();
+        var users = await db.Users.AsNoTracking().OrderBy(u => u.CreatedAt).ToListAsync();
+        users.Should().HaveCount(2);
+        users[0].Username.Should().Be("bob");
+        users[1].Username.Should().NotBe("bob");
+        users[1].Username.Should().StartWith("bob-");
+    }
+
+    [Fact]
+    public async Task Register_WithWeakPassword_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/register",
+            new RegisterRequest("c@example.com", "carol", "tiny"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Register_WithBadEmail_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/register",
+            new RegisterRequest("not-an-email", "dave", "long-and-fine-password"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Register_TokenValidatesAgainstAuthMe_AndHasPasswordIsTrue()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        var resp = await client.PostAsJsonAsync("/auth/register", GoodRegister());
+        var token = (await resp.Content.ReadFromJsonAsync<TokenResponse>())!;
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+        var me = await client.GetAsync("/auth/me");
+        me.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Password-registered account → hasPassword is true. The web settings view uses
+        // this to render "Change password" copy and require a current-password input.
+        var body = await me.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        body.GetProperty("hasPassword").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Login_HappyPath_ReturnsToken()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        (await client.PostAsJsonAsync("/auth/register", GoodRegister())).EnsureSuccessStatusCode();
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("alice@example.com", "correct-horse-battery"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var token = await resp.Content.ReadFromJsonAsync<TokenResponse>();
+        token!.Token.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Login_WithWrongPassword_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        (await client.PostAsJsonAsync("/auth/register", GoodRegister())).EnsureSuccessStatusCode();
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("alice@example.com", "wrong-password-here"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("invalid_credentials");
+    }
+
+    [Fact]
+    public async Task Login_WithUnknownEmail_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("nobody@example.com", "doesnt-matter-12345"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_AgainstOAuthOnlyUser_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Users.Add(new User
+            {
+                Username = "oauthonly",
+                Email = "oauthonly@example.com",
+                DiscordId = "d-2",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("oauthonly@example.com", "any-password-here"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_WithBadEmailFormat_Returns400FromValidationFilter()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("not-an-email", "anything-12345"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SetPassword_OAuthOnlyUserAttachesPassword_LoginSucceedsAfter()
+    {
+        await _fx.ResetAsync();
+        Assert.Null(_factory);
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+
+        // Seed an OAuth-only user and mint a JWT for them.
+        var (_, token) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory, "oauthuser", u =>
+        {
+            u.Email = "oauthuser@example.com";
+            u.DiscordId = "d-3";
+        });
+
+        using var authed = AuthTestHelpers.CreateBearerClient(_factory, token);
+
+        // Attach a password without currentPassword (allowed for OAuth-only users).
+        var setResp = await authed.PostAsJsonAsync(
+            "/auth/password",
+            new SetPasswordRequest(null, "fresh-strong-password"));
+        setResp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Now /auth/login with that password works.
+        using var anon = _factory.CreateClient();
+        var loginResp = await anon.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("oauthuser@example.com", "fresh-strong-password"));
+        loginResp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SetPassword_RotatesExistingPassword_RequiresCurrentPassword()
+    {
+        await _fx.ResetAsync();
+        Assert.Null(_factory);
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+
+        // Seed a user that already has a password.
+        Guid userId;
+        await using (var db = _fx.CreateContext())
+        {
+            using var scope = _factory.Services.CreateScope();
+            var hasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
+            var user = new User
+            {
+                Username = "rotater",
+                Email = "rotater@example.com",
+                PasswordHash = hasher.Hash("original-password-123"),
+                PasswordAlgo = hasher.Algorithm,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+            userId = user.Id;
+        }
+
+        // Mint a JWT for that user.
+        string token;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var jwt = scope.ServiceProvider.GetRequiredService<GankedTV.Api.Auth.Jwt.IJwtService>();
+            await using var db = _fx.CreateContext();
+            var user = (await db.Users.FindAsync(userId))!;
+            token = jwt.Issue(user);
+        }
+        using var authed = AuthTestHelpers.CreateBearerClient(_factory, token);
+
+        // Wrong current password → 400.
+        var bad = await authed.PostAsJsonAsync(
+            "/auth/password",
+            new SetPasswordRequest("not-the-original", "new-rotated-password"));
+        bad.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await bad.Content.ReadAsStringAsync()).Should().Contain("wrong_current_password");
+
+        // Correct current password → 204, and the new password works for login.
+        var good = await authed.PostAsJsonAsync(
+            "/auth/password",
+            new SetPasswordRequest("original-password-123", "new-rotated-password"));
+        good.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var anon = _factory.CreateClient();
+        var loginResp = await anon.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("rotater@example.com", "new-rotated-password"));
+        loginResp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SetPassword_TokenForDeletedUser_Returns401()
+    {
+        // JWT sub points at a user that no longer exists. The analogous case in MeEndpoints
+        // returns 401 (re-auth) so the SPA drops tokens and redirects; SetPassword mirrors it.
+        await _fx.ResetAsync();
+        Assert.Null(_factory);
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+        var (userId, token) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory, "deletee");
+
+        await using (var db = _fx.CreateContext())
+        {
+            var user = await db.Users.FindAsync(userId);
+            db.Users.Remove(user!);
+            await db.SaveChangesAsync();
+        }
+
+        using var authed = AuthTestHelpers.CreateBearerClient(_factory, token);
+        var resp = await authed.PostAsJsonAsync(
+            "/auth/password",
+            new SetPasswordRequest(null, "fresh-strong-password"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task SetPassword_Unauthenticated_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        var resp = await client.PostAsJsonAsync(
+            "/auth/password",
+            new SetPasswordRequest(null, "doesnt-matter-strong"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task SetPassword_WithWeakNewPassword_Returns400()
+    {
+        await _fx.ResetAsync();
+        Assert.Null(_factory);
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+        var (_, token) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory, "weakset");
+        using var authed = AuthTestHelpers.CreateBearerClient(_factory, token);
+
+        var resp = await authed.PostAsJsonAsync(
+            "/auth/password",
+            new SetPasswordRequest(null, "tiny"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Register_NullBody_Returns400FromValidationFilter()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        using var body = new StringContent("null", System.Text.Encoding.UTF8, "application/json");
+        var resp = await client.PostAsync("/auth/register", body);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Login_NullBody_Returns400FromValidationFilter()
+    {
+        await _fx.ResetAsync();
+        using var client = BuildClient();
+
+        using var body = new StringContent("null", System.Text.Encoding.UTF8, "application/json");
+        var resp = await client.PostAsync("/auth/login", body);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SetPassword_NullBody_Returns400FromValidationFilter()
+    {
+        await _fx.ResetAsync();
+        Assert.Null(_factory);
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+        var (_, token) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory, "nullbody");
+        using var authed = AuthTestHelpers.CreateBearerClient(_factory, token);
+
+        using var body = new StringContent("null", System.Text.Encoding.UTF8, "application/json");
+        var resp = await authed.PostAsync("/auth/password", body);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsRateLimitTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsRateLimitTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using GankedTV.Api.Auth;
+using GankedTV.Api.Contracts.Auth;
+using GankedTV.Api.Tests.TestSupport;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class AuthEndpointsRateLimitTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+
+    public AuthEndpointsRateLimitTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+            _factory = null;
+        }
+    }
+
+    [Fact]
+    public async Task Login_Exceeding5Per60s_Returns429()
+    {
+        await _fx.ResetAsync();
+        Assert.Null(_factory);
+        _factory = new AuthApiFactory(_fx.ConnectionString);
+        using var client = _factory.CreateClient();
+
+        // Fire one over the per-IP permit limit. The first PermitLimit calls all return
+        // 401 (invalid creds); the (PermitLimit+1)th is rejected by the limiter as 429.
+        for (var i = 0; i < AuthRateLimiting.CredentialsPermitLimit; i++)
+        {
+            var ok = await client.PostAsJsonAsync(
+                "/auth/login",
+                new LoginRequest("nobody@example.com", "wrong-password-12345"));
+            ok.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        var blocked = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("nobody@example.com", "wrong-password-12345"));
+        blocked.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/MeEndpointsSmokeTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/MeEndpointsSmokeTests.cs
@@ -107,6 +107,9 @@ public class MeEndpointsSmokeTests : IAsyncLifetime
         // so a round-trip rounds by up to 1 microsecond. 1ms tolerance comfortably absorbs that.
         body.GetProperty("createdAt").GetDateTimeOffset()
             .Should().BeCloseTo(createdAt, TimeSpan.FromMilliseconds(1));
+        // OAuth-only / no-credential user — hasPassword is false. Pinned here so the web
+        // SettingsPasswordView's "Set password" vs "Change password" copy stays correct.
+        body.GetProperty("hasPassword").GetBoolean().Should().BeFalse();
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/TestSupport/PostgresFixture.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/PostgresFixture.cs
@@ -8,7 +8,7 @@ namespace GankedTV.Api.Tests.TestSupport;
 
 public sealed class PostgresFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:16-alpine")
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:18-alpine")
         .WithDatabase("gankedtv_test")
         .WithUsername("gankedtv")
         .WithPassword("gankedtv_test")

--- a/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using GankedTV.Api.Auth.Passwords;
 using GankedTV.Api.Data;
 using GankedTV.Api.Tests.TestSupport;
 using GankedTV.Api.Tools;
@@ -86,7 +87,8 @@ public class SeedCommandTests : IAsyncLifetime
             db,
             NullLogger<SeedCommand>.Instance,
             TimeProvider.System,
-            new FakeHostEnvironment("Production"));
+            new FakeHostEnvironment("Production"),
+            new Argon2idPasswordHasher());
 
         await seed.RunAsync(CancellationToken.None);
 
@@ -95,8 +97,54 @@ public class SeedCommandTests : IAsyncLifetime
         (await verify.Clips.CountAsync()).Should().Be(0);
     }
 
+    [Fact]
+    public async Task FreshDb_AttachesDocumentedSeedPassword()
+    {
+        // The README documents seeduser@dev.local / testpass123! as the local-dev login;
+        // contributors should be able to call /auth/login with that pair after `make seed`.
+        await using var db = _fx.CreateContext();
+        await NewSeed(db).RunAsync(CancellationToken.None);
+
+        await using var verify = _fx.CreateContext();
+        var user = await verify.Users.SingleAsync();
+        user.PasswordHash.Should().NotBeNullOrEmpty();
+        user.PasswordAlgo.Should().Be("argon2id");
+        new Argon2idPasswordHasher().Verify(SeedCommand.SeedUserPassword, user.PasswordHash!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunTwice_DoesNotReplaceExistingPassword()
+    {
+        // Idempotency: a contributor who rotates the seed user's password via /auth/password
+        // should not have it stomped on by a second `make seed`.
+        await using (var db = _fx.CreateContext())
+        {
+            await NewSeed(db).RunAsync(CancellationToken.None);
+        }
+
+        // Manually rotate the password directly in the DB.
+        var hasher = new Argon2idPasswordHasher();
+        var rotated = hasher.Hash("rotated-password-1234");
+        await using (var db = _fx.CreateContext())
+        {
+            var user = await db.Users.SingleAsync();
+            user.PasswordHash = rotated;
+            await db.SaveChangesAsync();
+        }
+
+        // Second seed run should NOT overwrite the rotated password.
+        await using (var db = _fx.CreateContext())
+        {
+            await NewSeed(db).RunAsync(CancellationToken.None);
+        }
+
+        await using var verify = _fx.CreateContext();
+        var after = await verify.Users.SingleAsync();
+        after.PasswordHash.Should().Be(rotated);
+    }
+
     private SeedCommand NewSeed(GankedTvDbContext db) =>
-        new(db, NullLogger<SeedCommand>.Instance, TimeProvider.System, new FakeHostEnvironment("Development"));
+        new(db, NullLogger<SeedCommand>.Instance, TimeProvider.System, new FakeHostEnvironment("Development"), new Argon2idPasswordHasher());
 
     private sealed class FakeHostEnvironment(string name) : IHostEnvironment
     {

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -16,7 +16,7 @@
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.10.9",
         "@vitejs/plugin-vue": "^6.0.6",
-        "@vitest/coverage-v8": "^4.1.4",
+        "@vitest/coverage-istanbul": "^4.1.5",
         "@vitest/eslint-plugin": "^1.6.16",
         "@vue/eslint-config-typescript": "^14.7.0",
         "@vue/test-utils": "^2.4.6",
@@ -34,7 +34,7 @@
         "typescript": "~6.0.3",
         "vite": "^8.0.8",
         "vite-plugin-vue-devtools": "^8.1.1",
-        "vitest": "^4.1.4",
+        "vitest": "4.1.5",
         "vue-tsc": "^3.2.7",
       },
     },
@@ -48,13 +48,13 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
-    "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.28.6", "", {}, "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg=="],
 
-    "@babel/core": ["@babel/core@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw=="],
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
 
-    "@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
 
     "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.27.3", "", { "dependencies": { "@babel/types": "^7.27.3" } }, "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg=="],
 
@@ -104,7 +104,7 @@
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
-    "@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
@@ -208,6 +208,8 @@
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -304,56 +306,6 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA=="],
-
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.57.0", "", { "os": "android", "cpu": "arm64" }, "sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg=="],
-
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.57.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/NNIj9A7yLjKdmkx5dC2XQ9DmjIECpGpwHoGmA5E1AhU0fuICSqSWScPhN1yLCkEdkCwJIDu2xIeLPs60MNIVg=="],
-
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.57.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-xoh8abqgPrPYPr7pTYipqnUi1V3em56JzE/HgDgitTqZBZ3yKCWI+7KUkceM6tNweyUKYru1UMi7FC060RyKwA=="],
-
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.57.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-PCkMh7fNahWSbA0OTUQ2OpYHpjZZr0hPr8lId8twD7a7SeWrvT3xJVyza+dQwXSSq4yEQTMoXgNOfMCsn8584g=="],
-
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.57.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1j3stGx+qbhXql4OCDZhnK7b01s6rBKNybfsX+TNrEe9JNq4DLi1yGiR1xW+nL+FNVvI4D02PUnl6gJ/2y6WJA=="],
-
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.57.0", "", { "os": "linux", "cpu": "arm" }, "sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q=="],
-
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.57.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA=="],
-
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.57.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw=="],
-
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.57.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw=="],
-
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q=="],
-
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ=="],
-
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.57.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ=="],
-
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.57.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA=="],
-
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ=="],
-
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ=="],
-
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.57.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg=="],
-
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.57.0", "", { "os": "linux", "cpu": "x64" }, "sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A=="],
-
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.57.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw=="],
-
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.57.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw=="],
-
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.57.0", "", { "os": "none", "cpu": "arm64" }, "sha512-v5xwKDWcu7qhAEcsUubiav7r+48Uk/ENWdr82MBZZRIm7zThSxCIVDfb3ZeRRq9yqk+oIzMdDo6fCcA5DHfMyA=="],
-
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.57.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-XnaaaSMGSI6Wk8F4KK3QP7GfuuhjGchElsVerCplUuxRIzdvZ7hRBpLR0omCmw+kI2RFJB80nenhOoGXlJ5TfQ=="],
-
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.57.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-3K1lP+3BXY4t4VihLw5MEg6IZD3ojSYzqzBG571W3kNQe4G4CcFpSUQVgurYgib5d+YaCjeFow8QivWp8vuSvA=="],
-
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA=="],
-
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ=="],
-
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
@@ -428,23 +380,25 @@
 
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.6", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.13" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "vue": "^3.2.25" } }, "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg=="],
 
+    "@vitest/coverage-istanbul": ["@vitest/coverage-istanbul@4.1.5", "", { "dependencies": { "@babel/core": "^7.29.0", "@istanbuljs/schema": "^0.1.3", "@jridgewell/gen-mapping": "^0.3.13", "@jridgewell/trace-mapping": "0.3.31", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.5" } }, "sha512-X4kQMDEWh9mA0IiLuigtdYv4kXe+W8KLTbucoz15lbyZRPAxT5l+hu0JizI7Am050+G9vQnB7QJNgYi2LnwV4w=="],
+
     "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.4", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.4", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.4", "vitest": "4.1.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w=="],
 
     "@vitest/eslint-plugin": ["@vitest/eslint-plugin@1.6.16", "", { "dependencies": { "@typescript-eslint/scope-manager": "^8.58.0", "@typescript-eslint/utils": "^8.58.0" }, "peerDependencies": { "@typescript-eslint/eslint-plugin": "*", "eslint": ">=8.57.0", "typescript": ">=5.0.0", "vitest": "*" }, "optionalPeers": ["@typescript-eslint/eslint-plugin", "typescript", "vitest"] }, "sha512-2pBN1F1JXq6zTSaYC58CMJa7pGxXIRsLfOioeZM4cPE3pRdSh1ySTSoHPQlOTEF5WgoVzWZQxhGQ3ygT78hOVg=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
+    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
+    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
     "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
 
@@ -704,7 +658,7 @@
 
     "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
-    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
@@ -864,8 +818,6 @@
 
     "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
-    "rollup": ["rollup@4.57.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.0", "@rollup/rollup-android-arm64": "4.57.0", "@rollup/rollup-darwin-arm64": "4.57.0", "@rollup/rollup-darwin-x64": "4.57.0", "@rollup/rollup-freebsd-arm64": "4.57.0", "@rollup/rollup-freebsd-x64": "4.57.0", "@rollup/rollup-linux-arm-gnueabihf": "4.57.0", "@rollup/rollup-linux-arm-musleabihf": "4.57.0", "@rollup/rollup-linux-arm64-gnu": "4.57.0", "@rollup/rollup-linux-arm64-musl": "4.57.0", "@rollup/rollup-linux-loong64-gnu": "4.57.0", "@rollup/rollup-linux-loong64-musl": "4.57.0", "@rollup/rollup-linux-ppc64-gnu": "4.57.0", "@rollup/rollup-linux-ppc64-musl": "4.57.0", "@rollup/rollup-linux-riscv64-gnu": "4.57.0", "@rollup/rollup-linux-riscv64-musl": "4.57.0", "@rollup/rollup-linux-s390x-gnu": "4.57.0", "@rollup/rollup-linux-x64-gnu": "4.57.0", "@rollup/rollup-linux-x64-musl": "4.57.0", "@rollup/rollup-openbsd-x64": "4.57.0", "@rollup/rollup-openharmony-arm64": "4.57.0", "@rollup/rollup-win32-arm64-msvc": "4.57.0", "@rollup/rollup-win32-ia32-msvc": "4.57.0", "@rollup/rollup-win32-x64-gnu": "4.57.0", "@rollup/rollup-win32-x64-msvc": "4.57.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA=="],
-
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -968,7 +920,7 @@
 
     "vite-plugin-vue-inspector": ["vite-plugin-vue-inspector@5.3.2", "", { "dependencies": { "@babel/core": "^7.23.0", "@babel/plugin-proposal-decorators": "^7.23.0", "@babel/plugin-syntax-import-attributes": "^7.22.5", "@babel/plugin-syntax-import-meta": "^7.10.4", "@babel/plugin-transform-typescript": "^7.22.15", "@vue/babel-plugin-jsx": "^1.1.5", "@vue/compiler-dom": "^3.3.4", "kolorist": "^1.8.0", "magic-string": "^0.30.4" }, "peerDependencies": { "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0" } }, "sha512-YvEKooQcSiBTAs0DoYLfefNja9bLgkFM7NI2b07bE2SruuvX0MEa9cMaxjKVMkeCp5Nz9FRIdcN1rOdFVBeL6Q=="],
 
-    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
+    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
@@ -1010,17 +962,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@babel/core/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
-
-    "@babel/core/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/generator/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
-
-    "@babel/generator/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
@@ -1028,25 +970,35 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-member-expression-to-functions/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
 
     "@babel/helper-member-expression-to-functions/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
+    "@babel/helper-module-imports/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+
     "@babel/helper-module-imports/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
+    "@babel/helper-module-transforms/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+
     "@babel/helper-optimise-call-expression/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@babel/helper-replace-supers/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
 
     "@babel/helper-skip-transparent-expression-wrappers/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@babel/helpers/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
+    "@babel/template/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
     "@babel/template/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
 
     "@babel/template/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
-
-    "@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
-
-    "@babel/traverse/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1086,9 +1038,15 @@
 
     "@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
+    "@vitest/coverage-v8/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "@vue/babel-plugin-jsx/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+
     "@vue/babel-plugin-jsx/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@vue/babel-plugin-jsx/@vue/shared": ["@vue/shared@3.5.27", "", {}, "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ=="],
+
+    "@vue/babel-plugin-resolve-type/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
     "@vue/babel-plugin-resolve-type/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
 
@@ -1103,6 +1061,8 @@
     "@vue/devtools-api/@vue/devtools-kit": ["@vue/devtools-kit@7.7.9", "", { "dependencies": { "@vue/devtools-shared": "^7.7.9", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA=="],
 
     "@vue/language-core/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1136,9 +1096,11 @@
 
     "vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "vite-plugin-vue-inspector/@babel/core": ["@babel/core@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw=="],
+
     "vite-plugin-vue-inspector/@vue/compiler-dom": ["@vue/compiler-dom@3.5.27", "", { "dependencies": { "@vue/compiler-core": "3.5.27", "@vue/shared": "3.5.27" } }, "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w=="],
 
-    "vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+    "vitest/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "vue-eslint-parser/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -1153,6 +1115,48 @@
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "@babel/helper-module-transforms/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/helper-module-transforms/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@babel/helper-module-transforms/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "@babel/helper-module-transforms/@babel/traverse/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@babel/helper-replace-supers/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/helper-replace-supers/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@babel/helper-replace-supers/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "@babel/helper-replace-supers/@babel/traverse/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.54.0", "", {}, "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="],
 
@@ -1181,6 +1185,14 @@
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0" } }, "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg=="],
+
+    "@vitest/coverage-v8/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
+
+    "@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@vue/babel-plugin-jsx/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@vue/babel-plugin-jsx/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
 
     "@vue/babel-plugin-resolve-type/@babel/parser/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
@@ -1214,11 +1226,21 @@
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
+    "vite-plugin-vue-inspector/@babel/core/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "vite-plugin-vue-inspector/@babel/core/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "vite-plugin-vue-inspector/@babel/core/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "vite-plugin-vue-inspector/@babel/core/@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+
+    "vite-plugin-vue-inspector/@babel/core/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "vite-plugin-vue-inspector/@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "vite-plugin-vue-inspector/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.27", "", { "dependencies": { "@babel/parser": "^7.28.5", "@vue/shared": "3.5.27", "entities": "^7.0.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ=="],
 
     "vite-plugin-vue-inspector/@vue/compiler-dom/@vue/shared": ["@vue/shared@3.5.27", "", {}, "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ=="],
-
-    "vitest/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "vue-eslint-parser/espree/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -18,8 +18,8 @@
     "lint:check": "run-s lint:oxlint:check lint:eslint:check",
     "lint:oxlint:check": "oxlint .",
     "lint:eslint:check": "eslint . --cache",
-    "format": "prettier --write --experimental-cli --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/",
-    "format:check": "prettier --check --experimental-cli --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/"
+    "format": "prettier --write --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/",
+    "format:check": "prettier --check --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/"
   },
   "dependencies": {
     "pinia": "^3.0.4",
@@ -33,7 +33,7 @@
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.10.9",
     "@vitejs/plugin-vue": "^6.0.6",
-    "@vitest/coverage-v8": "^4.1.4",
+    "@vitest/coverage-istanbul": "^4.1.5",
     "@vitest/eslint-plugin": "^1.6.16",
     "@vue/eslint-config-typescript": "^14.7.0",
     "@vue/test-utils": "^2.4.6",
@@ -51,7 +51,7 @@
     "typescript": "~6.0.3",
     "vite": "^8.0.8",
     "vite-plugin-vue-devtools": "^8.1.1",
-    "vitest": "^4.1.4",
+    "vitest": "4.1.5",
     "vue-tsc": "^3.2.7"
   },
   "engines": {

--- a/web/src/api/__tests__/auth.spec.ts
+++ b/web/src/api/__tests__/auth.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { me, oauthStartUrl } from '../auth'
+import { login, me, oauthStartUrl, register, setPassword } from '../auth'
 import { configureAuth, BASE_URL } from '../client'
 
 beforeEach(() => {
@@ -62,6 +62,110 @@ describe('api/auth', () => {
       // Empty string is falsy — the guard skips the returnTo path, otherwise we'd produce
       // the ugly `.../start?returnTo=` which some gateways reject as a malformed query.
       expect(oauthStartUrl('discord', '')).toBe(`${BASE_URL}/auth/discord/start`)
+    })
+  })
+
+  describe('register()', () => {
+    it('POSTs the credentials body to /auth/register and returns the token response', async () => {
+      const tokens = { token: 'jwt', refresh: 'r1', expiresIn: 600 }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify(tokens), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+        ),
+      )
+
+      const result = await register({
+        email: 'a@b.dev',
+        username: 'a',
+        password: 'long-strong-password',
+      })
+
+      expect(result).toEqual(tokens)
+      // vi.mocked(fetch) (not the local mock var) preserves the global fetch's
+      // `[input, init?]` call signature so the [url, init] tuple destructure type-checks.
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/auth/register`)
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(init.body as string)).toEqual({
+        email: 'a@b.dev',
+        username: 'a',
+        password: 'long-strong-password',
+      })
+    })
+  })
+
+  describe('login()', () => {
+    it('POSTs the credentials body to /auth/login and returns the token response', async () => {
+      const tokens = { token: 'jwt', refresh: 'r1', expiresIn: 600 }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify(tokens), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+        ),
+      )
+
+      const result = await login({ email: 'a@b.dev', password: 'long-strong-password' })
+
+      expect(result).toEqual(tokens)
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/auth/login`)
+      expect(init.method).toBe('POST')
+    })
+  })
+
+  describe('setPassword()', () => {
+    it('POSTs both currentPassword and newPassword when current is provided', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(null, {
+              status: 204,
+              headers: { 'content-length': '0' },
+            }),
+        ),
+      )
+
+      await setPassword('old-password', 'new-strong-password')
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/auth/password`)
+      expect(JSON.parse(init.body as string)).toEqual({
+        currentPassword: 'old-password',
+        newPassword: 'new-strong-password',
+      })
+    })
+
+    it('passes currentPassword:null when caller has no existing password', async () => {
+      // OAuth-only users attaching a password for the first time — server treats
+      // the OAuth login that minted the token as proof of account control.
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(null, {
+              status: 204,
+              headers: { 'content-length': '0' },
+            }),
+        ),
+      )
+
+      await setPassword(null, 'new-strong-password')
+
+      const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(JSON.parse(init.body as string)).toEqual({
+        currentPassword: null,
+        newPassword: 'new-strong-password',
+      })
     })
   })
 })

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -7,6 +7,10 @@ export interface MeResponse {
   bio: string | null
   avatarUrl: string | null
   createdAt: string
+  // True when the account has a password set (covers both password-registered and
+  // OAuth-then-attached accounts). SettingsPasswordView uses this to switch between
+  // "Set password" (first-time) and "Change password" (rotation) copy.
+  hasPassword: boolean
 }
 
 export interface RefreshResponse {
@@ -14,6 +18,8 @@ export interface RefreshResponse {
   refresh: string
   expiresIn: number
 }
+
+export type TokenResponse = RefreshResponse
 
 export async function me(): Promise<MeResponse> {
   // /auth/me — not bare /me — to avoid tripping tracker blockers (Brave, uBlock,
@@ -27,4 +33,33 @@ export function oauthStartUrl(provider: 'discord' | 'google', returnTo?: string)
     url += `?returnTo=${encodeURIComponent(returnTo)}`
   }
   return url
+}
+
+export interface RegisterPayload {
+  email: string
+  username: string
+  password: string
+}
+
+export interface LoginPayload {
+  email: string
+  password: string
+}
+
+export function register(payload: RegisterPayload): Promise<TokenResponse> {
+  return api<TokenResponse>('/auth/register', { method: 'POST', body: payload })
+}
+
+export function login(payload: LoginPayload): Promise<TokenResponse> {
+  return api<TokenResponse>('/auth/login', { method: 'POST', body: payload })
+}
+
+// `currentPassword` is required only when the caller already has a password on file.
+// OAuth-only users attaching a password for the first time pass null — the server
+// trusts the OAuth login that minted the token as proof of account control.
+export function setPassword(currentPassword: string | null, newPassword: string): Promise<void> {
+  return api<void>('/auth/password', {
+    method: 'POST',
+    body: { currentPassword, newPassword },
+  })
 }

--- a/web/src/assets/base.css
+++ b/web/src/assets/base.css
@@ -38,6 +38,10 @@
   /* Vendor brand colors (theme-agnostic — locked to provider identity) */
   --color-discord: #5865f2;
   --color-discord-hover: #4752c4;
+  /* Google's official dark-button colors (2023 brand refresh). Required by
+     Google's identity guidelines — we can't substitute with project palette. */
+  --color-google: #131314;
+  --color-google-hover: #1f2024;
 
   /* Radius */
   --radius-sm: 0.375rem;

--- a/web/src/router/__tests__/index.spec.ts
+++ b/web/src/router/__tests__/index.spec.ts
@@ -68,6 +68,7 @@ describe('router beforeEach guard', () => {
       bio: null,
       avatarUrl: null,
       createdAt: '',
+      hasPassword: false,
     })
 
     await router.push('/upload')

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -15,9 +15,20 @@ const router = createRouter({
       component: () => import('@/views/LoginView.vue'),
     },
     {
+      path: '/register',
+      name: 'register',
+      component: () => import('@/views/RegisterView.vue'),
+    },
+    {
       path: '/upload',
       name: 'upload',
       component: () => import('@/views/UploadView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/settings/password',
+      name: 'settings-password',
+      component: () => import('@/views/SettingsPasswordView.vue'),
       meta: { requiresAuth: true },
     },
     {

--- a/web/src/stores/__tests__/auth.spec.ts
+++ b/web/src/stores/__tests__/auth.spec.ts
@@ -55,6 +55,7 @@ describe('useAuthStore', () => {
       bio: null,
       avatarUrl: null,
       createdAt: '',
+      hasPassword: false,
     })
 
     const auth = useAuthStore()
@@ -105,6 +106,7 @@ describe('useAuthStore', () => {
       bio: null,
       avatarUrl: null,
       createdAt: '',
+      hasPassword: true,
     })
 
     expect(auth.user?.username).toBe('zoe')

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
+import { nextTick, ref, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { login, oauthStartUrl } from '@/api/auth'
@@ -31,6 +31,21 @@ const email = ref('')
 const password = ref('')
 const submitting = ref(false)
 const formError = ref<string | null>(null)
+
+// Progressive disclosure: keep the OAuth buttons as the primary path on first
+// paint and only reveal the email form when the user explicitly opts into it.
+// Matches the convention used by GitHub / Linear / Vercel etc — fewest fields
+// to reach the most-common path.
+const showEmailForm = ref(false)
+const emailInputRef = ref<HTMLInputElement | null>(null)
+
+async function revealEmailForm() {
+  showEmailForm.value = true
+  // Auto-focus the email input on the next tick so keyboard users don't lose
+  // momentum tabbing through the OAuth buttons before reaching it.
+  await nextTick()
+  emailInputRef.value?.focus()
+}
 
 async function submitLogin(event: Event) {
   event.preventDefault()
@@ -121,11 +136,48 @@ async function devSignIn(username = 'seeduser') {
         </p>
       </div>
 
-      <!-- Email/password form -->
-      <form class="flex flex-col gap-3" @submit="submitLogin">
+      <!-- OAuth buttons (top — modern convention: surface the fastest path first) -->
+      <div class="flex flex-col gap-3">
+        <a
+          :href="oauthStartUrl('discord', returnTo)"
+          class="flex items-center justify-center gap-2.5 rounded-md bg-discord px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-white no-underline transition-colors duration-150 hover:bg-discord-hover"
+        >
+          <IconDiscord :size="20" class="shrink-0" />
+          Continue with Discord
+        </a>
+
+        <a
+          :href="oauthStartUrl('google', returnTo)"
+          class="flex items-center justify-center gap-2.5 rounded-md bg-google px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-white no-underline transition-colors duration-150 hover:bg-google-hover"
+        >
+          <IconGoogle :size="20" class="shrink-0" />
+          Continue with Google
+        </a>
+      </div>
+
+      <div class="my-4 flex items-center gap-3">
+        <div class="h-px flex-1 bg-border"></div>
+        <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted"> or </span>
+        <div class="h-px flex-1 bg-border"></div>
+      </div>
+
+      <!-- Collapsed state: a single "Continue with email" button matching the
+           OAuth buttons' visual weight. Clicking expands to the full form. -->
+      <button
+        v-if="!showEmailForm"
+        type="button"
+        class="flex w-full items-center justify-center gap-2.5 rounded-md border border-border-strong bg-surface-overlay px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-text-primary transition-[background-color,border-color] duration-150 hover:border-border-hover hover:bg-surface-raised"
+        @click="revealEmailForm"
+      >
+        Continue with email
+      </button>
+
+      <!-- Expanded state: actual email/password form -->
+      <form v-else class="flex flex-col gap-3" @submit="submitLogin">
         <label class="flex flex-col gap-1.5">
           <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">Email</span>
           <input
+            ref="emailInputRef"
             v-model="email"
             type="email"
             autocomplete="email"
@@ -150,46 +202,23 @@ async function devSignIn(username = 'seeduser') {
           :disabled="submitting"
           class="flex items-center justify-center gap-2 rounded-md bg-brand px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-white transition-colors duration-150 hover:bg-brand-light disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {{ submitting ? 'Signing in…' : 'Sign in' }}
+          {{ submitting ? 'Signing in…' : 'Sign in with email' }}
         </button>
         <p v-if="formError" class="m-0 font-mono text-[11px] tracking-wide text-error" role="alert">
           {{ formError }}
         </p>
-        <p class="m-0 mt-1 text-center font-body text-xs text-text-secondary">
-          New to GankedTV?
-          <RouterLink
-            :to="{ name: 'register', query: returnTo ? { redirect: returnTo } : {} }"
-            class="font-heading uppercase tracking-[0.04em] text-text-primary no-underline hover:text-brand"
-            >Create an account</RouterLink
-          >
-        </p>
       </form>
 
-      <div class="my-4 flex items-center gap-3">
-        <div class="h-px flex-1 bg-border"></div>
-        <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted"> or </span>
-        <div class="h-px flex-1 bg-border"></div>
-      </div>
-
-      <div class="flex flex-col gap-3">
-        <!-- Discord button -->
-        <a
-          :href="oauthStartUrl('discord', returnTo)"
-          class="flex items-center justify-center gap-2.5 rounded-md bg-discord px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-white no-underline transition-colors duration-150 hover:bg-discord-hover"
+      <!-- Always-visible registration link — new users won't think to expand
+           the email form first, so it stays outside the conditional. -->
+      <p class="m-0 mt-4 text-center font-body text-xs text-text-secondary">
+        New to GankedTV?
+        <RouterLink
+          :to="{ name: 'register', query: returnTo ? { redirect: returnTo } : {} }"
+          class="font-heading uppercase tracking-[0.04em] text-text-primary no-underline hover:text-brand"
+          >Create an account</RouterLink
         >
-          <IconDiscord :size="20" class="shrink-0" />
-          Continue with Discord
-        </a>
-
-        <!-- Google button -->
-        <a
-          :href="oauthStartUrl('google', returnTo)"
-          class="flex items-center justify-center gap-2.5 rounded-md border border-border-strong bg-surface-overlay px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-text-primary no-underline transition-[background-color,border-color] duration-150 hover:border-border-hover hover:bg-surface-raised"
-        >
-          <IconGoogle :size="20" class="shrink-0" />
-          Continue with Google
-        </a>
-      </div>
+      </p>
 
       <!-- Dev sign-in (local only — never bundled in production builds) -->
       <div v-if="isDev" class="mt-5 border-t border-border pt-5">

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -2,8 +2,8 @@
 import { ref, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { oauthStartUrl } from '@/api/auth'
-import { api } from '@/api/client'
+import { login, oauthStartUrl } from '@/api/auth'
+import { api, ApiError } from '@/api/client'
 import IconDiscord from '@/components/icons/IconDiscord.vue'
 import IconGoogle from '@/components/icons/IconGoogle.vue'
 
@@ -27,9 +27,46 @@ watchEffect(() => {
   }
 })
 
+const email = ref('')
+const password = ref('')
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+
+async function submitLogin(event: Event) {
+  event.preventDefault()
+  formError.value = null
+  submitting.value = true
+  try {
+    const tokens = await login({ email: email.value, password: password.value })
+    auth.setSession(tokens.token, tokens.refresh)
+    await auth.fetchMe()
+    router.replace(returnTo || '/')
+  } catch (err) {
+    formError.value = mapLoginError(err)
+  } finally {
+    submitting.value = false
+  }
+}
+
+function mapLoginError(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 401) {
+      return 'Email or password is incorrect. If you signed up with Discord or Google, use those buttons instead.'
+    }
+    if (err.status === 429) {
+      return 'Too many sign-in attempts. Wait a minute and try again.'
+    }
+    if (err.status === 400) {
+      return 'Please enter a valid email address.'
+    }
+  }
+  return 'Sign-in failed. Try again.'
+}
+
 // Dev-only sign-in: hits the /dev/token endpoint (mounted only when the API is in
-// Development mode) and drops the resulting JWT into the auth store. This is the
-// stand-in until manual email/password registration lands (issue #62).
+// Development mode) and drops the resulting JWT into the auth store. Kept alongside
+// the email/password form because it bypasses password auth — useful for tests where
+// the seeded password might have been rotated.
 const isDev = import.meta.env.DEV
 const devLoading = ref(false)
 const devError = ref<string | null>(null)
@@ -80,8 +117,58 @@ async function devSignIn(username = 'seeduser') {
           Sign In
         </h1>
         <p class="m-0 font-body text-sm text-text-secondary">
-          Connect with your gaming account to continue
+          Sign in with your email or a connected account
         </p>
+      </div>
+
+      <!-- Email/password form -->
+      <form class="flex flex-col gap-3" @submit="submitLogin">
+        <label class="flex flex-col gap-1.5">
+          <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">Email</span>
+          <input
+            v-model="email"
+            type="email"
+            autocomplete="email"
+            required
+            class="rounded-md border border-border-strong bg-surface-overlay px-3 py-2 font-body text-sm text-text-primary outline-none focus:border-border-hover"
+          />
+        </label>
+        <label class="flex flex-col gap-1.5">
+          <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">
+            Password
+          </span>
+          <input
+            v-model="password"
+            type="password"
+            autocomplete="current-password"
+            required
+            class="rounded-md border border-border-strong bg-surface-overlay px-3 py-2 font-body text-sm text-text-primary outline-none focus:border-border-hover"
+          />
+        </label>
+        <button
+          type="submit"
+          :disabled="submitting"
+          class="flex items-center justify-center gap-2 rounded-md bg-brand px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-white transition-colors duration-150 hover:bg-brand-light disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {{ submitting ? 'Signing in…' : 'Sign in' }}
+        </button>
+        <p v-if="formError" class="m-0 font-mono text-[11px] tracking-wide text-error" role="alert">
+          {{ formError }}
+        </p>
+        <p class="m-0 mt-1 text-center font-body text-xs text-text-secondary">
+          New to GankedTV?
+          <RouterLink
+            :to="{ name: 'register', query: returnTo ? { redirect: returnTo } : {} }"
+            class="font-heading uppercase tracking-[0.04em] text-text-primary no-underline hover:text-brand"
+            >Create an account</RouterLink
+          >
+        </p>
+      </form>
+
+      <div class="my-4 flex items-center gap-3">
+        <div class="h-px flex-1 bg-border"></div>
+        <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted"> or </span>
+        <div class="h-px flex-1 bg-border"></div>
       </div>
 
       <div class="flex flex-col gap-3">
@@ -93,13 +180,6 @@ async function devSignIn(username = 'seeduser') {
           <IconDiscord :size="20" class="shrink-0" />
           Continue with Discord
         </a>
-
-        <!-- Divider -->
-        <div class="flex items-center gap-3">
-          <div class="h-px flex-1 bg-border"></div>
-          <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted"> or </span>
-          <div class="h-px flex-1 bg-border"></div>
-        </div>
 
         <!-- Google button -->
         <a

--- a/web/src/views/RegisterView.vue
+++ b/web/src/views/RegisterView.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { register } from '@/api/auth'
+import { ApiError } from '@/api/client'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const rawRedirect = route.query.redirect
+let returnTo: string | undefined
+if (
+  typeof rawRedirect === 'string' &&
+  rawRedirect.startsWith('/') &&
+  !rawRedirect.startsWith('//')
+) {
+  returnTo = rawRedirect
+}
+
+watchEffect(() => {
+  if (auth.isAuthenticated) {
+    router.replace(returnTo || '/')
+  }
+})
+
+const email = ref('')
+const username = ref('')
+const password = ref('')
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+
+async function submitRegister(event: Event) {
+  event.preventDefault()
+  formError.value = null
+  submitting.value = true
+  try {
+    const tokens = await register({
+      email: email.value,
+      username: username.value,
+      password: password.value,
+    })
+    auth.setSession(tokens.token, tokens.refresh)
+    await auth.fetchMe()
+    router.replace(returnTo || '/')
+  } catch (err) {
+    formError.value = mapRegisterError(err)
+  } finally {
+    submitting.value = false
+  }
+}
+
+function mapRegisterError(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 409) {
+      return 'An account with this email already exists. Sign in with your existing method, then attach a password from your profile.'
+    }
+    if (err.status === 429) {
+      return 'Too many registration attempts. Wait a minute and try again.'
+    }
+    if (err.status === 400) {
+      const detail = errorDetail(err)
+      if (detail) return detail
+      return 'Check the email and password requirements (min 12 characters) and try again.'
+    }
+  }
+  return 'Sign-up failed. Try again.'
+}
+
+function errorDetail(err: ApiError): string | null {
+  const body = err.body as { detail?: string } | null
+  return body && typeof body.detail === 'string' && body.detail.length > 0 ? body.detail : null
+}
+</script>
+
+<template>
+  <div class="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center gap-8 px-6">
+    <div class="flex flex-col items-center gap-2.5 text-center">
+      <div class="flex items-center gap-2.5">
+        <span class="logo__mark"></span>
+        <span
+          class="font-display text-[28px] font-bold uppercase tracking-[0.04em] text-text-primary"
+        >
+          GANKED.TV
+        </span>
+      </div>
+      <div class="font-mono text-[11px] uppercase tracking-widest text-text-muted">
+        No algorithm. Just clips.
+      </div>
+    </div>
+
+    <div class="w-full max-w-100 rounded-lg border border-border bg-surface-raised px-8 py-9">
+      <div class="mb-6 text-center">
+        <h1 class="m-0 mb-2 font-heading text-[32px] font-bold uppercase text-text-primary">
+          Create account
+        </h1>
+        <p class="m-0 font-body text-sm text-text-secondary">
+          Pick a handle, set a password — no third-party account required.
+        </p>
+      </div>
+
+      <form class="flex flex-col gap-3" @submit="submitRegister">
+        <label class="flex flex-col gap-1.5">
+          <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">Email</span>
+          <input
+            v-model="email"
+            type="email"
+            autocomplete="email"
+            required
+            class="rounded-md border border-border-strong bg-surface-overlay px-3 py-2 font-body text-sm text-text-primary outline-none focus:border-border-hover"
+          />
+        </label>
+        <label class="flex flex-col gap-1.5">
+          <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">
+            Username
+          </span>
+          <input
+            v-model="username"
+            type="text"
+            autocomplete="username"
+            required
+            minlength="1"
+            maxlength="30"
+            class="rounded-md border border-border-strong bg-surface-overlay px-3 py-2 font-body text-sm text-text-primary outline-none focus:border-border-hover"
+          />
+        </label>
+        <label class="flex flex-col gap-1.5">
+          <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">
+            Password (min 12)
+          </span>
+          <input
+            v-model="password"
+            type="password"
+            autocomplete="new-password"
+            required
+            minlength="12"
+            maxlength="128"
+            class="rounded-md border border-border-strong bg-surface-overlay px-3 py-2 font-body text-sm text-text-primary outline-none focus:border-border-hover"
+          />
+        </label>
+        <button
+          type="submit"
+          :disabled="submitting"
+          class="flex items-center justify-center gap-2 rounded-md bg-brand px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-[0.06em] text-white transition-colors duration-150 hover:bg-brand-light disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {{ submitting ? 'Creating account…' : 'Create account' }}
+        </button>
+        <p v-if="formError" class="m-0 font-mono text-[11px] tracking-wide text-error" role="alert">
+          {{ formError }}
+        </p>
+        <p class="m-0 mt-1 text-center font-body text-xs text-text-secondary">
+          Already have an account?
+          <RouterLink
+            :to="{ name: 'login', query: returnTo ? { redirect: returnTo } : {} }"
+            class="font-heading uppercase tracking-[0.04em] text-text-primary no-underline hover:text-brand"
+            >Sign in</RouterLink
+          >
+        </p>
+      </form>
+    </div>
+  </div>
+</template>

--- a/web/src/views/SettingsPasswordView.vue
+++ b/web/src/views/SettingsPasswordView.vue
@@ -32,6 +32,13 @@ async function submit(event: Event) {
     currentPassword.value = ''
     newPassword.value = ''
   } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      // Token rejected — bounce back to login. Do this in the catch (not in the
+      // pure mapError helper) so navigation/logout side effects stay co-located
+      // with the error-handling flow, matching the LoginView/RegisterView pattern.
+      auth.logout()
+      router.replace({ name: 'login' })
+    }
     formError.value = mapError(err)
   } finally {
     submitting.value = false
@@ -41,9 +48,6 @@ async function submit(event: Event) {
 function mapError(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.status === 401) {
-      // Token rejected — bounce back to login.
-      auth.logout()
-      router.replace({ name: 'login' })
       return 'Session expired. Sign in again.'
     }
     if (err.status === 400) {

--- a/web/src/views/SettingsPasswordView.vue
+++ b/web/src/views/SettingsPasswordView.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { setPassword } from '@/api/auth'
+import { ApiError } from '@/api/client'
+
+const router = useRouter()
+const auth = useAuthStore()
+
+// /auth/me reports `hasPassword` so we can switch between "Set password" (OAuth-only,
+// first-time attach) and "Change password" (rotation) copy. While the user is still
+// loading we default to the rotation form — harmless: if no password is set on the
+// server, the currentPassword field is just left blank and the server accepts it.
+const isFirstTimeSet = computed(() => auth.user?.hasPassword === false)
+
+const currentPassword = ref('')
+const newPassword = ref('')
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+const successMessage = ref<string | null>(null)
+
+async function submit(event: Event) {
+  event.preventDefault()
+  formError.value = null
+  successMessage.value = null
+  submitting.value = true
+  try {
+    const current = currentPassword.value.length > 0 ? currentPassword.value : null
+    await setPassword(current, newPassword.value)
+    successMessage.value = 'Password updated.'
+    currentPassword.value = ''
+    newPassword.value = ''
+  } catch (err) {
+    formError.value = mapError(err)
+  } finally {
+    submitting.value = false
+  }
+}
+
+function mapError(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 401) {
+      // Token rejected — bounce back to login.
+      auth.logout()
+      router.replace({ name: 'login' })
+      return 'Session expired. Sign in again.'
+    }
+    if (err.status === 400) {
+      const detail = (err.body as { code?: string; detail?: string } | null)?.detail
+      const code = (err.body as { code?: string } | null)?.code
+      if (code === 'wrong_current_password') {
+        return 'The current password you entered is incorrect.'
+      }
+      if (typeof detail === 'string' && detail.length > 0) {
+        return detail
+      }
+      return 'Password rejected. Pick a longer one (min 12 characters).'
+    }
+  }
+  return 'Update failed. Try again.'
+}
+</script>
+
+<template>
+  <div class="mx-auto flex w-full max-w-xl flex-col gap-6 px-6 py-10">
+    <header>
+      <h1 class="m-0 mb-1 font-heading text-[28px] font-bold uppercase text-text-primary">
+        {{ isFirstTimeSet ? 'Set password' : 'Change password' }}
+      </h1>
+      <p class="m-0 font-body text-sm text-text-secondary">
+        Adding a password lets you sign in with email + password in addition to your connected
+        accounts.
+      </p>
+    </header>
+
+    <form
+      class="flex flex-col gap-3 rounded-lg border border-border bg-surface-raised px-6 py-6"
+      @submit="submit"
+    >
+      <label class="flex flex-col gap-1.5">
+        <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">
+          Current password
+          <span v-if="isFirstTimeSet" class="normal-case tracking-normal text-text-muted">
+            (leave blank if you don't have one yet)
+          </span>
+        </span>
+        <input
+          v-model="currentPassword"
+          type="password"
+          autocomplete="current-password"
+          class="rounded-md border border-border-strong bg-surface-overlay px-3 py-2 font-body text-sm text-text-primary outline-none focus:border-border-hover"
+        />
+      </label>
+      <label class="flex flex-col gap-1.5">
+        <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">
+          New password (min 12)
+        </span>
+        <input
+          v-model="newPassword"
+          type="password"
+          autocomplete="new-password"
+          required
+          minlength="12"
+          maxlength="128"
+          class="rounded-md border border-border-strong bg-surface-overlay px-3 py-2 font-body text-sm text-text-primary outline-none focus:border-border-hover"
+        />
+      </label>
+      <button
+        type="submit"
+        :disabled="submitting"
+        class="flex items-center justify-center gap-2 rounded-md bg-brand px-5 py-3 font-heading text-[14px] font-bold uppercase tracking-[0.06em] text-white transition-colors duration-150 hover:bg-brand-light disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {{ submitting ? 'Saving…' : 'Save password' }}
+      </button>
+      <p v-if="formError" class="m-0 font-mono text-[11px] tracking-wide text-error" role="alert">
+        {{ formError }}
+      </p>
+      <p
+        v-if="successMessage"
+        class="m-0 font-mono text-[11px] tracking-wide text-text-secondary"
+        role="status"
+      >
+        {{ successMessage }}
+      </p>
+    </form>
+  </div>
+</template>

--- a/web/src/views/SettingsPasswordView.vue
+++ b/web/src/views/SettingsPasswordView.vue
@@ -28,6 +28,13 @@ async function submit(event: Event) {
   try {
     const current = currentPassword.value.length > 0 ? currentPassword.value : null
     await setPassword(current, newPassword.value)
+    // Sync the local user state so the heading flips from "Set password" to
+    // "Change password" without waiting for the next /auth/me poll. The server
+    // just confirmed the write (204), so we know the new state is correct —
+    // skip the extra roundtrip that fetchMe() would cost.
+    if (auth.user) {
+      auth.user.hasPassword = true
+    }
     successMessage.value = 'Password updated.'
     currentPassword.value = ''
     newPassword.value = ''

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -12,7 +12,12 @@ export default mergeConfig(
       root: fileURLToPath(new URL('./', import.meta.url)),
       passWithNoTests: true,
       coverage: {
-        provider: 'v8',
+        // Istanbul (source instrumentation) instead of v8 (precise-coverage inspector
+        // API). v8 needs `node:inspector`'s `Profiler.startPreciseCoverage`, which
+        // bun's polyfill doesn't implement on 1.3.13+ — local `make ci-web` runs
+        // crash with "Coverage APIs are not supported" before any tests execute.
+        // Istanbul rewrites the source and works under any runtime; CI is unaffected.
+        provider: 'istanbul',
         include: ['src/api/**', 'src/router/**', 'src/stores/**'],
         exclude: ['**/__tests__/**', '**/*.spec.ts', '**/*.test.ts', '**/*.d.ts'],
         reporter: ['text', 'text-summary', 'json-summary'],


### PR DESCRIPTION
## Summary

Bundles two Phase 1 — Core Loop tickets into one PR because they share infra surface and want the same integration-test pass: bumps Postgres 16 → 18 and ships manual email/password auth alongside the existing OAuth providers, so the log in → upload → see feed → like loop is usable in CI / contributor-laptop / demo-account setups without third-party creds. Also adds a `make ci` developer-convenience target that mirrors the GitHub workflows.

Closes #64
Closes #62

## What's here

- **Postgres 18** in dev compose + Testcontainers fixture. `PGDATA` pinned to `/var/lib/postgresql/data/pgdata` (subdir of the existing volume) so the data path is stable across future major-version bumps — the upstream default moves per-major.
- **Email/password endpoints** mirroring the OAuth surface: `POST /auth/register`, `POST /auth/login`, `POST /auth/password` (authenticated, handles both first-time set and rotation). Argon2id (Konscious, OWASP baseline parameters, PHC encoding so cost factors can rotate later). Per-IP `FixedWindowLimiter` of 5/min on register + login. Generic 401 on login with constant-time-equivalent dummy verify on missing-user / no-password paths.
- **Account-merge policy.** OAuth callback's existing `TryLinkByEmailAsync` already covers OAuth↔OAuth and OAuth→password merging by verified email — kept as-is, regression test added. Password→OAuth direction is unsafe without email verification (deferred per the issue), so `/auth/register` returns 409 + nudges users to OAuth-then-attach via `POST /auth/password`.
- **Schema:** nullable `password_hash` + `password_algo` columns on `users` (extending vs separate table, per chat). Migration `AddUserPasswordCredentials`.
- **`/auth/me` now exposes `hasPassword: bool`** so the web settings view can switch between "Set password" and "Change password" copy correctly.
- **Web**: email/password form on `/login` alongside OAuth buttons, new `/register` view, new `/settings/password` view for OAuth users to attach a password.
- **Seed**: `seeduser@dev.local` / `testpass123!` documented in README. Idempotent — won't stomp on a rotated password.
- **`make ci` / `ci-server` / `ci-web`** mirror the GitHub workflow steps. Pre-push hook left untouched per direction (it scopes to changed dirs).
- **Coverage provider switched v8 → istanbul** in `vitest.config.ts` so `make ci-web` works under bun 1.3.13+ (bun's `node:inspector` polyfill doesn't implement the precise-coverage API v8 needs). CI numbers unchanged in shape.

## How to test manually

**One-time after pulling** (the PG18 PGDATA path move means existing local volumes need a wipe):

```bash
make clean && make up && make migrate && make seed
docker exec -it gankedtv-postgres-1 psql -U gankedtv -d gankedtv -c 'SELECT version();'  # expect PostgreSQL 18.x
```

**Full CI sweep**: `make ci` (server format/build/test+coverage, then web).

**Auth roundtrip:**

```bash
# Register
curl -X POST localhost:5000/auth/register -H 'content-type: application/json' \
  -d '{"email":"a@b.dev","username":"alice","password":"correct-horse-battery"}'

# Sign in as the seeded account
curl -X POST localhost:5000/auth/login -H 'content-type: application/json' \
  -d '{"email":"seeduser@dev.local","password":"testpass123!"}'

# Hit a protected route with the returned token
curl localhost:5000/auth/me -H "authorization: bearer <token>"

# Rate limit kicks in on the 6th login in 60s
for i in (seq 6); curl -s -o /dev/null -w "%{http_code}\n" -X POST localhost:5000/auth/login \
  -H 'content-type: application/json' -d '{"email":"x@y.z","password":"wrong-12345678"}'; end
# → 401, 401, 401, 401, 401, 429
```

**Account-merge sanity:**
- Register `b@c.dev` via `/auth/register`, then sign in via Discord/Google with a verified email matching `b@c.dev` → same user row, both `password_hash` and the provider id populated.
- Sign in via OAuth, then `POST /auth/password` with the access token to attach a password → `/auth/login` with that email succeeds and returns the same user.
- `POST /auth/register` with an email that already belongs to an OAuth-only account → 409 with `email_taken`.

**Web flow** (`make up && make server` + `make web`):
- `/register` → sign up → land on home authenticated.
- `/login` → sign in with `seeduser@dev.local` / `testpass123!` (or your registered account).
- OAuth buttons on `/login` still work — no regression.
- `/settings/password` switches to "Set password" copy when the account has no password (OAuth-only).

## Checklist

- [ ] One-time `make clean && make up && make migrate && make seed` run after pulling (PGDATA path moved).
- [ ] `make ci` passes locally (server 416/416 at 94/85, web 95/95 at 93/96).
- [ ] OAuth roundtrip still works after merging (regression-tested by the existing `AuthEndpointsCallbackTests` and a new `UserUpsertService` link-preserves-password test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email/password registration, credential login, and password set/change flows added.
  * UI: registration page, email/password sign-in option, and password settings page.
  * Login endpoint rate limiting to reduce abuse.
  * Stronger password rules enforced (longer minimum, common-password rejection).

* **Documentation**
  * Added local Makefile targets and README guidance to run full CI locally; seeded dev user credentials documented.

* **Tests**
  * Extensive auth, password policy, and rate-limit integration/unit tests added.

* **Chores**
  * Development Postgres image bumped to v18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->