### PR TITLE
chore: move dev API port from 5000 to 5050

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ S3_SECRET_KEY=minioadmin
 S3_PUBLIC_URL=
 
 # API
-API_PORT=5000
+API_PORT=5050
 ASPNETCORE_ENVIRONMENT=Development
 
 # JWT + refresh tokens
@@ -36,11 +36,11 @@ WEB_ORIGIN=http://localhost:5173
 
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
-DISCORD_REDIRECT_URI=http://localhost:5000/auth/discord/callback
+DISCORD_REDIRECT_URI=http://localhost:5050/auth/discord/callback
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-GOOGLE_REDIRECT_URI=http://localhost:5000/auth/google/callback
+GOOGLE_REDIRECT_URI=http://localhost:5050/auth/google/callback
 
 # Clip upload limits
 MAX_UPLOAD_SIZE_MB=500

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ gankedtv/
 
 | Service    | URL                    | Credentials              |
 |------------|------------------------|--------------------------|
-| API        | http://localhost:5000  | -                        |
+| API        | http://localhost:5050  | -                        |
 | Web        | http://localhost:5173  | -                        |
 | PostgreSQL | localhost:5435         | gankedtv / gankedtv_dev  |
 | MinIO API  | http://localhost:9000  | minioadmin / minioadmin  |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cd server
 dotnet run --project src/GankedTV.Api
 ```
 
-API available at `http://localhost:5000`
+API available at `http://localhost:5050`
 
 ### 3. Run the Web App
 

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -289,7 +289,7 @@ app.UseMiddleware<ErrorHandlingMiddleware>();
 // 404 for unmatched routes, 415 for unsupported media types) into ProblemDetails so every
 // error response from the API has the same JSON envelope regardless of origin.
 app.UseStatusCodePages();
-// Skip in dev — :5000 is plain HTTP and the redirect emits CORS-less 307s.
+// Skip in dev — :5050 is plain HTTP and the redirect emits CORS-less 307s.
 if (!app.Environment.IsDevelopment())
 {
     app.UseHttpsRedirection();

--- a/server/src/GankedTV.Api/Properties/launchSettings.json
+++ b/server/src/GankedTV.Api/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5000",
+      "applicationUrl": "http://localhost:5050",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7035;http://localhost:5000",
+      "applicationUrl": "https://localhost:7035;http://localhost:5050",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,5 @@
 const BASE_URL =
-  (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:5000'
+  (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:5050'
 
 export class ApiError extends Error {
   constructor(


### PR DESCRIPTION
## Summary
- macOS Monterey+ ControlCenter (AirPlay Receiver) binds `*:5000` at boot, colliding with the default ASP.NET dev port. When Kestrel still manages to bind `127.0.0.1:5000`, browsers can intermittently hit AirPlay instead, which responds without CORS headers and surfaces as `No 'Access-Control-Allow-Origin' header` / `ERR_FAILED`.
- Moves the dev port to **5050** in `launchSettings.json`, the web client default, `.env.example`, README, CLAUDE.md, and the `Program.cs` comment so every macOS contributor avoids the conflict without disabling AirPlay Receiver.

## Test plan
- [ ] `make dev-all` — server boots on `http://localhost:5050`, web boots on `:5173`
- [ ] Browser request `http://localhost:5173` → app loads, `/auth/me` returns 401 with proper CORS headers (no `ERR_FAILED`)
- [ ] `lsof -nP -iTCP:5050 -sTCP:LISTEN` shows only Kestrel (no ControlCenter conflict)
- [ ] Update any local `.env` files manually if they pin the old `API_PORT`/redirect URIs
- [ ] OAuth flows: anyone with Discord/Google app callbacks pointing at `:5000` needs to update their app config to `:5050`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local API port from 5000 to 5050 across development configuration and environment templates.
  * Updated OAuth callback URIs (Discord and Google) to use the new port.
  * Updated launch profiles and documentation to reflect new API endpoint port.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/75)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->