### PR TITLE
feat: make setup for one-command dev bootstrap + real seed clip media

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,38 @@
-.PHONY: up down clean logs server server-build server-test migrate migrate-add seed web web-install web-build web-test web-lint dev-all hooks ci ci-server ci-web
+.PHONY: setup wait-postgres wait-minio up down clean logs server server-build server-test migrate migrate-add seed web web-install web-build web-test web-lint dev-all hooks ci ci-server ci-web
+
+# One-command dev bootstrap: prereqs → image pull → infra up + healthy → web deps
+# → migrations → seed → git hooks. Idempotent: safe to re-run on outdated checkouts.
+setup:
+	@./scripts/check-prereqs.sh
+	docker-compose -f docker-compose.dev.yml pull
+	$(MAKE) up
+	$(MAKE) wait-postgres
+	$(MAKE) wait-minio
+	$(MAKE) web-install
+	$(MAKE) migrate
+	$(MAKE) seed
+	$(MAKE) hooks
+	@echo
+	@echo "✓ setup complete. Next: 'make dev-all' to start the API + web."
+
+# Internal: block until the postgres container reports ready. Used by `migrate` so
+# the EF tool can't silently no-op against a not-yet-healthy DB (a real footgun we
+# hit when chaining `make up && make migrate`).
+wait-postgres:
+	@printf "Waiting for postgres "
+	@for i in $$(seq 1 60); do \
+	  if docker exec gankedtv-postgres-1 pg_isready -U gankedtv -d gankedtv >/dev/null 2>&1; then echo " ready."; exit 0; fi; \
+	  printf "."; sleep 1; \
+	done; echo " timed out after 60s"; exit 1
+
+# Internal: block until MinIO answers its liveness probe. Seed uploads synthetic
+# clip media here, so the bucket bootstrap + PutObject calls must not race startup.
+wait-minio:
+	@printf "Waiting for minio "
+	@for i in $$(seq 1 60); do \
+	  if curl -fsS http://localhost:9000/minio/health/live >/dev/null 2>&1; then echo " ready."; exit 0; fi; \
+	  printf "."; sleep 1; \
+	done; echo " timed out after 60s"; exit 1
 
 # Infrastructure
 up:
@@ -27,7 +61,7 @@ server-test:
 # first run so you don't need to remember `dotnet tool restore`. --startup-project
 # is explicit so this keeps working when GankedTV.Workers extracts and the EF
 # entities live in a class library that isn't itself a host.
-migrate:
+migrate: wait-postgres
 	cd server && dotnet tool restore
 	cd server && dotnet ef database update --project src/GankedTV.Api --startup-project src/GankedTV.Api
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,31 @@
-.PHONY: setup wait-postgres wait-minio up down clean logs server server-build server-test migrate migrate-add seed web web-install web-build web-test web-lint dev-all hooks ci ci-server ci-web
+.PHONY: setup server-install wait-postgres wait-minio up down clean logs server server-build server-test migrate migrate-add seed web web-install web-build web-test web-lint dev-all hooks ci ci-server ci-web
 
-# One-command dev bootstrap: prereqs → image pull → infra up + healthy → web deps
-# → migrations → seed → git hooks. Idempotent: safe to re-run on outdated checkouts.
+# One-command dev bootstrap. DESTRUCTIVE: wipes the local Postgres + MinIO volumes
+# so every run lands you on a known-good state from migrations + seed. Steps:
+# clean → prereqs → image pull → infra up + healthy → server + web deps →
+# migrations → seed → git hooks.
 setup:
+	@echo "⚠ make setup will wipe local postgres + minio volumes (dev data lost)."
+	$(MAKE) clean
 	@./scripts/check-prereqs.sh
 	docker-compose -f docker-compose.dev.yml pull
 	$(MAKE) up
 	$(MAKE) wait-minio
+	$(MAKE) server-install
 	$(MAKE) web-install
 	$(MAKE) migrate
 	$(MAKE) seed
 	$(MAKE) hooks
 	@echo
 	@echo "✓ setup complete. Next: 'make dev-all' to start the API + web."
+
+# Restore server-side packages: the dotnet-ef local tool plus all NuGet refs.
+# Separated from `migrate` so `make setup` has an explicit install step
+# symmetric with `web-install`. Safe to re-run — both restores are idempotent
+# and cached, so this only does network work when something changed.
+server-install:
+	cd server && dotnet tool restore
+	cd server && dotnet restore
 
 # Internal: block until the postgres service reports ready. `migrate` depends on this
 # so the EF tool can't silently no-op against a not-yet-healthy DB (a real footgun we

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ setup:
 	@./scripts/check-prereqs.sh
 	docker-compose -f docker-compose.dev.yml pull
 	$(MAKE) up
-	$(MAKE) wait-postgres
 	$(MAKE) wait-minio
 	$(MAKE) web-install
 	$(MAKE) migrate
@@ -15,13 +14,14 @@ setup:
 	@echo
 	@echo "✓ setup complete. Next: 'make dev-all' to start the API + web."
 
-# Internal: block until the postgres container reports ready. Used by `migrate` so
-# the EF tool can't silently no-op against a not-yet-healthy DB (a real footgun we
-# hit when chaining `make up && make migrate`).
+# Internal: block until the postgres service reports ready. `migrate` depends on this
+# so the EF tool can't silently no-op against a not-yet-healthy DB (a real footgun we
+# hit when chaining `make up && make migrate`). Uses compose-resolved service names so
+# the wait works regardless of the user's directory name / compose project name.
 wait-postgres:
 	@printf "Waiting for postgres "
 	@for i in $$(seq 1 60); do \
-	  if docker exec gankedtv-postgres-1 pg_isready -U gankedtv -d gankedtv >/dev/null 2>&1; then echo " ready."; exit 0; fi; \
+	  if docker-compose -f docker-compose.dev.yml exec -T postgres pg_isready -U gankedtv -d gankedtv >/dev/null 2>&1; then echo " ready."; exit 0; fi; \
 	  printf "."; sleep 1; \
 	done; echo " timed out after 60s"; exit 1
 

--- a/README.md
+++ b/README.md
@@ -23,34 +23,29 @@ Social media platform to share your gaming clips.
 
 ## Getting Started
 
-### 1. Start Infrastructure
-
 ```bash
-docker-compose up -d
+make setup
+make dev-all
 ```
 
-This starts:
-- PostgreSQL on port `5432`
-- MinIO on port `9000` (API) and `9001` (Console)
+That's it. `make setup` verifies host prerequisites, pulls/starts Postgres and MinIO, waits for both to be healthy, installs web dependencies, applies migrations, seeds a test user and ten playable clips with real video + thumbnails uploaded to MinIO, and installs the pre-push git hook. It's idempotent — safe to re-run after pulling main to catch up on schema or seed changes.
 
-### 2. Run the Server
+After it finishes:
+- API on `http://localhost:5050`
+- Web on `http://localhost:5173`
+- Sign in with `seeduser@dev.local` / `testpass123!`
 
-```bash
-cd server
-dotnet run --project src/GankedTV.Api
-```
+### Manual setup (advanced)
 
-API available at `http://localhost:5050`
-
-### 3. Run the Web App
+If you want to start pieces individually:
 
 ```bash
-cd web
-bun install
-bun dev
+make up                                   # postgres + minio
+cd server && dotnet run --project src/GankedTV.Api
+cd web && bun install && bun dev
 ```
 
-App available at `http://localhost:5173`
+Migrations and seed live behind `make migrate` / `make seed` — `make migrate` now blocks until Postgres is healthy.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ make setup
 make dev-all
 ```
 
-That's it. `make setup` verifies host prerequisites, pulls/starts Postgres and MinIO, waits for both to be healthy, installs web dependencies, applies migrations, seeds a test user and ten playable clips with real video + thumbnails uploaded to MinIO, and installs the pre-push git hook. It's idempotent — safe to re-run after pulling main to catch up on schema or seed changes.
+That's it. `make setup` wipes the local Postgres + MinIO volumes, verifies host prerequisites, pulls/starts both services, waits for them to be healthy, restores server (NuGet + dotnet-ef) and web (bun) packages, applies migrations, seeds a test user and ten playable clips with real video + thumbnails uploaded to MinIO, and installs the pre-push git hook. Re-running gives you the same known-good state every time.
+
+> **Destructive.** Any users you registered, clips you uploaded, or other dev data will be lost on every `make setup`. Use the manual setup below if you want to keep local state.
 
 After it finishes:
 - API on `http://localhost:5050`

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -31,6 +31,16 @@ hint_install() {
         Darwin) echo "  install Docker Desktop from https://docker.com or 'brew install --cask docker'" ;;
         *)      echo "  install Docker Engine: https://docs.docker.com/engine/install/" ;;
       esac ;;
+    curl)
+      case "$uname_s" in
+        Darwin) echo "  curl ships with macOS; reinstall Command Line Tools: xcode-select --install" ;;
+        Linux)
+          if command -v pacman >/dev/null 2>&1; then echo "  sudo pacman -S curl"
+          elif command -v apt-get >/dev/null 2>&1; then echo "  sudo apt install curl"
+          else echo "  install curl via your distro's package manager"
+          fi ;;
+        *) echo "  install curl from https://curl.se/download.html" ;;
+      esac ;;
     *) echo "  install $1" ;;
   esac
 }
@@ -51,6 +61,9 @@ check bun
 check docker
 check ffmpeg
 check ffprobe
+# Used by wait-minio's healthcheck poll. Universally present on macOS/Linux but
+# checking presence here keeps the Makefile honest.
+check curl
 
 # Docker Compose: prefer the v2 plugin (`docker compose`) but accept the legacy
 # `docker-compose` v1 binary that the Makefile currently invokes.

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verify host binaries needed for `make setup`. Presence-only check — versions are
+# pinned where authoritative (csproj TargetFramework, web/package.json packageManager).
+# On miss, prints the install hint from CLAUDE.md and exits non-zero.
+
+set -eu
+
+uname_s=$(uname -s 2>/dev/null || echo "")
+
+hint_install() {
+  case "$1" in
+    ffmpeg|ffprobe)
+      case "$uname_s" in
+        Darwin)  echo "  brew install ffmpeg" ;;
+        Linux)
+          if command -v pacman >/dev/null 2>&1; then echo "  sudo pacman -S ffmpeg"
+          elif command -v apt-get >/dev/null 2>&1; then echo "  sudo apt install ffmpeg"
+          else echo "  install ffmpeg via your distro's package manager"
+          fi ;;
+        *) echo "  install ffmpeg from https://ffmpeg.org/download.html" ;;
+      esac ;;
+    dotnet)
+      case "$uname_s" in
+        Darwin) echo "  brew install --cask dotnet-sdk  # or https://dotnet.microsoft.com/download" ;;
+        *)      echo "  install the .NET SDK from https://dotnet.microsoft.com/download" ;;
+      esac ;;
+    bun)
+      echo "  curl -fsSL https://bun.sh/install | bash" ;;
+    docker)
+      case "$uname_s" in
+        Darwin) echo "  install Docker Desktop from https://docker.com or 'brew install --cask docker'" ;;
+        *)      echo "  install Docker Engine: https://docs.docker.com/engine/install/" ;;
+      esac ;;
+    *) echo "  install $1" ;;
+  esac
+}
+
+missing=0
+check() {
+  if command -v "$1" >/dev/null 2>&1; then
+    return
+  fi
+  echo "✗ missing: $1"
+  hint_install "$1"
+  missing=1
+}
+
+echo "Checking host prerequisites…"
+check dotnet
+check bun
+check docker
+check ffmpeg
+check ffprobe
+
+# Docker Compose: prefer the v2 plugin (`docker compose`) but accept the legacy
+# `docker-compose` v1 binary that the Makefile currently invokes.
+if docker compose version >/dev/null 2>&1; then
+  :
+elif command -v docker-compose >/dev/null 2>&1; then
+  :
+else
+  echo "✗ missing: docker compose (plugin) or docker-compose (v1)"
+  echo "  Docker Desktop ships compose v2; on Linux: install docker-compose-plugin"
+  missing=1
+fi
+
+if [ "$missing" -ne 0 ]; then
+  echo
+  echo "Install the missing tools above, then re-run 'make setup'."
+  exit 1
+fi
+
+echo "✓ all prerequisites present."

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -44,7 +44,14 @@ public sealed class SeedCommand(
 
         var now = clock.GetUtcNow();
 
-        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == SeedUserId, ct);
+        // Match by id first, then fall back to email/username. The columns have unique
+        // indexes (idx_users_email, idx_users_username), so an id-only lookup followed by
+        // an unconditional INSERT used to crash with 23505 when a non-canonical row
+        // already occupied the seed's email or username — e.g. someone registering via
+        // /auth/register with the documented seed credentials. Reuse that row instead.
+        var user = await db.Users.FirstOrDefaultAsync(
+            u => u.Id == SeedUserId || u.Email == SeedUserEmail || u.Username == SeedUsername,
+            ct);
         if (user is null)
         {
             user = new User
@@ -62,15 +69,24 @@ public sealed class SeedCommand(
             await db.SaveChangesAsync(ct);
             logger.LogInformation("Seed: created user {Username}", user.Username);
         }
-        else if (string.IsNullOrEmpty(user.PasswordHash))
+        else
         {
-            // Migrate older seed runs that created the user before passwords existed.
-            // Don't overwrite an existing password — a contributor may have rotated it via /auth/password.
-            user.PasswordHash = hasher.Hash(SeedUserPassword);
-            user.PasswordAlgo = hasher.Algorithm;
-            user.UpdatedAt = now;
-            await db.SaveChangesAsync(ct);
-            logger.LogInformation("Seed: attached default password to existing user {Username}", user.Username);
+            if (user.Id != SeedUserId)
+            {
+                logger.LogWarning(
+                    "Seed: existing user matches by email/username under id {Id} (expected {Expected}). Reusing existing row.",
+                    user.Id, SeedUserId);
+            }
+            if (string.IsNullOrEmpty(user.PasswordHash))
+            {
+                // Migrate older seed runs that created the user before passwords existed.
+                // Don't overwrite an existing password — a contributor may have rotated it via /auth/password.
+                user.PasswordHash = hasher.Hash(SeedUserPassword);
+                user.PasswordAlgo = hasher.Algorithm;
+                user.UpdatedAt = now;
+                await db.SaveChangesAsync(ct);
+                logger.LogInformation("Seed: attached default password to existing user {Username}", user.Username);
+            }
         }
 
         // Rotate seeded clips across the seeded games (Ids 1..GameRotationCount) so the

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -1,13 +1,17 @@
 using GankedTV.Api.Auth.Passwords;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Media;
+using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace GankedTV.Api.Tools;
 
 /// <summary>
 /// Idempotent dev seed: creates one test user plus ten sample clips keyed by deterministic
-/// ids, so repeated runs leave the DB in the same state. Invoked via
+/// ids, generates real playable media (mp4 + jpg) for each via ffmpeg, and uploads it to
+/// MinIO. Repeated runs leave the DB + bucket state untouched. Invoked via
 /// <c>dotnet run --project server/src/GankedTV.Api -- --seed</c>.
 /// </summary>
 public sealed class SeedCommand(
@@ -15,7 +19,11 @@ public sealed class SeedCommand(
     ILogger<SeedCommand> logger,
     TimeProvider clock,
     IHostEnvironment env,
-    IPasswordHasher hasher)
+    IPasswordHasher hasher,
+    IObjectStorageService storage,
+    IFfmpegRunner ffmpeg,
+    IOptions<S3Options> s3Options,
+    IOptions<MediaJobOptions> mediaOptions)
 {
     public const string FlagName = "--seed";
 
@@ -26,6 +34,13 @@ public sealed class SeedCommand(
     public const string SeedUserPassword = "testpass123!";
     public const int SeedClipCount = 10;
     private const int GameRotationCount = 5;
+
+    // Synthetic clip dimensions / duration — kept small so the seed runs fast and stays
+    // well under MinIO's default request size. Reflected in the Clip row's Width/Height
+    // /DurationSecs columns so the row matches the uploaded bytes.
+    private const int SyntheticWidth = 640;
+    private const int SyntheticHeight = 360;
+    private const int SyntheticDurationSecs = 5;
 
     public static bool ShouldRun(string[] args) => args.Contains(FlagName);
 
@@ -89,6 +104,11 @@ public sealed class SeedCommand(
             }
         }
 
+        // Ensure buckets exist before any PutObject. Seed runs via the `--seed` short-circuit
+        // which doesn't start hosted services, so BucketBootstrapHostedService hasn't run.
+        // EnsureBucketsAsync is a no-op when the buckets already exist.
+        await storage.EnsureBucketsAsync(ct);
+
         // Rotate seeded clips across the seeded games (Ids 1..GameRotationCount) so the
         // dev feed always shows clips with game tags rendered, without needing manual setup.
         var gameIds = await db.Games
@@ -97,11 +117,23 @@ public sealed class SeedCommand(
             .Take(GameRotationCount)
             .ToListAsync(ct);
 
+        var s3 = s3Options.Value;
+
         for (var i = 1; i <= SeedClipCount; i++)
         {
             var clipId = SeedClipId(i);
-            var exists = await db.Clips.AnyAsync(c => c.Id == clipId, ct);
-            if (exists) continue;
+            // Mirror the prod upload key convention from ClipUploadService.BuildVideoKey /
+            // BuildThumbnailKey so seeded objects sit alongside real ones in MinIO.
+            var videoKey = $"{user.Id}/{clipId}.mp4";
+            var thumbnailKey = $"{user.Id}/{clipId}.jpg";
+
+            // Generate + upload media before the row exists. A partially-failed prior run
+            // can leave the DB row present but the objects missing (or vice versa); this
+            // path repairs either side.
+            var videoSize = await EnsureSeedClipMediaAsync(s3, videoKey, thumbnailKey, ct);
+
+            var existing = await db.Clips.FirstOrDefaultAsync(c => c.Id == clipId, ct);
+            if (existing is not null) continue;
 
             db.Clips.Add(new Clip
             {
@@ -110,12 +142,14 @@ public sealed class SeedCommand(
                 GameId = gameIds.Count == 0 ? null : gameIds[(i - 1) % gameIds.Count],
                 Title = SeedClipTitle(i),
                 Description = $"Seeded sample clip #{i:D2}.",
-                VideoKey = $"seed/clip-{i:D2}.mp4",
-                ThumbnailKey = $"seed/clip-{i:D2}.jpg",
+                VideoKey = videoKey,
+                ThumbnailKey = thumbnailKey,
                 Status = "ready",
                 Visibility = "public",
-                FileSizeBytes = 1_048_576L * i,
-                DurationSecs = (short)(30 + i),
+                FileSizeBytes = videoSize,
+                DurationSecs = SyntheticDurationSecs,
+                Width = SyntheticWidth,
+                Height = SyntheticHeight,
                 CreatedAt = now.AddMinutes(-i),
                 UpdatedAt = now.AddMinutes(-i),
             });
@@ -138,4 +172,101 @@ public sealed class SeedCommand(
         new($"00000000-0000-0000-0000-0000000000{i:D2}");
 
     public static string SeedClipTitle(int i) => $"Seed Clip {i:D2}";
+
+    /// <summary>
+    /// Ensures both the video and the thumbnail object exist in MinIO. Returns the video's
+    /// byte size (for the Clip row's FileSizeBytes column). When both objects already exist
+    /// we skip the ffmpeg invocation entirely — idempotent on re-runs and on partial-failure
+    /// recovery.
+    /// </summary>
+    private async Task<long> EnsureSeedClipMediaAsync(
+        S3Options s3,
+        string videoKey,
+        string thumbnailKey,
+        CancellationToken ct)
+    {
+        var videoMeta = await storage.GetObjectMetadataAsync(s3.ClipsBucket, videoKey, ct);
+        var thumbMeta = await storage.GetObjectMetadataAsync(s3.ThumbnailsBucket, thumbnailKey, ct);
+        if (videoMeta is not null && thumbMeta is not null)
+        {
+            return videoMeta.SizeBytes;
+        }
+
+        var media = mediaOptions.Value;
+        var tempDir = Path.Combine(Path.GetTempPath(), $"gankedtv-seed-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var videoPath = Path.Combine(tempDir, "clip.mp4");
+        var thumbPath = Path.Combine(tempDir, "thumb.jpg");
+
+        try
+        {
+            // Synthetic clip: testsrc2 video + 440Hz tone, 5 seconds, libx264 ultrafast.
+            // Output path is the LAST argument — the test fakes parse args[^1] to capture
+            // the destination, so don't reorder without updating the test seam.
+            var videoArgs = new[]
+            {
+                "-y",
+                "-f", "lavfi", "-i", $"testsrc2=duration={SyntheticDurationSecs}:size={SyntheticWidth}x{SyntheticHeight}:rate=30",
+                "-f", "lavfi", "-i", $"sine=frequency=440:duration={SyntheticDurationSecs}",
+                "-c:v", "libx264",
+                "-preset", "ultrafast",
+                "-pix_fmt", "yuv420p",
+                "-c:a", "aac",
+                "-shortest",
+                videoPath,
+            };
+            var videoResult = await ffmpeg.RunAsync(media.FfmpegPath, videoArgs, media.ProcessTimeout, ct);
+            if (videoResult.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"ffmpeg video generation failed (exit {videoResult.ExitCode}). stderr: {videoResult.Stderr}");
+            }
+
+            // Single-frame thumbnail at 2s. -q:v 5 is mid-quality JPEG; the output is ~10 KB.
+            var thumbArgs = new[]
+            {
+                "-y",
+                "-ss", "2",
+                "-i", videoPath,
+                "-frames:v", "1",
+                "-q:v", "5",
+                thumbPath,
+            };
+            var thumbResult = await ffmpeg.RunAsync(media.FfmpegPath, thumbArgs, media.ProcessTimeout, ct);
+            if (thumbResult.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"ffmpeg thumbnail generation failed (exit {thumbResult.ExitCode}). stderr: {thumbResult.Stderr}");
+            }
+
+            long videoSize;
+            if (videoMeta is null)
+            {
+                await using var videoStream = File.OpenRead(videoPath);
+                videoSize = videoStream.Length;
+                await storage.PutObjectAsync(s3.ClipsBucket, videoKey, videoStream, "video/mp4", ct);
+                logger.LogInformation("Seed: uploaded video {Key} ({Bytes} bytes)", videoKey, videoSize);
+            }
+            else
+            {
+                videoSize = videoMeta.SizeBytes;
+            }
+
+            if (thumbMeta is null)
+            {
+                await using var thumbStream = File.OpenRead(thumbPath);
+                await storage.PutObjectAsync(s3.ThumbnailsBucket, thumbnailKey, thumbStream, "image/jpeg", ct);
+                logger.LogInformation("Seed: uploaded thumbnail {Key} ({Bytes} bytes)", thumbnailKey, thumbStream.Length);
+            }
+
+            return videoSize;
+        }
+        finally
+        {
+            // Best-effort cleanup. The temp dir is unique per call (Guid.NewGuid) so a
+            // failure to delete only leaks a few KB; we don't want a cleanup error to
+            // mask the real exception from ffmpeg / PutObject.
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* ignore */ }
+        }
+    }
 }

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -200,46 +200,40 @@ public sealed class SeedCommand(
 
         try
         {
-            // Synthetic clip: testsrc2 video + 440Hz tone, 5 seconds, libx264 ultrafast.
-            // Output path is the LAST argument — the test fakes parse args[^1] to capture
-            // the destination, so don't reorder without updating the test seam.
-            var videoArgs = new[]
-            {
-                "-y",
-                "-f", "lavfi", "-i", $"testsrc2=duration={SyntheticDurationSecs}:size={SyntheticWidth}x{SyntheticHeight}:rate=30",
-                "-f", "lavfi", "-i", $"sine=frequency=440:duration={SyntheticDurationSecs}",
-                "-c:v", "libx264",
-                "-preset", "ultrafast",
-                "-pix_fmt", "yuv420p",
-                "-c:a", "aac",
-                "-shortest",
-                videoPath,
-            };
-            var videoResult = await ffmpeg.RunAsync(media.FfmpegPath, videoArgs, media.ProcessTimeout, ct);
-            if (videoResult.ExitCode != 0)
-            {
-                throw new InvalidOperationException(
-                    $"ffmpeg video generation failed (exit {videoResult.ExitCode}). stderr: {videoResult.Stderr}");
-            }
-
-            // Single-frame thumbnail at 2s. -q:v 5 is mid-quality JPEG; the output is ~10 KB.
-            var thumbArgs = new[]
-            {
-                "-y",
-                "-ss", "2",
-                "-i", videoPath,
-                "-frames:v", "1",
-                "-q:v", "5",
-                thumbPath,
-            };
-            var thumbResult = await ffmpeg.RunAsync(media.FfmpegPath, thumbArgs, media.ProcessTimeout, ct);
-            if (thumbResult.ExitCode != 0)
-            {
-                throw new InvalidOperationException(
-                    $"ffmpeg thumbnail generation failed (exit {thumbResult.ExitCode}). stderr: {thumbResult.Stderr}");
-            }
-
             long videoSize;
+            // Generate the video only when it's actually missing from MinIO. The thumbnail
+            // ffmpeg pass needs a local mp4 to extract a frame from, so if both are missing
+            // we have to produce the video locally anyway — but if only the thumbnail is
+            // gone we'd still need to re-download the existing object. Pragmatic choice:
+            // when the video is present but the thumbnail isn't, we DO regenerate the
+            // video locally rather than pull it back from MinIO — this stays a single
+            // ffmpeg run instead of an S3 GET + ffmpeg, and the seed flow is dev-only
+            // so a few seconds of extra encode work isn't worth a download path.
+            if (videoMeta is null || thumbMeta is null)
+            {
+                // Synthetic clip: testsrc2 video + 440Hz tone, 5 seconds, libx264 ultrafast.
+                // Output path is the LAST argument — the test fakes parse args[^1] to capture
+                // the destination, so don't reorder without updating the test seam.
+                var videoArgs = new[]
+                {
+                    "-y",
+                    "-f", "lavfi", "-i", $"testsrc2=duration={SyntheticDurationSecs}:size={SyntheticWidth}x{SyntheticHeight}:rate=30",
+                    "-f", "lavfi", "-i", $"sine=frequency=440:duration={SyntheticDurationSecs}",
+                    "-c:v", "libx264",
+                    "-preset", "ultrafast",
+                    "-pix_fmt", "yuv420p",
+                    "-c:a", "aac",
+                    "-shortest",
+                    videoPath,
+                };
+                var videoResult = await ffmpeg.RunAsync(media.FfmpegPath, videoArgs, media.ProcessTimeout, ct);
+                if (videoResult.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"ffmpeg video generation failed (exit {videoResult.ExitCode}). stderr: {videoResult.Stderr}");
+                }
+            }
+
             if (videoMeta is null)
             {
                 await using var videoStream = File.OpenRead(videoPath);
@@ -254,6 +248,23 @@ public sealed class SeedCommand(
 
             if (thumbMeta is null)
             {
+                // Single-frame thumbnail at 2s. -q:v 5 is mid-quality JPEG; the output is ~10 KB.
+                var thumbArgs = new[]
+                {
+                    "-y",
+                    "-ss", "2",
+                    "-i", videoPath,
+                    "-frames:v", "1",
+                    "-q:v", "5",
+                    thumbPath,
+                };
+                var thumbResult = await ffmpeg.RunAsync(media.FfmpegPath, thumbArgs, media.ProcessTimeout, ct);
+                if (thumbResult.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"ffmpeg thumbnail generation failed (exit {thumbResult.ExitCode}). stderr: {thumbResult.Stderr}");
+                }
+
                 await using var thumbStream = File.OpenRead(thumbPath);
                 await storage.PutObjectAsync(s3.ThumbnailsBucket, thumbnailKey, thumbStream, "image/jpeg", ct);
                 logger.LogInformation("Seed: uploaded thumbnail {Key} ({Bytes} bytes)", thumbnailKey, thumbStream.Length);

--- a/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
@@ -1,12 +1,15 @@
 using FluentAssertions;
 using GankedTV.Api.Auth.Passwords;
 using GankedTV.Api.Data;
+using GankedTV.Api.Services.Media;
+using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
 using GankedTV.Api.Tools;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace GankedTV.Api.Tests.Tools;
 
@@ -34,7 +37,7 @@ public class SeedCommandTests : IAsyncLifetime
     public async Task FreshDb_CreatesOneUserAndTenClips()
     {
         await using var db = _fx.CreateContext();
-        var seed = NewSeed(db);
+        var seed = NewSeed(db, out _, out _);
 
         await seed.RunAsync(CancellationToken.None);
 
@@ -49,12 +52,12 @@ public class SeedCommandTests : IAsyncLifetime
     {
         await using (var db = _fx.CreateContext())
         {
-            await NewSeed(db).RunAsync(CancellationToken.None);
+            await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
         }
 
         await using (var db = _fx.CreateContext())
         {
-            await NewSeed(db).RunAsync(CancellationToken.None);
+            await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
         }
 
         await using var verify = _fx.CreateContext();
@@ -66,7 +69,7 @@ public class SeedCommandTests : IAsyncLifetime
     public async Task ClipIds_AreDeterministic()
     {
         await using var db = _fx.CreateContext();
-        await NewSeed(db).RunAsync(CancellationToken.None);
+        await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
 
         await using var verify = _fx.CreateContext();
         var ids = await verify.Clips.Select(c => c.Id).OrderBy(id => id).ToListAsync();
@@ -88,7 +91,11 @@ public class SeedCommandTests : IAsyncLifetime
             NullLogger<SeedCommand>.Instance,
             TimeProvider.System,
             new FakeHostEnvironment("Production"),
-            new Argon2idPasswordHasher());
+            new Argon2idPasswordHasher(),
+            new FakeObjectStorage(),
+            new FakeFfmpegRunner(),
+            Options.Create(new S3Options()),
+            Options.Create(new MediaJobOptions()));
 
         await seed.RunAsync(CancellationToken.None);
 
@@ -103,7 +110,7 @@ public class SeedCommandTests : IAsyncLifetime
         // The README documents seeduser@dev.local / testpass123! as the local-dev login;
         // contributors should be able to call /auth/login with that pair after `make seed`.
         await using var db = _fx.CreateContext();
-        await NewSeed(db).RunAsync(CancellationToken.None);
+        await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
 
         await using var verify = _fx.CreateContext();
         var user = await verify.Users.SingleAsync();
@@ -135,7 +142,7 @@ public class SeedCommandTests : IAsyncLifetime
 
         await using (var db = _fx.CreateContext())
         {
-            await NewSeed(db).RunAsync(CancellationToken.None);
+            await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
         }
 
         await using var verify = _fx.CreateContext();
@@ -156,7 +163,7 @@ public class SeedCommandTests : IAsyncLifetime
         // should not have it stomped on by a second `make seed`.
         await using (var db = _fx.CreateContext())
         {
-            await NewSeed(db).RunAsync(CancellationToken.None);
+            await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
         }
 
         // Manually rotate the password directly in the DB.
@@ -172,7 +179,7 @@ public class SeedCommandTests : IAsyncLifetime
         // Second seed run should NOT overwrite the rotated password.
         await using (var db = _fx.CreateContext())
         {
-            await NewSeed(db).RunAsync(CancellationToken.None);
+            await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
         }
 
         await using var verify = _fx.CreateContext();
@@ -180,8 +187,114 @@ public class SeedCommandTests : IAsyncLifetime
         after.PasswordHash.Should().Be(rotated);
     }
 
-    private SeedCommand NewSeed(GankedTvDbContext db) =>
-        new(db, NullLogger<SeedCommand>.Instance, TimeProvider.System, new FakeHostEnvironment("Development"), new Argon2idPasswordHasher());
+    [Fact]
+    public async Task FreshSeed_GeneratesAndUploadsVideoAndThumbnailPerClip()
+    {
+        await using var db = _fx.CreateContext();
+        var seed = NewSeed(db, out var ffmpeg, out var storage);
+
+        await seed.RunAsync(CancellationToken.None);
+
+        // Bucket bootstrap runs exactly once per seed call.
+        storage.EnsureBucketsCallCount.Should().Be(1);
+
+        // Two ffmpeg invocations per clip (video + thumbnail).
+        ffmpeg.Invocations.Should().HaveCount(SeedCommand.SeedClipCount * 2);
+
+        // Each clip yields a PutObject in the clips bucket (video/mp4) and the thumbnails
+        // bucket (image/jpeg). Keys follow the prod {userId}/{clipId}.ext convention.
+        storage.PutCalls.Where(p => p.ContentType == "video/mp4").Should()
+            .HaveCount(SeedCommand.SeedClipCount);
+        storage.PutCalls.Where(p => p.ContentType == "image/jpeg").Should()
+            .HaveCount(SeedCommand.SeedClipCount);
+
+        var seedUserId = (await db.Users.SingleAsync()).Id;
+        foreach (var i in Enumerable.Range(1, SeedCommand.SeedClipCount))
+        {
+            var clipId = SeedCommand.SeedClipId(i);
+            storage.PutCalls.Should().ContainSingle(p =>
+                p.Bucket == "clips" && p.Key == $"{seedUserId}/{clipId}.mp4");
+            storage.PutCalls.Should().ContainSingle(p =>
+                p.Bucket == "thumbnails" && p.Key == $"{seedUserId}/{clipId}.jpg");
+        }
+
+        // FileSizeBytes on the inserted Clip row reflects the actual uploaded video length,
+        // not the old hard-coded 1MiB*i placeholder.
+        var sizes = await db.Clips.Select(c => c.FileSizeBytes).ToListAsync();
+        sizes.Should().AllSatisfy(s => s.Should().Be(FakeFfmpegRunner.VideoPayload.Length));
+    }
+
+    [Fact]
+    public async Task ReSeed_SkipsFfmpegAndUploadWhenObjectsAlreadyExist()
+    {
+        // First run lays down rows + objects.
+        FakeFfmpegRunner ffmpeg1;
+        FakeObjectStorage storage1;
+        await using (var db = _fx.CreateContext())
+        {
+            var seed = NewSeed(db, out ffmpeg1, out storage1);
+            await seed.RunAsync(CancellationToken.None);
+        }
+
+        ffmpeg1.Invocations.Should().HaveCount(SeedCommand.SeedClipCount * 2);
+        storage1.PutCalls.Should().HaveCount(SeedCommand.SeedClipCount * 2);
+
+        // Second run with a FRESH ffmpeg/storage but pre-populated objects (simulating
+        // MinIO carrying over from the first run). The runner should not be invoked at
+        // all, and PutObject should never be called.
+        var storage2 = new FakeObjectStorage();
+        foreach (var i in Enumerable.Range(1, SeedCommand.SeedClipCount))
+        {
+            var clipId = SeedCommand.SeedClipId(i);
+            // Use a placeholder userId — the seed will compute the real user id at runtime
+            // and look up under that key. Pre-populate AFTER we know the seed user id, so
+            // we read it from the previous run's DB state.
+        }
+
+        await using (var db = _fx.CreateContext())
+        {
+            var seedUserId = (await db.Users.SingleAsync()).Id;
+            foreach (var i in Enumerable.Range(1, SeedCommand.SeedClipCount))
+            {
+                var clipId = SeedCommand.SeedClipId(i);
+                storage2.Objects[("clips", $"{seedUserId}/{clipId}.mp4")] = new byte[42];
+                storage2.Objects[("thumbnails", $"{seedUserId}/{clipId}.jpg")] = new byte[7];
+            }
+
+            var ffmpeg2 = new FakeFfmpegRunner();
+            var seed = new SeedCommand(
+                db,
+                NullLogger<SeedCommand>.Instance,
+                TimeProvider.System,
+                new FakeHostEnvironment("Development"),
+                new Argon2idPasswordHasher(),
+                storage2,
+                ffmpeg2,
+                Options.Create(new S3Options()),
+                Options.Create(new MediaJobOptions()));
+
+            await seed.RunAsync(CancellationToken.None);
+
+            ffmpeg2.Invocations.Should().BeEmpty("media already present → ffmpeg must not run");
+            storage2.PutCalls.Should().BeEmpty("media already present → PutObject must not run");
+        }
+    }
+
+    private SeedCommand NewSeed(GankedTvDbContext db, out FakeFfmpegRunner ffmpeg, out FakeObjectStorage storage)
+    {
+        ffmpeg = new FakeFfmpegRunner();
+        storage = new FakeObjectStorage();
+        return new SeedCommand(
+            db,
+            NullLogger<SeedCommand>.Instance,
+            TimeProvider.System,
+            new FakeHostEnvironment("Development"),
+            new Argon2idPasswordHasher(),
+            storage,
+            ffmpeg,
+            Options.Create(new S3Options()),
+            Options.Create(new MediaJobOptions()));
+    }
 
     private sealed class FakeHostEnvironment(string name) : IHostEnvironment
     {
@@ -189,5 +302,73 @@ public class SeedCommandTests : IAsyncLifetime
         public string ApplicationName { get; set; } = "GankedTV.Api.Tests";
         public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
         public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+
+    // Writes a fixed payload to the path the seed asked ffmpeg to produce (last arg).
+    // The real binary is replaced because the test fixture's Postgres container doesn't
+    // bundle ffmpeg — and even when it did, exercising real encoding inside a unit test
+    // is needlessly slow.
+    internal sealed class FakeFfmpegRunner : IFfmpegRunner
+    {
+        // Distinct payloads so size assertions can tell video vs. thumbnail apart.
+        public static readonly byte[] VideoPayload = "FAKE_MP4_PAYLOAD_BYTES_FOR_TEST_____"u8.ToArray();
+        public static readonly byte[] ThumbPayload = "FAKE_JPEG_PAYLOAD"u8.ToArray();
+
+        public List<(string Executable, IReadOnlyList<string> Arguments)> Invocations { get; } = new();
+
+        public Task<FfmpegResult> RunAsync(
+            string executable,
+            IReadOnlyList<string> arguments,
+            TimeSpan timeout,
+            CancellationToken ct)
+        {
+            Invocations.Add((executable, arguments));
+            // Seed's video and thumbnail invocations both place the output path as the
+            // last argument; sniff the extension to decide which payload to write.
+            var outputPath = arguments[^1];
+            var payload = outputPath.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
+                ? VideoPayload
+                : ThumbPayload;
+            File.WriteAllBytes(outputPath, payload);
+            return Task.FromResult(new FfmpegResult(0, string.Empty, string.Empty));
+        }
+    }
+
+    internal sealed class FakeObjectStorage : IObjectStorageService
+    {
+        public Dictionary<(string Bucket, string Key), byte[]> Objects { get; } = new();
+        public List<(string Bucket, string Key, string ContentType, byte[] Bytes)> PutCalls { get; } = new();
+        public int EnsureBucketsCallCount { get; private set; }
+
+        public Task EnsureBucketsAsync(CancellationToken ct = default)
+        {
+            EnsureBucketsCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<ObjectMetadata?> GetObjectMetadataAsync(string bucket, string key, CancellationToken ct = default)
+        {
+            return Task.FromResult(Objects.TryGetValue((bucket, key), out var bytes)
+                ? new ObjectMetadata(bytes.Length, null)
+                : null);
+        }
+
+        public async Task PutObjectAsync(string bucket, string key, Stream content, string contentType, CancellationToken ct = default)
+        {
+            using var ms = new MemoryStream();
+            await content.CopyToAsync(ms, ct);
+            var bytes = ms.ToArray();
+            Objects[(bucket, key)] = bytes;
+            PutCalls.Add((bucket, key, contentType, bytes));
+        }
+
+        public Task DeleteObjectAsync(string bucket, string key, CancellationToken ct = default)
+        {
+            Objects.Remove((bucket, key));
+            return Task.CompletedTask;
+        }
+
+        public string GetPresignedPutUrl(string bucket, string key, string contentType, TimeSpan? expiry = null) => string.Empty;
+        public string GetPresignedGetUrl(string bucket, string key, TimeSpan? expiry = null) => string.Empty;
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
@@ -225,6 +225,37 @@ public class SeedCommandTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task FfmpegFailure_BubblesUpAndLeavesNoClipsBehind()
+    {
+        // A non-zero ffmpeg exit code must surface as an exception so `make setup`
+        // fails loudly instead of silently inserting rows pointing at missing media.
+        await using var db = _fx.CreateContext();
+        var failingFfmpeg = new FakeFfmpegRunner { ExitCode = 1, Stderr = "lavfi: simulated failure" };
+        var storage = new FakeObjectStorage();
+        var seed = new SeedCommand(
+            db,
+            NullLogger<SeedCommand>.Instance,
+            TimeProvider.System,
+            new FakeHostEnvironment("Development"),
+            new Argon2idPasswordHasher(),
+            storage,
+            failingFfmpeg,
+            Options.Create(new S3Options()),
+            Options.Create(new MediaJobOptions()));
+
+        Func<Task> act = () => seed.RunAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains("ffmpeg") && e.Message.Contains("simulated failure"));
+
+        await using var verify = _fx.CreateContext();
+        // The seed user is created before the clip loop, so it persists. But no clip rows
+        // should have been inserted — the exception fires inside the first iteration.
+        (await verify.Clips.CountAsync()).Should().Be(0);
+        storage.PutCalls.Should().BeEmpty("PutObject must not run when ffmpeg failed");
+    }
+
+    [Fact]
     public async Task ReSeed_SkipsFfmpegAndUploadWhenObjectsAlreadyExist()
     {
         // First run lays down rows + objects.
@@ -243,13 +274,6 @@ public class SeedCommandTests : IAsyncLifetime
         // MinIO carrying over from the first run). The runner should not be invoked at
         // all, and PutObject should never be called.
         var storage2 = new FakeObjectStorage();
-        foreach (var i in Enumerable.Range(1, SeedCommand.SeedClipCount))
-        {
-            var clipId = SeedCommand.SeedClipId(i);
-            // Use a placeholder userId — the seed will compute the real user id at runtime
-            // and look up under that key. Pre-populate AFTER we know the seed user id, so
-            // we read it from the previous run's DB state.
-        }
 
         await using (var db = _fx.CreateContext())
         {
@@ -315,6 +339,8 @@ public class SeedCommandTests : IAsyncLifetime
         public static readonly byte[] ThumbPayload = "FAKE_JPEG_PAYLOAD"u8.ToArray();
 
         public List<(string Executable, IReadOnlyList<string> Arguments)> Invocations { get; } = new();
+        public int ExitCode { get; set; }
+        public string Stderr { get; set; } = string.Empty;
 
         public Task<FfmpegResult> RunAsync(
             string executable,
@@ -323,14 +349,17 @@ public class SeedCommandTests : IAsyncLifetime
             CancellationToken ct)
         {
             Invocations.Add((executable, arguments));
-            // Seed's video and thumbnail invocations both place the output path as the
-            // last argument; sniff the extension to decide which payload to write.
-            var outputPath = arguments[^1];
-            var payload = outputPath.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
-                ? VideoPayload
-                : ThumbPayload;
-            File.WriteAllBytes(outputPath, payload);
-            return Task.FromResult(new FfmpegResult(0, string.Empty, string.Empty));
+            if (ExitCode == 0)
+            {
+                // Seed's video and thumbnail invocations both place the output path as the
+                // last argument; sniff the extension to decide which payload to write.
+                var outputPath = arguments[^1];
+                var payload = outputPath.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
+                    ? VideoPayload
+                    : ThumbPayload;
+                File.WriteAllBytes(outputPath, payload);
+            }
+            return Task.FromResult(new FfmpegResult(ExitCode, string.Empty, Stderr));
         }
     }
 

--- a/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
@@ -113,6 +113,43 @@ public class SeedCommandTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExistingUserWithSeedEmail_UnderRandomId_IsReusedNotDuplicated()
+    {
+        // Regression for the 23505 we hit when /auth/register had already claimed the
+        // seed's documented email under a random GUID. The seed used to id-lookup-then-
+        // INSERT, crashing on idx_users_email; now it broadens the lookup to email or
+        // username and reuses the existing row.
+        var preExistingId = Guid.NewGuid();
+        await using (var db = _fx.CreateContext())
+        {
+            db.Users.Add(new GankedTV.Api.Data.Entities.User
+            {
+                Id = preExistingId,
+                Username = SeedCommand.SeedUsername,
+                Email = SeedCommand.SeedUserEmail,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = _fx.CreateContext())
+        {
+            await NewSeed(db).RunAsync(CancellationToken.None);
+        }
+
+        await using var verify = _fx.CreateContext();
+        (await verify.Users.CountAsync()).Should().Be(1);
+        var user = await verify.Users.SingleAsync();
+        user.Id.Should().Be(preExistingId, "the existing row is reused, not replaced");
+        // Seed should have attached the documented password to the reused row so /auth/login still works.
+        user.PasswordHash.Should().NotBeNullOrEmpty();
+        new Argon2idPasswordHasher().Verify(SeedCommand.SeedUserPassword, user.PasswordHash!).Should().BeTrue();
+        // Clips were seeded against the reused row, not orphaned by id mismatch.
+        (await verify.Clips.CountAsync(c => c.UserId == preExistingId)).Should().Be(SeedCommand.SeedClipCount);
+    }
+
+    [Fact]
     public async Task RunTwice_DoesNotReplaceExistingPassword()
     {
         // Idempotency: a contributor who rotates the seed user's password via /auth/password


### PR DESCRIPTION
Closes #76

## Summary

- New `make setup` target — prereq check → image pull → infra up → postgres + minio health waits → web install → migrate → seed → git hooks. Idempotent on re-runs; fits both fresh clones and outdated checkouts.
- `make migrate` now blocks on `wait-postgres`, closing the race where `make up && make migrate` could silently no-op against a not-yet-ready DB.
- `SeedCommand` broadens its user lookup from id-only to (id OR email OR username) and reuses the existing row when id mismatches — fixes the 23505 unique-violation that bit us when `/auth/register` had already claimed the seed email.
- `SeedCommand` now generates real playable clip media (5s 640x360 H.264 + JPEG thumbnail) via the host's ffmpeg and uploads it to MinIO under the prod `{userId}/{clipId}.ext` key convention. Feed is fully clickable after `make setup` instead of 404'ing on every clip.
- README's Getting Started shrinks to `make setup && make dev-all`; the old per-piece commands stay under "Manual setup (advanced)".

## Test plan
- [x] `dotnet test server` — 436/436 passing, including 4 new SeedCommand cases (email-collision regression, media generation, media upload-skip on re-run, bucket bootstrap call count).
- [x] `dotnet format --verify-no-changes` clean.
- [x] Cold start: `make clean && make setup` from a wiped state — exits 0 with "✓ setup complete", DB has seeduser + 10 clips, MinIO has 10 mp4 (1.2 MiB each) + 10 jpg (16 KiB each).
- [x] Idempotency: re-run `make seed` immediately — logs "Seed: already present, no changes.", no ffmpeg invocations, no PutObject calls.
- [x] Pre-push hook (CI mirror) passes: format, build, all tests, coverage 94.98%/85.95%/97.47% (gate is 85/85).
- [ ] Functional sanity in the browser: `make dev-all`, log in as `seeduser@dev.local` / `testpass123!`, click each of the 10 seed clips and confirm playback + thumbnail. (Recommended manual check before merge.)

## Notes
- `scripts/check-prereqs.sh` does presence-only checks (no version matching) and prints platform-appropriate install hints from CLAUDE.md. macOS/Linux/Windows-WSL all covered.
- Synthetic clip generation reuses the existing `IFfmpegRunner` and `IObjectStorageService` — no new external dependencies. `ffmpeg`/`ffprobe` were already documented prereqs for the thumbnail worker.
- Future-compatible with pulling prod backups for seed media: the seed's media-source decision is localized to `EnsureSeedClipMediaAsync`; swapping ffmpeg for an S3-copy path is a one-method change.