### PR TITLE
feat: clip owner edit and delete actions

### DIFF
--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -257,6 +257,54 @@ describe('api/clips', () => {
     })
   })
 
+  describe('delete()', () => {
+    const CLIP_ID = 'a4f1e2c0-0000-0000-0000-000000000001'
+
+    it('DELETEs /clips/{id} and resolves to undefined on 204 No Content', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      )
+
+      const result = await clips.delete(CLIP_ID)
+
+      expect(result).toBeUndefined()
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips/${CLIP_ID}`)
+      expect(init.method).toBe('DELETE')
+    })
+
+    it('sends the bearer token when one is configured', async () => {
+      configureAuth({
+        getAccessToken: () => 'tok-xyz',
+        getRefreshToken: () => null,
+        onTokenRefreshed: () => {},
+        onRefreshFailed: () => {},
+      })
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      )
+
+      await clips.delete(CLIP_ID)
+
+      const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(new Headers(init.headers).get('Authorization')).toBe('Bearer tok-xyz')
+    })
+
+    it('throws ApiError on non-2xx with the response body', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ code: 'CLIP_NOT_OWNER' }, 403)),
+      )
+
+      await expect(clips.delete(CLIP_ID)).rejects.toMatchObject({
+        status: 403,
+        body: { code: 'CLIP_NOT_OWNER' },
+      })
+    })
+  })
+
   describe('like() / unlike()', () => {
     it('POSTs /clips/{id}/like and returns the new count + liked flag', async () => {
       vi.stubGlobal(

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -120,6 +120,10 @@ export const clips = {
     return api<ClipDetail>(`/clips/${encodeURIComponent(id)}`, { method: 'PATCH', body })
   },
 
+  delete(id: string): Promise<void> {
+    return api<void>(`/clips/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  },
+
   like(id: string): Promise<LikeResult> {
     return api<LikeResult>(`/clips/${encodeURIComponent(id)}/like`, { method: 'POST' })
   },

--- a/web/src/components/ClipEditDialog.vue
+++ b/web/src/components/ClipEditDialog.vue
@@ -45,9 +45,10 @@ const diff = computed((): UpdateClipBody => {
   const trimmedTitle = localTitle.value.trim()
   if (trimmedTitle !== props.clip.title) body.title = trimmedTitle
   // Normalize empty string ↔ null when comparing, but send "" to the server to clear.
-  const localDescNorm = localDesc.value === '' ? null : localDesc.value
+  const trimmedDesc = localDesc.value.trim()
+  const localDescNorm = trimmedDesc === '' ? null : trimmedDesc
   const originalDescNorm = props.clip.description || null
-  if (localDescNorm !== originalDescNorm) body.description = localDesc.value
+  if (localDescNorm !== originalDescNorm) body.description = trimmedDesc
   if ((localGame.value?.id ?? null) !== (props.clip.game?.id ?? null))
     body.gameId = localGame.value?.id ?? null
   if (localVisibility.value !== props.clip.visibility) body.visibility = localVisibility.value

--- a/web/src/components/ConfirmDialog.vue
+++ b/web/src/components/ConfirmDialog.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps<{
+  open: boolean
+  title: string
+  body: string
+  confirmLabel: string
+  cancelLabel?: string
+  variant?: 'danger' | 'default'
+  busy?: boolean
+}>()
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+
+const cancelBtn = ref<HTMLButtonElement | null>(null)
+
+watch(
+  () => props.open,
+  (open) => {
+    if (open) nextTick(() => cancelBtn.value?.focus())
+  },
+)
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && props.open && !props.busy) emit('cancel')
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      leave-active-class="transition-opacity duration-150"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-center justify-center px-4"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="`confirm-dialog-title-${title}`"
+      >
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/70" @click="!busy && emit('cancel')" />
+
+        <!-- Dialog card -->
+        <div
+          class="relative z-10 w-full max-w-lg rounded-md border border-border bg-surface-raised shadow-[0_0_40px_var(--color-brand-glow)]"
+          @click.stop
+        >
+          <!-- Header -->
+          <div class="flex items-center justify-between border-b border-border px-5 py-4">
+            <h2
+              :id="`confirm-dialog-title-${title}`"
+              class="font-heading text-lg font-bold uppercase tracking-[0.04em] text-text-primary"
+            >
+              {{ title }}
+            </h2>
+            <button
+              type="button"
+              :disabled="busy"
+              @click="emit('cancel')"
+              aria-label="Close"
+              class="cursor-pointer font-mono text-xl leading-none text-text-muted transition-colors duration-150 hover:text-text-primary disabled:pointer-events-none disabled:opacity-40"
+            >
+              ×
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="px-5 py-4 font-body text-sm leading-relaxed text-text-secondary">
+            {{ body }}
+          </div>
+
+          <!-- Footer -->
+          <div class="flex justify-end gap-2.5 border-t border-border px-5 py-4">
+            <button
+              ref="cancelBtn"
+              type="button"
+              :disabled="busy"
+              @click="emit('cancel')"
+              class="cursor-pointer rounded-md border border-border bg-surface-overlay px-5 py-2.5 font-heading text-sm font-bold uppercase tracking-wider text-text-secondary transition-colors duration-150 hover:text-text-primary disabled:pointer-events-none disabled:opacity-40"
+            >
+              {{ cancelLabel ?? 'Cancel' }}
+            </button>
+            <button
+              type="button"
+              :disabled="busy"
+              @click="emit('confirm')"
+              :class="[
+                'rounded-md px-5 py-2.5 font-heading text-sm font-bold uppercase tracking-wider transition-all duration-150',
+                busy
+                  ? 'cursor-not-allowed border border-border bg-surface-overlay text-text-muted'
+                  : variant === 'danger'
+                    ? 'cursor-pointer bg-[color:var(--color-error)] text-white hover:bg-[color:var(--color-error)]/90'
+                    : 'cursor-pointer bg-brand-light text-white hover:bg-brand',
+              ]"
+            >
+              {{ busy ? `${confirmLabel}…` : confirmLabel }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/web/src/components/ConfirmDialog.vue
+++ b/web/src/components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, watch, nextTick, onMounted, onUnmounted, useId } from 'vue'
 
 const props = defineProps<{
   open: boolean
@@ -16,6 +16,7 @@ const emit = defineEmits<{
   cancel: []
 }>()
 
+const titleId = useId()
 const cancelBtn = ref<HTMLButtonElement | null>(null)
 
 watch(
@@ -46,7 +47,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
         class="fixed inset-0 z-50 flex items-center justify-center px-4"
         role="dialog"
         aria-modal="true"
-        :aria-labelledby="`confirm-dialog-title-${title}`"
+        :aria-labelledby="titleId"
       >
         <!-- Backdrop -->
         <div class="absolute inset-0 bg-black/70" @click="!busy && emit('cancel')" />
@@ -59,7 +60,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
           <!-- Header -->
           <div class="flex items-center justify-between border-b border-border px-5 py-4">
             <h2
-              :id="`confirm-dialog-title-${title}`"
+              :id="titleId"
               class="font-heading text-lg font-bold uppercase tracking-[0.04em] text-text-primary"
             >
               {{ title }}

--- a/web/src/components/GameSelector.vue
+++ b/web/src/components/GameSelector.vue
@@ -6,7 +6,7 @@ import GameChipButton from '@/components/GameChipButton.vue'
 import GameSearchResult from '@/components/GameSearchResult.vue'
 
 defineProps<{ modelValue: GameSummary | null }>()
-const emit = defineEmits<{ 'update:modelValue': [value: GameListItem | null] }>()
+const emit = defineEmits<{ 'update:modelValue': [value: GameSummary | null] }>()
 
 const popularGames = ref<GameListItem[]>([])
 const gameSearch = ref('')
@@ -48,7 +48,8 @@ watch(gameSearch, (q) => {
 })
 
 function pickGame(g: GameListItem) {
-  emit('update:modelValue', g)
+  const { id, name, slug, tag } = g
+  emit('update:modelValue', { id, name, slug, tag })
   gameSearch.value = ''
   gameResults.value = []
   showGameDropdown.value = false

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -12,6 +12,7 @@ import GameTag from '@/components/GameTag.vue'
 import AuthorHandle from '@/components/AuthorHandle.vue'
 import StatusPanel from '@/components/StatusPanel.vue'
 import ClipEditDialog from '@/components/ClipEditDialog.vue'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import IconHeart from '@/components/icons/IconHeart.vue'
 import IconShare from '@/components/icons/IconShare.vue'
 import IconMoreVertical from '@/components/icons/IconMoreVertical.vue'
@@ -172,6 +173,8 @@ const authorAvatarUrl = computed(() => safeImageUrl(clip.value?.author.avatarUrl
 
 const menuOpen = ref(false)
 const editOpen = ref(false)
+const deleteOpen = ref(false)
+const deleting = ref(false)
 
 const isOwner = computed(() => !!auth.user && !!clip.value && clip.value.author.id === auth.user.id)
 
@@ -215,6 +218,30 @@ function onEditError(message: string) {
 function openEdit() {
   closeMenu()
   editOpen.value = true
+}
+
+function openDelete() {
+  closeMenu()
+  deleteOpen.value = true
+}
+
+async function onConfirmDelete() {
+  if (!clip.value || !auth.user) return
+  deleting.value = true
+  try {
+    await clips.delete(clip.value.id)
+    fireToast('Clip deleted')
+    await router.push({ name: 'user', params: { username: auth.user.username } })
+  } catch (err) {
+    const message =
+      err instanceof ApiError
+        ? ((err.body as { code?: string } | null)?.code ?? 'Failed to delete clip')
+        : 'Failed to delete clip'
+    fireToast(message)
+  } finally {
+    deleting.value = false
+    deleteOpen.value = false
+  }
 }
 </script>
 
@@ -338,6 +365,13 @@ function openEdit() {
                 >
                   Edit
                 </button>
+                <button
+                  type="button"
+                  class="w-full cursor-pointer rounded-md px-4 py-2.5 text-left font-body text-sm text-error transition-colors duration-100 hover:bg-surface-raised"
+                  @click="openDelete"
+                >
+                  Delete
+                </button>
               </div>
             </div>
           </div>
@@ -383,6 +417,17 @@ function openEdit() {
       @close="editOpen = false"
       @saved="onSaved"
       @error="onEditError"
+    />
+
+    <ConfirmDialog
+      :open="deleteOpen"
+      title="Delete clip?"
+      body="This permanently removes the clip and its video file. This can't be undone."
+      confirm-label="Delete"
+      variant="danger"
+      :busy="deleting"
+      @cancel="deleteOpen = false"
+      @confirm="onConfirmDelete"
     />
 
     <!-- Toast — kept inside the page's single root so the route-level

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -225,6 +225,12 @@ function openDelete() {
   deleteOpen.value = true
 }
 
+const DELETE_ERROR_CODES: Record<string, string> = {
+  forbidden: "You don't have permission to delete this clip",
+  not_found: 'Clip not found',
+  unauthorized: 'You need to be logged in to delete this clip',
+}
+
 async function onConfirmDelete() {
   if (!clip.value || !auth.user) return
   deleting.value = true
@@ -233,10 +239,11 @@ async function onConfirmDelete() {
     fireToast('Clip deleted')
     await router.push({ name: 'user', params: { username: auth.user.username } })
   } catch (err) {
-    const message =
-      err instanceof ApiError
-        ? ((err.body as { code?: string } | null)?.code ?? 'Failed to delete clip')
-        : 'Failed to delete clip'
+    let message = 'Failed to delete clip'
+    if (err instanceof ApiError) {
+      const code = (err.body as { code?: string } | null)?.code
+      if (code && DELETE_ERROR_CODES[code]) message = DELETE_ERROR_CODES[code]
+    }
     fireToast(message)
   } finally {
     deleting.value = false


### PR DESCRIPTION
# Depends on #78  — review and merge that first.


## Summary
Adds a Delete action to the clip owner more-menu, gated behind a reusable confirmation modal. Also ships the clip edit dialog (wired to `PATCH /clips/{id}`) and a `GameSelector` component extracted from upload — the edit and delete actions ship together as the clip owner action set.

## What's here
- **ConfirmDialog.vue** — reusable destructive-confirm modal with danger variant, busy state, and accessible markup (`role=dialog`, `aria-modal`, `aria-labelledby`, autofocus on Cancel)
- **ClipEditDialog.vue** — owner-gated edit dialog for title/description/game/visibility via sparse-diff PATCH
- **GameSelector.vue** — debounced game search with popular chips, extracted from UploadView and shared between upload and edit
- **clips.ts** — `clips.delete(id)` wrapping `DELETE /clips/{id}` (204) and `clips.update()` for PATCH
- **Server** — adds `visibility` to `ClipDetailResponse` and fixes `GetDetail` to serve unlisted clips via direct link (feed gate only)

Closes #71

## How to test manually
1. Log in as a clip owner and open one of your clips.
2. Open the more-menu (⋯) — **Edit** and **Delete** appear; verify they're absent when viewing as another user.
3. **Delete flow:** click Delete → modal opens; Cancel closes it without a request; Confirm triggers DELETE, shows a toast, and redirects to your profile.
4. **Edit flow:** click Edit → dialog opens pre-filled; change a field and submit → clip updates in place.
5. Open an unlisted clip via direct link — it should load; confirm it doesn't appear in feeds.

## Checklist
- [ ] Verified manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Clip owners can delete their clips from the clip view, accessible via the owner's menu. A confirmation dialog appears before deletion is completed, with support for canceling via escape key or clicking outside. Success and error notifications inform users of the deletion outcome. The dialog prevents interactions while the deletion request is processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->