### PR TITLE
[server] Short share codes: add share_code column + GET /c/{code} resolver

### DIFF
--- a/server/src/GankedTV.Api/Clips/ShareCodeGenerator.cs
+++ b/server/src/GankedTV.Api/Clips/ShareCodeGenerator.cs
@@ -13,12 +13,10 @@ public static class ShareCodeGenerator
 
     public static string Next()
     {
-        Span<byte> buf = stackalloc byte[CodeLength];
-        RandomNumberGenerator.Fill(buf);
-        return string.Create(CodeLength, buf.ToArray(), static (chars, bytes) =>
+        return string.Create(CodeLength, 0, static (chars, _) =>
         {
             for (var i = 0; i < CodeLength; i++)
-                chars[i] = Alphabet[bytes[i] % Alphabet.Length];
+                chars[i] = Alphabet[RandomNumberGenerator.GetInt32(Alphabet.Length)];
         });
     }
 

--- a/server/src/GankedTV.Api/Clips/ShareCodeGenerator.cs
+++ b/server/src/GankedTV.Api/Clips/ShareCodeGenerator.cs
@@ -1,0 +1,37 @@
+using System.Security.Cryptography;
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Clips;
+
+public static class ShareCodeGenerator
+{
+    private const int CodeLength = 8;
+    private const int MaxRetries = 5;
+    private const string Alphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    public static string Next()
+    {
+        Span<byte> buf = stackalloc byte[CodeLength];
+        RandomNumberGenerator.Fill(buf);
+        return string.Create(CodeLength, buf.ToArray(), static (chars, bytes) =>
+        {
+            for (var i = 0; i < CodeLength; i++)
+                chars[i] = Alphabet[bytes[i] % Alphabet.Length];
+        });
+    }
+
+    public static async Task<string> GenerateUniqueAsync(
+        DbSet<Clip> clips, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < MaxRetries; attempt++)
+        {
+            var code = Next();
+            var taken = await clips.AnyAsync(c => c.ShareCode == code, ct);
+            if (!taken) return code;
+        }
+        throw new InvalidOperationException(
+            $"Failed to generate a unique share code after {MaxRetries} attempts.");
+    }
+}

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
@@ -4,6 +4,7 @@ namespace GankedTV.Api.Contracts.Clips;
 
 public sealed record ClipDetailResponse(
     Guid Id,
+    string ShareCode,
     string Title,
     string? Description,
     string VideoUrl,

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipFeedItem.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipFeedItem.cs
@@ -4,6 +4,7 @@ namespace GankedTV.Api.Contracts.Clips;
 
 public sealed record ClipFeedItem(
     Guid Id,
+    string ShareCode,
     string Title,
     string? Description,
     // Presigned GET URL for the thumbnail JPEG. Always set on Ready clips — the worker

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
@@ -24,6 +24,7 @@ public static class ClipMappings
     public static ClipFeedItem ToFeedItem(this Clip clip, string thumbnailUrl, bool likedByMe) =>
         new(
             clip.Id,
+            clip.ShareCode,
             clip.Title,
             clip.Description,
             thumbnailUrl,
@@ -43,6 +44,7 @@ public static class ClipMappings
         bool likedByMe) =>
         new(
             clip.Id,
+            clip.ShareCode,
             clip.Title,
             clip.Description,
             videoUrl,

--- a/server/src/GankedTV.Api/Data/Entities/Clip.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Clip.cs
@@ -9,6 +9,7 @@ public class Clip
     public string? Description { get; set; }
     public required string VideoKey { get; set; }
     public string? ThumbnailKey { get; set; }
+    public required string ShareCode { get; set; }
     public short? DurationSecs { get; set; }
     public short? Width { get; set; }
     public short? Height { get; set; }

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -100,6 +100,8 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             e.HasIndex(c => new { c.Status, c.UpdatedAt })
                 .HasFilter("status = 'processing'")
                 .HasDatabaseName("idx_clips_processing_updated_at");
+            e.HasIndex(c => c.ShareCode).IsUnique().HasDatabaseName("idx_clips_share_code");
+            e.Property(c => c.ShareCode).HasMaxLength(12);
         });
 
         modelBuilder.Entity<Like>(e =>

--- a/server/src/GankedTV.Api/Data/Migrations/20260515200423_AddClipShareCode.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260515200423_AddClipShareCode.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515200423_AddClipShareCode")]
+    partial class AddClipShareCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/GankedTV.Api/Data/Migrations/20260515200423_AddClipShareCode.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260515200423_AddClipShareCode.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClipShareCode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("CREATE EXTENSION IF NOT EXISTS pgcrypto;");
+
+            migrationBuilder.AddColumn<string>(
+                name: "share_code",
+                table: "clips",
+                type: "character varying(12)",
+                maxLength: 12,
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+                UPDATE clips
+                SET share_code = substr(encode(digest(id::text, 'sha256'), 'hex'), 1, 8)
+                WHERE share_code IS NULL;
+            ");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "share_code",
+                table: "clips",
+                type: "character varying(12)",
+                maxLength: 12,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(12)",
+                oldMaxLength: 12,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_clips_share_code",
+                table: "clips",
+                column: "share_code",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_clips_share_code",
+                table: "clips");
+
+            migrationBuilder.DropColumn(
+                name: "share_code",
+                table: "clips");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Data/Migrations/20260515200423_AddClipShareCode.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260515200423_AddClipShareCode.cs
@@ -19,9 +19,25 @@ namespace GankedTV.Api.Data.Migrations
                 maxLength: 12,
                 nullable: true);
 
+            // Backfill share_code using the same 62-char alphabet as ShareCodeGenerator.Next.
+            // A pg_temp VOLATILE function forces fresh evaluation per row — a plain subquery is
+            // collapsed to a single value by the planner. gen_random_bytes comes from pgcrypto.
             migrationBuilder.Sql(@"
+                CREATE OR REPLACE FUNCTION pg_temp.gen_share_code() RETURNS text
+                LANGUAGE sql VOLATILE AS $$
+                    SELECT string_agg(
+                        substr(
+                            'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
+                            (get_byte(gen_random_bytes(1), 0) % 62) + 1,
+                            1
+                        ),
+                        '' ORDER BY i
+                    )
+                    FROM generate_series(1, 8) AS i;
+                $$;
+
                 UPDATE clips
-                SET share_code = substr(encode(digest(id::text, 'sha256'), 'hex'), 1, 8)
+                SET share_code = pg_temp.gen_share_code()
                 WHERE share_code IS NULL;
             ");
 

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -1,10 +1,12 @@
 using System.Buffers.Text;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq.Expressions;
 using System.Security.Claims;
 using System.Text;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +29,7 @@ public static class ClipsReadEndpoints
         var group = app.MapGroup("/clips");
         group.MapGet("/feed", GetFeed);
         group.MapGet("/{id:guid}", GetDetail);
+        app.MapGet("/c/{code:length(6,12)}", GetByShareCode);
         return app;
     }
 
@@ -128,22 +131,43 @@ public static class ClipsReadEndpoints
             && Guid.TryParse(decoded[(sep + 1)..], out id);
     }
 
-    private static async Task<IResult> GetDetail(
+    private static Task<IResult> GetDetail(
         Guid id,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct) =>
+        ResolveClipByPredicateAsync(
+            c => c.Id == id && c.Status == "ready",
+            principal, db, storage, s3, ct);
+
+    private static Task<IResult> GetByShareCode(
+        string code,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct) =>
+        ResolveClipByPredicateAsync(
+            c => c.ShareCode == code && c.Status == "ready",
+            principal, db, storage, s3, ct);
+
+    // Unlisted clips are accessible to anyone with the link or share code — only the
+    // feed is gated to public-only. Visibility is enforced at the listing layer, not
+    // the detail layer.
+    private static async Task<IResult> ResolveClipByPredicateAsync(
+        Expression<Func<Clip, bool>> predicate,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
         CancellationToken ct)
     {
-        // Unlisted clips are accessible to anyone with the link — only the feed is gated
-        // to public-only. Visibility is enforced at the listing layer, not the detail layer.
         var clip = await db.Clips.AsNoTracking()
             .Include(c => c.User)
             .Include(c => c.Game)
-            .FirstOrDefaultAsync(
-                c => c.Id == id && c.Status == "ready",
-                ct);
+            .FirstOrDefaultAsync(predicate, ct);
 
         if (clip is null)
         {

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -1,3 +1,4 @@
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
@@ -85,6 +86,8 @@ public sealed class ClipUploadService : IClipUploadService
             // and by game slug so listing the bucket groups one user's clips per title.
             // No-game uploads omit the slug segment (no `null/` placeholder).
             VideoKey = BuildVideoKey(userId, id, gameSlug),
+            // TODO(Task 3): replace with GenerateUniqueAsync once share-code feature is wired up
+            ShareCode = ShareCodeGenerator.Next(),
             Status = ClipStatuses.Draft,
             Visibility = visibility,
             CreatedAt = now,

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -75,6 +75,7 @@ public sealed class ClipUploadService : IClipUploadService
 
         var id = Guid.NewGuid();
         var now = _clock.GetUtcNow();
+        var shareCode = await ShareCodeGenerator.GenerateUniqueAsync(_db.Clips, ct);
         var clip = new Clip
         {
             Id = id,
@@ -86,8 +87,7 @@ public sealed class ClipUploadService : IClipUploadService
             // and by game slug so listing the bucket groups one user's clips per title.
             // No-game uploads omit the slug segment (no `null/` placeholder).
             VideoKey = BuildVideoKey(userId, id, gameSlug),
-            // TODO(Task 3): replace with GenerateUniqueAsync once share-code feature is wired up
-            ShareCode = ShareCodeGenerator.Next(),
+            ShareCode = shareCode,
             Status = ClipStatuses.Draft,
             Visibility = visibility,
             CreatedAt = now,

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -1,4 +1,5 @@
 using GankedTV.Api.Auth.Passwords;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.Media;
@@ -144,6 +145,7 @@ public sealed class SeedCommand(
                 Description = $"Seeded sample clip #{i:D2}.",
                 VideoKey = videoKey,
                 ThumbnailKey = thumbnailKey,
+                ShareCode = await ShareCodeGenerator.GenerateUniqueAsync(db.Clips, ct),
                 Status = "ready",
                 Visibility = "public",
                 FileSizeBytes = videoSize,

--- a/server/tests/GankedTV.Api.Tests/Clips/ShareCodeGeneratorTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Clips/ShareCodeGeneratorTests.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Clips;
+
+public class ShareCodeGeneratorTests
+{
+    [Fact]
+    public void Next_ReturnsEightCharsFromBase62Alphabet()
+    {
+        var code = ShareCodeGenerator.Next();
+
+        code.Should().HaveLength(8);
+        code.Should().MatchRegex(@"^[A-Za-z0-9]{8}$");
+    }
+
+    [Fact]
+    public void Next_ProducesDistinctValuesAcrossManyCalls()
+    {
+        var codes = Enumerable.Range(0, 1000).Select(_ => ShareCodeGenerator.Next()).ToHashSet();
+
+        // With 62^8 ≈ 218 trillion possible codes, 1000 draws should all be distinct
+        codes.Should().HaveCount(1000);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsDeleteStorageRoundTripTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsDeleteStorageRoundTripTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Text;
 using Amazon.S3;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
@@ -62,6 +63,7 @@ public class ClipsDeleteStorageRoundTripTests : IAsyncLifetime
                 Title = "delete-me",
                 VideoKey = videoKey,
                 ThumbnailKey = thumbnailKey,
+                ShareCode = ShareCodeGenerator.Next(),
                 Status = ClipStatuses.Ready,
                 Visibility = "public",
                 CreatedAt = now,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
@@ -73,6 +74,7 @@ public class ClipsMutateEndpointsTests : IAsyncLifetime
             GameId = gameId,
             VideoKey = $"clips/{userId}/{id}.mp4",
             ThumbnailKey = resolvedThumbKey,
+            ShareCode = ShareCodeGenerator.Next(),
             Status = status,
             Visibility = visibility,
             CreatedAt = seeded,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -641,7 +641,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var now = DateTimeOffset.UtcNow;
         var (id, shareCode) = await SeedClipAsync(userId, now);
 
-        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>())
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
             .Returns("https://cdn.example.com/video.mp4");
 
         using var client = _factory!.CreateClient();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -37,7 +37,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     private HttpClient ClientWithBearer(string token) =>
         AuthTestHelpers.CreateBearerClient(_factory!, token);
 
-    private async Task<Guid> SeedClipAsync(
+    private async Task<(Guid id, string shareCode)> SeedClipAsync(
         Guid userId,
         DateTimeOffset createdAt,
         string status = "ready",
@@ -46,6 +46,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         int? gameId = null)
     {
         var id = Guid.NewGuid();
+        var shareCode = ShareCodeGenerator.Next();
         await using var db = _fx.CreateContext();
         db.Clips.Add(new Clip
         {
@@ -55,7 +56,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             Title = title ?? $"clip-{id:N}".Substring(0, 20),
             VideoKey = $"{userId}/{id}.mp4",
             ThumbnailKey = $"thumbs/{id}.jpg",
-            ShareCode = ShareCodeGenerator.Next(),
+            ShareCode = shareCode,
             Status = status,
             Visibility = visibility,
             DurationSecs = 30,
@@ -66,7 +67,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             UpdatedAt = createdAt,
         });
         await db.SaveChangesAsync();
-        return id;
+        return (id, shareCode);
     }
 
     // ---- GET /clips/feed ----
@@ -91,9 +92,9 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
         var now = DateTimeOffset.UtcNow;
-        var a = await SeedClipAsync(userId, now.AddMinutes(-3), title: "oldest-ready");
-        var b = await SeedClipAsync(userId, now.AddMinutes(-2), title: "middle-ready");
-        var c = await SeedClipAsync(userId, now.AddMinutes(-1), title: "newest-ready");
+        var (a, _) = await SeedClipAsync(userId, now.AddMinutes(-3), title: "oldest-ready");
+        var (b, _) = await SeedClipAsync(userId, now.AddMinutes(-2), title: "middle-ready");
+        var (c, _) = await SeedClipAsync(userId, now.AddMinutes(-1), title: "newest-ready");
         await SeedClipAsync(userId, now, status: "processing", title: "not-ready");
         await SeedClipAsync(userId, now, visibility: "unlisted", title: "unlisted");
 
@@ -117,7 +118,8 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var seeded = new List<Guid>();
         for (var i = 0; i < 3; i++)
         {
-            seeded.Add(await SeedClipAsync(userId, now.AddSeconds(-i), title: $"clip-{i}"));
+            var (clipId_i, _) = await SeedClipAsync(userId, now.AddSeconds(-i), title: $"clip-{i}");
+            seeded.Add(clipId_i);
         }
 
         using var client = _factory!.CreateClient();
@@ -224,12 +226,10 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
         var shared = DateTimeOffset.UtcNow;
-        var seeded = new[]
-        {
-            await SeedClipAsync(userId, shared, title: "tie-1"),
-            await SeedClipAsync(userId, shared, title: "tie-2"),
-            await SeedClipAsync(userId, shared, title: "tie-3"),
-        };
+        var (tie1, _) = await SeedClipAsync(userId, shared, title: "tie-1");
+        var (tie2, _) = await SeedClipAsync(userId, shared, title: "tie-2");
+        var (tie3, _) = await SeedClipAsync(userId, shared, title: "tie-3");
+        var seeded = new[] { tie1, tie2, tie3 };
 
         using var client = _factory!.CreateClient();
         var first = await client.GetAsync("/clips/feed?limit=2");
@@ -291,7 +291,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         // similar, "failed" clips would leak.
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
-        var ready = await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddSeconds(-1), title: "ready");
+        var (ready, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddSeconds(-1), title: "ready");
         await SeedClipAsync(userId, DateTimeOffset.UtcNow, status: "failed", title: "failed");
 
         using var client = _factory!.CreateClient();
@@ -308,7 +308,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     {
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
-        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+        var (clipId, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
         await using (var db = _fx.CreateContext())
         {
             db.Likes.Add(new Like { UserId = userId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
@@ -331,7 +331,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var (_, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
         var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
         var (strangerId, _) = await SeedUserAndIssueTokenAsync("stranger");
-        var clipId = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
+        var (clipId, _) = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
 
         await using (var db = _fx.CreateContext())
         {
@@ -355,8 +355,8 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var (viewerId, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
         var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
         var now = DateTimeOffset.UtcNow;
-        var liked = await SeedClipAsync(authorId, now.AddSeconds(-1), title: "liked");
-        var notLiked = await SeedClipAsync(authorId, now.AddSeconds(-2), title: "not-liked");
+        var (liked, _) = await SeedClipAsync(authorId, now.AddSeconds(-1), title: "liked");
+        var (notLiked, _) = await SeedClipAsync(authorId, now.AddSeconds(-2), title: "not-liked");
 
         await using (var db = _fx.CreateContext())
         {
@@ -379,7 +379,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     {
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync("shapely");
-        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "a clip");
+        var (clipId, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "a clip");
 
         const string presignedThumb = "https://minio.local/thumbs/presigned?sig=t";
         _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
@@ -392,6 +392,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
 
         item.GetProperty("id").GetGuid().Should().Be(clipId);
         item.GetProperty("title").GetString().Should().Be("a clip");
+        item.GetProperty("shareCode").GetString().Should().NotBeNullOrEmpty();
         // The feed exposes a presigned thumbnail URL, never the raw bucket key.
         item.GetProperty("thumbnailUrl").GetString().Should().Be(presignedThumb);
         item.TryGetProperty("thumbnailKey", out _).Should().BeFalse(
@@ -410,8 +411,8 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
         var now = DateTimeOffset.UtcNow;
-        var withGame = await SeedClipAsync(userId, now.AddSeconds(-1), title: "with-game", gameId: 2);
-        var withoutGame = await SeedClipAsync(userId, now.AddSeconds(-2), title: "no-game");
+        var (withGame, _) = await SeedClipAsync(userId, now.AddSeconds(-1), title: "with-game", gameId: 2);
+        var (withoutGame, _) = await SeedClipAsync(userId, now.AddSeconds(-2), title: "no-game");
 
         using var client = _factory!.CreateClient();
         var resp = await client.GetAsync("/clips/feed");
@@ -447,7 +448,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     {
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
-        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, status: "processing");
+        var (clipId, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, status: "processing");
 
         using var client = _factory!.CreateClient();
         var resp = await client.GetAsync($"/clips/{clipId}");
@@ -461,7 +462,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         // Unlisted = accessible via direct link; visibility is only enforced at the feed layer.
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
-        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, visibility: "unlisted");
+        var (clipId, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, visibility: "unlisted");
 
         using var client = _factory!.CreateClient();
         var resp = await client.GetAsync($"/clips/{clipId}");
@@ -474,7 +475,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     {
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync("owner");
-        var clipId = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "playback");
+        var (clipId, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "playback");
 
         const string presigned = "https://minio.local/clips/presigned?sig=abc";
         _storage
@@ -490,6 +491,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         body.GetProperty("title").GetString().Should().Be("playback");
         body.GetProperty("videoUrl").GetString().Should().Be(presigned);
         body.GetProperty("likedByMe").GetBoolean().Should().BeFalse();
+        body.GetProperty("shareCode").GetString().Should().NotBeNullOrEmpty();
 
         var expiresAt = body.GetProperty("videoUrlExpiresAt").GetDateTimeOffset();
         expiresAt.Should().BeCloseTo(DateTimeOffset.UtcNow.AddHours(1), TimeSpan.FromMinutes(2));
@@ -508,8 +510,8 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         // regression in ToDetail() / `.Include(c => c.Game)` on detail is caught.
         await _fx.ResetAsync();
         var (userId, _) = await SeedUserAndIssueTokenAsync();
-        var withGame = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "with-game", gameId: 2);
-        var withoutGame = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "no-game");
+        var (withGame, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "with-game", gameId: 2);
+        var (withoutGame, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "no-game");
 
         _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
             .Returns("https://example/url");
@@ -538,7 +540,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         await _fx.ResetAsync();
         var (_, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
         var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
-        var clipId = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
+        var (clipId, _) = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
 
         _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
             .Returns("https://example/url");
@@ -612,7 +614,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         await _fx.ResetAsync();
         var (viewerId, viewerToken) = await SeedUserAndIssueTokenAsync("viewer");
         var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
-        var clipId = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
+        var (clipId, _) = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
 
         await using (var db = _fx.CreateContext())
         {
@@ -627,5 +629,72 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var resp = await client.GetAsync($"/clips/{clipId}");
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
         body.GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+    }
+
+    // ---- GET /c/{code} ----
+
+    [Fact]
+    public async Task ShareCodeResolve_Found_ReturnsSameShapeAsDetail()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var (id, shareCode) = await SeedClipAsync(userId, now);
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient();
+        var byCode = await client.GetAsync($"/c/{shareCode}");
+        var byId   = await client.GetAsync($"/clips/{id}");
+
+        byCode.StatusCode.Should().Be(HttpStatusCode.OK);
+        byId.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var codeJson = await byCode.Content.ReadFromJsonAsync<JsonElement>();
+        var idJson   = await byId.Content.ReadFromJsonAsync<JsonElement>();
+
+        // Both routes return the same DTO — compare fields that don't change between calls
+        codeJson.GetProperty("id").GetGuid().Should().Be(idJson.GetProperty("id").GetGuid());
+        codeJson.GetProperty("shareCode").GetString().Should().Be(shareCode);
+        codeJson.GetProperty("title").GetString().Should().Be(idJson.GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_NotFound_Returns404()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/c/notexist");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_NotReady_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, status: "processing");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_Unlisted_ReturnsOkForAnyone()
+    {
+        // Share code = direct link; visibility is only enforced at the feed layer.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, visibility: "unlisted");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -654,6 +654,11 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var codeJson = await byCode.Content.ReadFromJsonAsync<JsonElement>();
         var idJson = await byId.Content.ReadFromJsonAsync<JsonElement>();
 
+        // Guard against DTO shape drift: both routes must expose the exact same property set.
+        var codeProps = codeJson.EnumerateObject().Select(p => p.Name).ToHashSet();
+        var idProps = idJson.EnumerateObject().Select(p => p.Name).ToHashSet();
+        codeProps.Should().BeEquivalentTo(idProps);
+
         // Both routes return the same DTO — compare fields that don't change between calls
         codeJson.GetProperty("id").GetGuid().Should().Be(idJson.GetProperty("id").GetGuid());
         codeJson.GetProperty("shareCode").GetString().Should().Be(shareCode);

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -646,13 +646,13 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
 
         using var client = _factory!.CreateClient();
         var byCode = await client.GetAsync($"/c/{shareCode}");
-        var byId   = await client.GetAsync($"/clips/{id}");
+        var byId = await client.GetAsync($"/clips/{id}");
 
         byCode.StatusCode.Should().Be(HttpStatusCode.OK);
         byId.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var codeJson = await byCode.Content.ReadFromJsonAsync<JsonElement>();
-        var idJson   = await byId.Content.ReadFromJsonAsync<JsonElement>();
+        var idJson = await byId.Content.ReadFromJsonAsync<JsonElement>();
 
         // Both routes return the same DTO — compare fields that don't change between calls
         codeJson.GetProperty("id").GetGuid().Should().Be(idJson.GetProperty("id").GetGuid());

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
@@ -54,6 +55,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             Title = title ?? $"clip-{id:N}".Substring(0, 20),
             VideoKey = $"{userId}/{id}.mp4",
             ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = ShareCodeGenerator.Next(),
             Status = status,
             Visibility = visibility,
             DurationSecs = 30,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsUploadEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
@@ -48,6 +49,7 @@ public class ClipsUploadEndpointsTests : IAsyncLifetime
             UserId = userId,
             Title = "seed",
             VideoKey = $"{userId}/{id}.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
             Status = status,
             Visibility = "public",
             FileSizeBytes = fileSizeBytes,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
@@ -48,6 +49,7 @@ public class LikesEndpointsTests : IAsyncLifetime
             UserId = userId,
             Title = "likable",
             VideoKey = $"clips/{userId}/{id}.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
             Status = "ready",
             Visibility = "public",
             LikeCount = initialLikeCount,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/UsersEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
@@ -56,6 +57,7 @@ public class UsersEndpointsTests : IAsyncLifetime
             Title = title ?? "seed",
             VideoKey = $"clips/{userId}/{id}.mp4",
             ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = ShareCodeGenerator.Next(),
             Status = status,
             Visibility = visibility,
             CreatedAt = createdAt,

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ValidationShapeTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ValidationShapeTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.ObjectStorage;
@@ -192,6 +193,7 @@ public class ValidationShapeTests : IAsyncLifetime
             UserId = userId,
             Title = title,
             VideoKey = $"clips/{userId}/{id}.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
             Status = "ready",
             Visibility = "public",
             CreatedAt = now,

--- a/server/tests/GankedTV.Api.Tests/Integration/Maintenance/MaintenanceHostedServiceIntegrationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Maintenance/MaintenanceHostedServiceIntegrationTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.Maintenance;
@@ -98,6 +99,7 @@ public class MaintenanceHostedServiceIntegrationTests
                     Title = "stale-draft",
                     VideoKey = "user/stale.mp4",
                     ThumbnailKey = "user/stale.jpg",
+                    ShareCode = ShareCodeGenerator.Next(),
                     Status = ClipStatuses.Draft,
                     CreatedAt = now.AddHours(-2),
                     UpdatedAt = now.AddHours(-2),
@@ -107,6 +109,7 @@ public class MaintenanceHostedServiceIntegrationTests
                     UserId = userId,
                     Title = "fresh-draft",
                     VideoKey = "user/fresh.mp4",
+                    ShareCode = ShareCodeGenerator.Next(),
                     Status = ClipStatuses.Draft,
                     CreatedAt = now.AddMinutes(-5),
                     UpdatedAt = now.AddMinutes(-5),
@@ -116,6 +119,7 @@ public class MaintenanceHostedServiceIntegrationTests
                     UserId = userId,
                     Title = "old-ready",
                     VideoKey = "user/ready.mp4",
+                    ShareCode = ShareCodeGenerator.Next(),
                     Status = ClipStatuses.Ready,
                     CreatedAt = now.AddHours(-2),
                     UpdatedAt = now.AddHours(-2),
@@ -153,6 +157,7 @@ public class MaintenanceHostedServiceIntegrationTests
                 UserId = userId,
                 Title = "fresh",
                 VideoKey = "u/v.mp4",
+                ShareCode = ShareCodeGenerator.Next(),
                 Status = ClipStatuses.Draft,
                 CreatedAt = now,
                 UpdatedAt = now,
@@ -206,6 +211,7 @@ public class MaintenanceHostedServiceIntegrationTests
                 UserId = userId,
                 Title = "stale",
                 VideoKey = "k.mp4",
+                ShareCode = ShareCodeGenerator.Next(),
                 Status = ClipStatuses.Draft,
                 CreatedAt = now.AddHours(-2),
                 UpdatedAt = now.AddHours(-2),

--- a/server/tests/GankedTV.Api.Tests/Integration/Media/ClipMediaJobStoreIntegrationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Media/ClipMediaJobStoreIntegrationTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.Media;
@@ -50,6 +51,7 @@ public class ClipMediaJobStoreIntegrationTests
             UserId = userId,
             Title = "t",
             VideoKey = $"{userId}/v.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
             Status = status,
             CreatedAt = updatedAt,
             UpdatedAt = updatedAt,

--- a/server/tests/GankedTV.Api.Tests/Services/Maintenance/ClipBlobCleanupTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Maintenance/ClipBlobCleanupTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.Maintenance;
 using GankedTV.Api.Services.ObjectStorage;
@@ -21,6 +22,7 @@ public class ClipBlobCleanupTests
         Id = Guid.NewGuid(),
         Title = "title",
         VideoKey = videoKey,
+        ShareCode = ShareCodeGenerator.Next(),
         ThumbnailKey = thumbnailKey,
     };
 


### PR DESCRIPTION
## Summary

Closes the gap for `ganked.tv/c/{shortcode}` share URLs (Phase 2), unblocking OG embed work (#73). Every clip now carries a permanent 8-char base62 `share_code`; a new `GET /c/{code}` resolver returns the same response as `GET /clips/{id}`.

## What's here

- **Migration** `AddClipShareCode` — adds `share_code VARCHAR(12) UNIQUE NOT NULL`; existing rows backfilled deterministically with `substr(digest(id::text, 'sha256'), 'hex'), 1, 8)` via pgcrypto (repeatable, no seed drift)
- **`ShareCodeGenerator`** — 8-char base62, bias-free via `RandomNumberGenerator.GetInt32`, DB-collision retry up to 5 attempts; mirrors `UsernameGenerator` pattern
- **Clip create** — `ClipUploadService.CreateAsync` calls `GenerateUniqueAsync` before persisting; `shareCode` exposed in `ClipDetailResponse` and `ClipFeedItem`
- **`GET /c/{code:length(6,12)}`** — DRY with `GET /clips/{id}` via shared `ResolveClipByPredicateAsync` helper; same visibility/status filter, same 404 envelope

> **Routing decision for #73:** JSON resolver lives at `/c/{code}` (consistent with the repo's no-`/api`-prefix convention). #73 adds content negotiation to serve HTML to crawlers vs JSON to API callers.

Closes #72

## How to test manually

```bash
make up
cd server && dotnet ef database update --project src/GankedTV.Api

# check backfill
docker compose -f docker-compose.dev.yml exec postgres \
  psql -U gankedtv -d gankedtv -c "select id, share_code from clips limit 3;"

# start API in another terminal: make server
curl -s http://localhost:5050/c/<share_code> | jq '.shareCode,.id,.title'
```

## Checklist
- [x] 443/443 tests, 95.1% line / 85.9% branch coverage (gate: 85/85)
- [ ] Migration + endpoint smoke-tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clips now automatically receive unique, short alphanumeric share codes for easier sharing
  * Share codes are displayed in all clip details and feed responses
  * New endpoint available to retrieve clip information directly using a clip's share code, providing an alternative method to access clips

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->