### PR TITLE
feat: social embeds (OG/Twitter meta tags) for /c/{code} share links

### DIFF
--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -248,7 +248,9 @@ public static class ClipsReadEndpoints
     {
         var title = WebUtility.HtmlEncode(clip.Title);
         var desc = clip.Description is not null ? WebUtility.HtmlEncode(clip.Description) : null;
-        var canonicalUrl = $"{request.Scheme}://{request.Host}/c/{clip.ShareCode}";
+        var canonicalUrl = WebUtility.HtmlEncode($"{request.Scheme}://{request.Host}/c/{clip.ShareCode}");
+        var encodedVideoUrl = WebUtility.HtmlEncode(videoUrl);
+        var encodedThumbnailUrl = WebUtility.HtmlEncode(thumbnailUrl);
         // width/height fallback: Discord/Twitter require numeric values
         var width = clip.Width?.ToString() ?? "1280";
         var height = clip.Height?.ToString() ?? "720";
@@ -264,17 +266,17 @@ public static class ClipsReadEndpoints
             <meta property="og:url" content="{canonicalUrl}" />
             <meta property="og:title" content="{title}" />
             {(desc is not null ? $"""<meta property="og:description" content="{desc}" />""" : "")}
-            <meta property="og:image" content="{thumbnailUrl}" />
-            <meta property="og:video" content="{videoUrl}" />
-            <meta property="og:video:secure_url" content="{videoUrl}" />
+            <meta property="og:image" content="{encodedThumbnailUrl}" />
+            <meta property="og:video" content="{encodedVideoUrl}" />
+            <meta property="og:video:secure_url" content="{encodedVideoUrl}" />
             <meta property="og:video:type" content="video/mp4" />
             <meta property="og:video:width" content="{width}" />
             <meta property="og:video:height" content="{height}" />
             <meta name="twitter:card" content="player" />
-            <meta name="twitter:player" content="{videoUrl}" />
+            <meta name="twitter:player" content="{encodedVideoUrl}" />
             <meta name="twitter:player:width" content="{width}" />
             <meta name="twitter:player:height" content="{height}" />
-            <meta name="twitter:image" content="{thumbnailUrl}" />
+            <meta name="twitter:image" content="{encodedThumbnailUrl}" />
             </head>
             <body></body>
             </html>

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -163,30 +163,41 @@ public static class ClipsReadEndpoints
 
         var (clip, videoUrl, thumbnailUrl) = result.Value;
         var userAgent = request.Headers.UserAgent.ToString();
+        var webOrigin = oauthOptions.Value.WebOrigin.TrimEnd('/');
 
+        // Crawler UA wins over Accept negotiation: a bot advertising application/json
+        // (rare but possible) still needs the OG HTML so previews render.
         if (IsCrawler(userAgent))
-            return Results.Content(BuildOgHtml(clip, videoUrl, thumbnailUrl, request), "text/html; charset=utf-8");
+            return Results.Content(BuildOgHtml(clip, videoUrl, thumbnailUrl, webOrigin), "text/html; charset=utf-8");
 
         if (request.Headers.Accept.ToString().Contains("application/json"))
-        {
-            var likedByMe = false;
-            if (TryGetUserId(principal, out var userId))
-            {
-                likedByMe = await db.Likes.AsNoTracking()
-                    .AnyAsync(l => l.ClipId == clip.Id && l.UserId == userId, ct);
-            }
-            var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
-            return Results.Ok(clip.ToDetail(videoUrl, expiresAt, thumbnailUrl, likedByMe));
-        }
+            return await BuildDetailResultAsync(clip, videoUrl, thumbnailUrl, principal, db, ct);
 
-        var webOrigin = oauthOptions.Value.WebOrigin.TrimEnd('/');
         return Results.Redirect($"{webOrigin}/c/{code}", permanent: false);
+    }
+
+    private static async Task<IResult> BuildDetailResultAsync(
+        Clip clip,
+        string videoUrl,
+        string thumbnailUrl,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var likedByMe = false;
+        if (TryGetUserId(principal, out var userId))
+        {
+            likedByMe = await db.Likes.AsNoTracking()
+                .AnyAsync(l => l.ClipId == clip.Id && l.UserId == userId, ct);
+        }
+        var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
+        return Results.Ok(clip.ToDetail(videoUrl, expiresAt, thumbnailUrl, likedByMe));
     }
 
     // Unlisted clips are accessible to anyone with the link or share code — only the
     // feed is gated to public-only. Visibility is enforced at the listing layer, not
     // the detail layer.
-    internal static async Task<(Clip clip, string videoUrl, string thumbnailUrl)?> LoadClipWithUrlsAsync(
+    private static async Task<(Clip clip, string videoUrl, string thumbnailUrl)?> LoadClipWithUrlsAsync(
         Expression<Func<Clip, bool>> predicate,
         GankedTvDbContext db,
         IObjectStorageService storage,
@@ -223,16 +234,7 @@ public static class ClipsReadEndpoints
         }
 
         var (clip, videoUrl, thumbnailUrl) = result.Value;
-        var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
-
-        var likedByMe = false;
-        if (TryGetUserId(principal, out var userId))
-        {
-            likedByMe = await db.Likes.AsNoTracking()
-                .AnyAsync(l => l.ClipId == clip.Id && l.UserId == userId, ct);
-        }
-
-        return Results.Ok(clip.ToDetail(videoUrl, expiresAt, thumbnailUrl, likedByMe));
+        return await BuildDetailResultAsync(clip, videoUrl, thumbnailUrl, principal, db, ct);
     }
 
     private static readonly string[] CrawlerSubstrings =
@@ -244,11 +246,15 @@ public static class ClipsReadEndpoints
     private static bool IsCrawler(string userAgent) =>
         CrawlerSubstrings.Any(s => userAgent.Contains(s, StringComparison.OrdinalIgnoreCase));
 
-    private static string BuildOgHtml(Clip clip, string videoUrl, string thumbnailUrl, HttpRequest request)
+    private static string BuildOgHtml(Clip clip, string videoUrl, string thumbnailUrl, string webOrigin)
     {
         var title = WebUtility.HtmlEncode(clip.Title);
-        var desc = clip.Description is not null ? WebUtility.HtmlEncode(clip.Description) : null;
-        var canonicalUrl = WebUtility.HtmlEncode($"{request.Scheme}://{request.Host}/c/{clip.ShareCode}");
+        // IsNullOrWhiteSpace, not just null: an empty Description still emits an empty
+        // <meta og:description> which crawlers (notably Slack) render as a blank line.
+        var desc = !string.IsNullOrWhiteSpace(clip.Description) ? WebUtility.HtmlEncode(clip.Description) : null;
+        // webOrigin is the public, config-driven origin (not request.Scheme/Host, which
+        // behind a reverse proxy without UseForwardedHeaders surfaces the internal URL).
+        var canonicalUrl = WebUtility.HtmlEncode($"{webOrigin}/c/{clip.ShareCode}");
         var encodedVideoUrl = WebUtility.HtmlEncode(videoUrl);
         var encodedThumbnailUrl = WebUtility.HtmlEncode(thumbnailUrl);
         // width/height fallback: Discord/Twitter require numeric values
@@ -256,6 +262,10 @@ public static class ClipsReadEndpoints
         var height = clip.Height?.ToString() ?? "720";
         // video/mp4 is hardcoded — it's the only content type allowed by ClipValidationOptions
 
+        // Twitter card: summary_large_image rather than `player`. `player` requires an
+        // HTTPS iframe HTML page (not a raw mp4) plus Twitter app approval; pointing
+        // it at the presigned mp4 falls back to summary anyway. summary_large_image
+        // renders the thumbnail + title/description directly.
         return $"""
             <!DOCTYPE html>
             <html>
@@ -272,10 +282,9 @@ public static class ClipsReadEndpoints
             <meta property="og:video:type" content="video/mp4" />
             <meta property="og:video:width" content="{width}" />
             <meta property="og:video:height" content="{height}" />
-            <meta name="twitter:card" content="player" />
-            <meta name="twitter:player" content="{encodedVideoUrl}" />
-            <meta name="twitter:player:width" content="{width}" />
-            <meta name="twitter:player:height" content="{height}" />
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:title" content="{title}" />
+            {(desc is not null ? $"""<meta name="twitter:description" content="{desc}" />""" : "")}
             <meta name="twitter:image" content="{encodedThumbnailUrl}" />
             </head>
             <body></body>

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -2,8 +2,10 @@ using System.Buffers.Text;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq.Expressions;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
+using GankedTV.Api.Auth;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
@@ -142,23 +144,50 @@ public static class ClipsReadEndpoints
             c => c.Id == id && c.Status == "ready",
             principal, db, storage, s3, ct);
 
-    private static Task<IResult> GetByShareCode(
+    private static async Task<IResult> GetByShareCode(
         string code,
+        HttpRequest request,
+        IOptions<OAuthOptions> oauthOptions,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
-        CancellationToken ct) =>
-        ResolveClipByPredicateAsync(
+        CancellationToken ct)
+    {
+        var result = await LoadClipWithUrlsAsync(
             c => c.ShareCode == code && c.Status == "ready",
-            principal, db, storage, s3, ct);
+            db, storage, s3, ct);
+
+        if (result is null)
+            return ProblemResults.NotFound("not_found");
+
+        var (clip, videoUrl, thumbnailUrl) = result.Value;
+        var userAgent = request.Headers.UserAgent.ToString();
+
+        if (IsCrawler(userAgent))
+            return Results.Content(BuildOgHtml(clip, videoUrl, thumbnailUrl, request), "text/html; charset=utf-8");
+
+        if (request.Headers.Accept.ToString().Contains("application/json"))
+        {
+            var likedByMe = false;
+            if (TryGetUserId(principal, out var userId))
+            {
+                likedByMe = await db.Likes.AsNoTracking()
+                    .AnyAsync(l => l.ClipId == clip.Id && l.UserId == userId, ct);
+            }
+            var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
+            return Results.Ok(clip.ToDetail(videoUrl, expiresAt, thumbnailUrl, likedByMe));
+        }
+
+        var webOrigin = oauthOptions.Value.WebOrigin.TrimEnd('/');
+        return Results.Redirect($"{webOrigin}/c/{code}", permanent: false);
+    }
 
     // Unlisted clips are accessible to anyone with the link or share code — only the
     // feed is gated to public-only. Visibility is enforced at the listing layer, not
     // the detail layer.
-    private static async Task<IResult> ResolveClipByPredicateAsync(
+    internal static async Task<(Clip clip, string videoUrl, string thumbnailUrl)?> LoadClipWithUrlsAsync(
         Expression<Func<Clip, bool>> predicate,
-        ClaimsPrincipal principal,
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
@@ -170,13 +199,31 @@ public static class ClipsReadEndpoints
             .FirstOrDefaultAsync(predicate, ct);
 
         if (clip is null)
+            return null;
+
+        var videoUrl = storage.GetPresignedGetUrl(s3.Value.ClipsBucket, clip.VideoKey, VideoUrlLifetime);
+        var thumbnailUrl = BuildThumbnailUrl(storage, s3.Value.ThumbnailsBucket, clip.ThumbnailKey);
+
+        return (clip, videoUrl, thumbnailUrl);
+    }
+
+    private static async Task<IResult> ResolveClipByPredicateAsync(
+        Expression<Func<Clip, bool>> predicate,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        var result = await LoadClipWithUrlsAsync(predicate, db, storage, s3, ct);
+
+        if (result is null)
         {
             return ProblemResults.NotFound("not_found");
         }
 
+        var (clip, videoUrl, thumbnailUrl) = result.Value;
         var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
-        var videoUrl = storage.GetPresignedGetUrl(s3.Value.ClipsBucket, clip.VideoKey, VideoUrlLifetime);
-        var thumbnailUrl = BuildThumbnailUrl(storage, s3.Value.ThumbnailsBucket, clip.ThumbnailKey);
 
         var likedByMe = false;
         if (TryGetUserId(principal, out var userId))
@@ -186,6 +233,52 @@ public static class ClipsReadEndpoints
         }
 
         return Results.Ok(clip.ToDetail(videoUrl, expiresAt, thumbnailUrl, likedByMe));
+    }
+
+    private static readonly string[] CrawlerSubstrings =
+    [
+        "Discordbot", "Twitterbot", "facebookexternalhit", "Slackbot",
+        "LinkedInBot", "TelegramBot", "WhatsApp", "redditbot"
+    ];
+
+    private static bool IsCrawler(string userAgent) =>
+        CrawlerSubstrings.Any(s => userAgent.Contains(s, StringComparison.OrdinalIgnoreCase));
+
+    private static string BuildOgHtml(Clip clip, string videoUrl, string thumbnailUrl, HttpRequest request)
+    {
+        var title = WebUtility.HtmlEncode(clip.Title);
+        var desc = clip.Description is not null ? WebUtility.HtmlEncode(clip.Description) : null;
+        var canonicalUrl = $"{request.Scheme}://{request.Host}/c/{clip.ShareCode}";
+        // width/height fallback: Discord/Twitter require numeric values
+        var width = clip.Width?.ToString() ?? "1280";
+        var height = clip.Height?.ToString() ?? "720";
+        // video/mp4 is hardcoded — it's the only content type allowed by ClipValidationOptions
+
+        return $"""
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <meta charset="utf-8" />
+            <title>{title}</title>
+            <meta property="og:type" content="video.other" />
+            <meta property="og:url" content="{canonicalUrl}" />
+            <meta property="og:title" content="{title}" />
+            {(desc is not null ? $"""<meta property="og:description" content="{desc}" />""" : "")}
+            <meta property="og:image" content="{thumbnailUrl}" />
+            <meta property="og:video" content="{videoUrl}" />
+            <meta property="og:video:secure_url" content="{videoUrl}" />
+            <meta property="og:video:type" content="video/mp4" />
+            <meta property="og:video:width" content="{width}" />
+            <meta property="og:video:height" content="{height}" />
+            <meta name="twitter:card" content="player" />
+            <meta name="twitter:player" content="{videoUrl}" />
+            <meta name="twitter:player:width" content="{width}" />
+            <meta name="twitter:player:height" content="{height}" />
+            <meta name="twitter:image" content="{thumbnailUrl}" />
+            </head>
+            <body></body>
+            </html>
+            """;
     }
 
     internal static async Task<HashSet<Guid>> LoadLikedClipIdsAsync(

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -645,6 +645,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             .Returns("https://cdn.example.com/video.mp4");
 
         using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
         var byCode = await client.GetAsync($"/c/{shareCode}");
         var byId = await client.GetAsync($"/clips/{id}");
 
@@ -701,5 +702,88 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var resp = await client.GetAsync($"/c/{shareCode}");
 
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_CrawlerUA_ReturnsHtmlWithOgTags()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "My Awesome Clip");
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Discordbot/2.0");
+
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("text/html");
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain("og:title");
+        body.Should().Contain("og:image");
+        body.Should().Contain("og:video");
+        body.Should().Contain("twitter:card");
+        body.Should().Contain("My Awesome Clip");
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_NonCrawlerUA_Returns302ToWebOrigin()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (compatible)");
+
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Found);
+        resp.Headers.Location.Should().NotBeNull();
+        resp.Headers.Location!.ToString().Should().StartWith("http://localhost:5173");
+        resp.Headers.Location!.ToString().Should().EndWith($"/c/{shareCode}");
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_CrawlerUA_NotFound_Returns404()
+    {
+        await _fx.ResetAsync();
+
+        using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Discordbot/2.0");
+
+        var resp = await client.GetAsync("/c/unknowncode");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_CrawlerUA_HtmlEscapesTitle()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "<script>alert('xss')</script>");
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Discordbot/2.0");
+
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().NotContain("<script>alert");
+        body.Should().Contain("&lt;script&gt;");
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -699,6 +699,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, visibility: "unlisted");
 
         using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
         var resp = await client.GetAsync($"/c/{shareCode}");
 
         resp.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -768,6 +768,115 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ShareCodeResolve_CrawlerUA_BeatsAcceptJsonHeader()
+    {
+        // Precedence lock: a crawler UA that also sends `Accept: application/json`
+        // (rare but legal) must still receive the OG HTML — embed rendering wins over
+        // negotiation. If the branch ordering ever flips, social previews break.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow, title: "Precedence Clip");
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Discordbot/2.0");
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("text/html");
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain("og:title");
+        body.Should().Contain("Precedence Clip");
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_CrawlerUA_CanonicalUrlUsesWebOrigin()
+    {
+        // og:url must point at the user-facing web origin (WebOrigin config), not
+        // request.Scheme/Host — behind a reverse proxy the latter exposes the internal
+        // API host (e.g. http://localhost:5050) and breaks canonical links.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (_, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Discordbot/2.0");
+
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain($"http://localhost:5173/c/{shareCode}");
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_CrawlerUA_DescriptionPopulatesBothOgAndTwitterTags()
+    {
+        // When Description is present, both og:description and twitter:description must
+        // be emitted (and HTML-escaped). Pairs with the empty-description test below,
+        // which locks the null branch.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (id, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+        await using (var db = _fx.CreateContext())
+        {
+            var clip = db.Clips.Single(c => c.Id == id);
+            clip.Description = "A clutch ace under pressure";
+            await db.SaveChangesAsync();
+        }
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Discordbot/2.0");
+
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain("og:description");
+        body.Should().Contain("twitter:description");
+        body.Should().Contain("A clutch ace under pressure");
+    }
+
+    [Fact]
+    public async Task ShareCodeResolve_CrawlerUA_EmptyDescriptionOmitsOgDescriptionTag()
+    {
+        // Whitespace/empty Description must not produce <meta og:description content="" />.
+        // Slack in particular renders the empty tag as a blank line under the title.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var (id, shareCode) = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+        await using (var db = _fx.CreateContext())
+        {
+            var clip = db.Clips.Single(c => c.Id == id);
+            clip.Description = "";
+            await db.SaveChangesAsync();
+        }
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://cdn.example.com/video.mp4");
+
+        using var client = _factory!.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Discordbot/2.0");
+
+        var resp = await client.GetAsync($"/c/{shareCode}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().NotContain("og:description");
+        body.Should().NotContain("twitter:description");
+    }
+
+    [Fact]
     public async Task ShareCodeResolve_CrawlerUA_HtmlEscapesTitle()
     {
         await _fx.ResetAsync();

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -70,6 +70,7 @@ describe('api/clips', () => {
         createdAt: '2026-04-26T12:00:00Z',
         author: { id: 'u', username: 'zoe', avatarUrl: null },
         likedByMe: false,
+        shareCode: 'abc123',
       }
       vi.stubGlobal(
         'fetch',
@@ -95,6 +96,38 @@ describe('api/clips', () => {
 
       const [url] = vi.mocked(fetch).mock.calls[0] as [string]
       expect(url).toBe(`${BASE_URL}/clips/${encodeURIComponent('weird id/with?chars')}`)
+    })
+  })
+
+  describe('getByShareCode()', () => {
+    it('issues GET /c/{code} and returns the parsed detail', async () => {
+      const detail = {
+        id: 'a4f1e2c0-0000-0000-0000-000000000002',
+        title: 'Share Sample',
+        description: null,
+        videoUrl: 'https://cdn.example.com/clips/def.mp4?sig=xyz',
+        videoUrlExpiresAt: '2026-04-26T13:00:00Z',
+        thumbnailUrl: 'https://cdn.example.com/thumbs/def.jpg?sig=xyz',
+        durationSecs: 30,
+        width: 1280,
+        height: 720,
+        viewCount: 5,
+        likeCount: 2,
+        createdAt: '2026-04-26T12:00:00Z',
+        author: { id: 'u2', username: 'alex', avatarUrl: null },
+        likedByMe: false,
+        shareCode: 'abc123',
+      }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(detail)),
+      )
+
+      const result = await clips.getByShareCode('abc123')
+
+      expect(result).toEqual(detail)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/c/abc123`)
     })
   })
 

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -126,8 +126,25 @@ describe('api/clips', () => {
       const result = await clips.getByShareCode('abc123')
 
       expect(result).toEqual(detail)
-      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
       expect(url).toBe(`${BASE_URL}/c/abc123`)
+      // Server does Accept-based content negotiation on /c/{code} — without this
+      // header the JS app would receive the crawler HTML page instead of JSON.
+      expect(new Headers(init.headers).get('Accept')).toBe('application/json')
+    })
+
+    it('URI-encodes reserved characters in the share code', async () => {
+      // Codes today are server-generated alphanumeric, but encoding is cheap
+      // insurance against future schemes that may include reserved characters.
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({})),
+      )
+
+      await clips.getByShareCode('/?&=%')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/c/${encodeURIComponent('/?&=%')}`)
     })
   })
 

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -27,6 +27,7 @@ export interface ClipFeedItem {
   author: AuthorSummary
   game: GameSummary | null
   likedByMe: boolean
+  shareCode: string
 }
 
 export interface ClipDetail {
@@ -46,6 +47,7 @@ export interface ClipDetail {
   game: GameSummary | null
   likedByMe: boolean
   visibility: 'public' | 'unlisted'
+  shareCode: string
 }
 
 export interface UpdateClipBody {
@@ -102,6 +104,10 @@ export const clips = {
 
   getDetail(id: string): Promise<ClipDetail> {
     return api<ClipDetail>(`/clips/${encodeURIComponent(id)}`)
+  },
+
+  getByShareCode(code: string): Promise<ClipDetail> {
+    return api<ClipDetail>(`/c/${encodeURIComponent(code)}`)
   },
 
   create(body: CreateClipBody): Promise<{ id: string }> {

--- a/web/src/components/__tests__/ClipCard.spec.ts
+++ b/web/src/components/__tests__/ClipCard.spec.ts
@@ -16,6 +16,7 @@ function makeClip(overrides: Partial<ClipFeedItem> = {}): ClipFeedItem {
     author: { id: 'u1', username: 'phantomveil', avatarUrl: null },
     game: { id: 1, name: 'Valorant', slug: 'valorant', tag: 'VALORANT' },
     likedByMe: false,
+    shareCode: 'testcode',
     ...overrides,
   }
 }

--- a/web/src/router/__tests__/index.spec.ts
+++ b/web/src/router/__tests__/index.spec.ts
@@ -80,3 +80,11 @@ describe('router beforeEach guard', () => {
     expect(router.currentRoute.value.name).toBe('not-found')
   })
 })
+
+describe('share-code route', () => {
+  it('resolves /c/:code to the clip-share route and exposes the code param', async () => {
+    await router.push('/c/abc123')
+    expect(router.currentRoute.value.name).toBe('clip-share')
+    expect(router.currentRoute.value.params.code).toBe('abc123')
+  })
+})

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -47,6 +47,11 @@ const router = createRouter({
       component: () => import('@/views/ClipView.vue'),
     },
     {
+      path: '/c/:code',
+      name: 'clip-share',
+      component: () => import('@/views/ClipView.vue'),
+    },
+    {
       path: '/user/:username',
       name: 'user',
       component: () => import('@/views/UserView.vue'),

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -40,21 +40,27 @@ let latestLoadId = 0
 
 const clipId = computed(() => {
   const id = route.params.id
-  return Array.isArray(id) ? id[0] : id
+  return Array.isArray(id) ? id[0] : (id as string | undefined)
+})
+const shareCode = computed(() => {
+  const code = route.params.code
+  return Array.isArray(code) ? code[0] : (code as string | undefined)
 })
 
-async function loadClip(id: string) {
+async function loadClip() {
   const myLoadId = ++latestLoadId
   loading.value = true
   errored.value = false
   clip.value = null
   teardownPlayer()
   try {
-    const detail = await clips.getDetail(id)
+    const fetched = shareCode.value
+      ? await clips.getByShareCode(shareCode.value)
+      : await clips.getDetail(clipId.value!)
     if (myLoadId !== latestLoadId) return
-    clip.value = detail
-    liked.value = detail.likedByMe
-    likeCount.value = detail.likeCount
+    clip.value = fetched
+    liked.value = fetched.likedByMe
+    likeCount.value = fetched.likeCount
   } catch (err) {
     if (myLoadId !== latestLoadId) return
     if (err instanceof ApiError && err.status === 404) {
@@ -68,10 +74,10 @@ async function loadClip(id: string) {
 }
 
 watch(
-  clipId,
-  (id) => {
-    if (!id) return
-    loadClip(id)
+  [clipId, shareCode],
+  ([id, code]) => {
+    if (!id && !code) return
+    loadClip()
   },
   { immediate: true },
 )
@@ -148,7 +154,10 @@ async function toggleLike() {
 
 async function handleShare() {
   try {
-    await navigator.clipboard.writeText(window.location.href)
+    const url = clip.value?.shareCode
+      ? `${window.location.origin}/c/${clip.value.shareCode}`
+      : window.location.href
+    await navigator.clipboard.writeText(url)
     fireToast('🔗 Link copied to clipboard')
   } catch {
     fireToast('Copy failed')
@@ -261,7 +270,7 @@ async function onConfirmDelete() {
     <StatusPanel v-else-if="errored" kind="error" message="Couldn't load this clip.">
       <button
         class="cursor-pointer rounded-sm border border-border bg-surface-raised px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
-        @click="clipId && loadClip(clipId)"
+        @click="(clipId || shareCode) && loadClip()"
       >
         Retry
       </button>


### PR DESCRIPTION
# Depends on #80  — review and merge that first.


## Summary

Share links need to embed with thumbnail and inline player in Discord, Twitter/X, Slack, and Telegram — plain SPA links give crawlers nothing to work with. This PR makes `GET /c/{code}` serve crawler-specific OG/Twitter Card HTML while preserving the existing JSON and browser redirect paths.

Depends on #72 (share code column + short-URL resolver — already in this branch).

## What's here

- **Server — UA content negotiation on `GET /c/{code}`:** social crawlers receive OG/Twitter Card HTML with presigned thumbnail and video URLs; `Accept: application/json` returns the existing JSON DTO (SPA contract unchanged); everything else gets a `302` to `${WebOrigin}/c/{code}`
- **Server — `LoadClipWithUrlsAsync` extraction:** DRYs the DB lookup + URL signing shared by the JSON and HTML paths; all URL values in the HTML template are `HtmlEncode`d to handle `&` in presigned S3 query strings
- **Web — `/c/:code` route + types + API client:** `shareCode: string` added to `ClipFeedItem`/`ClipDetail`; `clips.getByShareCode()` added; `/c/:code` route registered (name: `clip-share`, reuses `ClipView`); `ClipView` generalised to load via either `clipId` or `shareCode` param; share button now copies the short URL

Closes #73.

## How to test manually

```bash
# Crawler gets OG HTML
curl -s -H 'User-Agent: Discordbot/2.0' http://localhost:5050/c/{code} | grep -E 'og:|twitter:'

# Browser gets 302 to SPA
curl -I -H 'User-Agent: Mozilla/5.0' http://localhost:5050/c/{code}
```

- Visit `http://localhost:5173/c/{code}` — clip loads and plays via the new `clip-share` route
- Click share on any clip — clipboard contains `http://localhost:5173/c/{code}` (short URL, not `/clip/{id}`)

## Checklist

- [ ] Verified manually (crawler UA → OG HTML, browser → redirect, SPA → plays, share button → short URL)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shareable clip URLs (/c/:code) with client support and a new API call to load clip details by share code.
  * Social preview pages for crawlers (OG/Twitter metadata) and a canonical share action that copies the /c/<code> link.

* **Bug Fixes**
  * Preview HTML is properly HTML-escaped and uses the canonical web origin for og:url.

* **Tests**
  * Added integration and client tests covering share-code routing, negotiation, encoding, and crawler behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->