### PR TITLE
[server] Rate limit clip mutate endpoints

### DIFF
--- a/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
+++ b/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
@@ -34,27 +34,32 @@ public static class ClipsRateLimiting
                 .ExecuteAsync(ctx.HttpContext));
 
         options.AddPolicy<string>(ClipsWritePolicy, ctx =>
-        {
-            // RequireAuthorization() on every /clips write group ensures HttpContext.User is
-            // populated before the limiter runs (UseAuthentication is wired before
-            // UseRateLimiter in Program.cs). We still fall through to IP / "unknown" so the
-            // partition function is total — a misconfiguration that drops the auth middleware
-            // must not collapse every caller into a single bucket and bypass the limit.
-            var sub = ctx.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
-                ?? ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            var key = !string.IsNullOrEmpty(sub)
-                ? $"u:{sub}"
-                : $"ip:{ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
-
-            return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+            RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(ctx), _ => new FixedWindowRateLimiterOptions
             {
                 AutoReplenishment = true,
                 PermitLimit = WritePermitLimit,
                 Window = WriteWindow,
                 QueueLimit = 0,
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-            });
-        });
+            }));
         return options;
+    }
+
+    // Internal so unit tests can exercise the fallback branches that the HTTP-level integration
+    // tests can't reach (RequireAuthorization rejects pre-limiter, so the per-IP and
+    // NameIdentifier paths are unreachable through real requests).
+    //
+    // RequireAuthorization() on every /clips write group ensures HttpContext.User is populated
+    // before the limiter runs (UseAuthentication is wired before UseRateLimiter in Program.cs).
+    // The IP / "unknown" fallbacks remain so the partition function is total — a misconfiguration
+    // that drops the auth middleware must not collapse every caller into a single bucket and
+    // bypass the limit.
+    internal static string ResolvePartitionKey(HttpContext ctx)
+    {
+        var sub = ctx.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return !string.IsNullOrEmpty(sub)
+            ? $"u:{sub}"
+            : $"ip:{ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
     }
 }

--- a/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
+++ b/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.RateLimiting;
@@ -16,6 +17,16 @@ public static class ClipsRateLimiting
 
     // 30 writes per minute. Per-user when the caller is authenticated, per-IP otherwise.
     // Fixed window (not sliding) — same shape as the credentials policy, no extra state.
+    //
+    // The 30 covers the WHOLE clip-write surface — every endpoint that attaches this policy
+    // shares one bucket per user: POST /clips, POST /clips/{id}/upload-url, POST /clips/{id}/complete,
+    // PATCH /clips/{id}, DELETE /clips/{id}, POST /clips/{id}/like, DELETE /clips/{id}/like.
+    // A happy-path upload burns 3 (create + upload-url + complete), so the floor is ~10 clips/min
+    // per user before the bucket exhausts. Pinned by ClipsRateLimitTests.MixedWrites_ShareBucket.
+    //
+    // SCALING CAVEAT: this is in-process, per-instance state. Once the API runs on more than
+    // one pod the effective limit becomes 30 × pod_count per user. Phase 4 (issue #74 out-of-scope)
+    // moves to a Redis-backed limiter for cluster-wide enforcement.
     public const int WritePermitLimit = 30;
     public static readonly TimeSpan WriteWindow = TimeSpan.FromMinutes(1);
 
@@ -29,9 +40,19 @@ public static class ClipsRateLimiting
         // slot. Wiring it here means every limiter rejection (this policy AND the credentials
         // policy registered in AuthRateLimiting) share one RFC 7807 envelope with
         // `code = "rate_limited"`, matching every other 4xx body the API emits.
+        //
+        // Sets `Retry-After` (seconds) from the lease metadata when available so well-behaved
+        // clients (and the SPA) can back off instead of polling blind. RFC 6585 §4.
         options.OnRejected = static (ctx, _) =>
-            new ValueTask(ProblemResults.TooManyRequests(RateLimitedCode)
+        {
+            if (ctx.Lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfter))
+            {
+                ctx.HttpContext.Response.Headers.RetryAfter =
+                    ((int)retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+            }
+            return new ValueTask(ProblemResults.TooManyRequests(RateLimitedCode)
                 .ExecuteAsync(ctx.HttpContext));
+        };
 
         options.AddPolicy<string>(ClipsWritePolicy, ctx =>
             RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(ctx), _ => new FixedWindowRateLimiterOptions

--- a/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
+++ b/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
@@ -1,0 +1,60 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.RateLimiting;
+using GankedTV.Api.Problems;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace GankedTV.Api.Clips;
+
+// Rate-limit policy for clip mutation endpoints (POST /clips, PATCH/DELETE /clips/{id},
+// the upload-url and complete steps, and the like/unlike pair). Kept out of Program.cs
+// so the policy + partition logic stay inside the coverage denominator — Program.cs is
+// excluded per CLAUDE.md.
+public static class ClipsRateLimiting
+{
+    public const string ClipsWritePolicy = "clips-write";
+
+    // 30 writes per minute. Per-user when the caller is authenticated, per-IP otherwise.
+    // Fixed window (not sliding) — same shape as the credentials policy, no extra state.
+    public const int WritePermitLimit = 30;
+    public static readonly TimeSpan WriteWindow = TimeSpan.FromMinutes(1);
+
+    // Machine-readable code stamped into the ProblemDetails extensions when any policy
+    // rejects. Mirrors the convention from ProblemResults.* used elsewhere in the API.
+    public const string RateLimitedCode = "rate_limited";
+
+    public static RateLimiterOptions AddClipsWritePolicy(this RateLimiterOptions options)
+    {
+        // OnRejected is a single global handler on RateLimiterOptions — there's no per-policy
+        // slot. Wiring it here means every limiter rejection (this policy AND the credentials
+        // policy registered in AuthRateLimiting) share one RFC 7807 envelope with
+        // `code = "rate_limited"`, matching every other 4xx body the API emits.
+        options.OnRejected = static (ctx, _) =>
+            new ValueTask(ProblemResults.TooManyRequests(RateLimitedCode)
+                .ExecuteAsync(ctx.HttpContext));
+
+        options.AddPolicy<string>(ClipsWritePolicy, ctx =>
+        {
+            // RequireAuthorization() on every /clips write group ensures HttpContext.User is
+            // populated before the limiter runs (UseAuthentication is wired before
+            // UseRateLimiter in Program.cs). We still fall through to IP / "unknown" so the
+            // partition function is total — a misconfiguration that drops the auth middleware
+            // must not collapse every caller into a single bucket and bypass the limit.
+            var sub = ctx.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+                ?? ctx.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var key = !string.IsNullOrEmpty(sub)
+                ? $"u:{sub}"
+                : $"ip:{ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+
+            return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+            {
+                AutoReplenishment = true,
+                PermitLimit = WritePermitLimit,
+                Window = WriteWindow,
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            });
+        });
+        return options;
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
@@ -22,7 +23,9 @@ public static class ClipsMutateEndpoints
 
     public static IEndpointRouteBuilder MapClipsMutateEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/clips").RequireAuthorization();
+        var group = app.MapGroup("/clips")
+            .RequireAuthorization()
+            .RequireRateLimiting(ClipsRateLimiting.ClipsWritePolicy);
         group.MapPatch("/{id:guid}", PatchClip).WithValidation<UpdateClipRequest>();
         group.MapDelete("/{id:guid}", DeleteClip);
         return app;

--- a/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.Clips;
@@ -17,7 +18,9 @@ public static class ClipsUploadEndpoints
 
     public static IEndpointRouteBuilder MapClipsUploadEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/clips").RequireAuthorization();
+        var group = app.MapGroup("/clips")
+            .RequireAuthorization()
+            .RequireRateLimiting(ClipsRateLimiting.ClipsWritePolicy);
         group.MapPost("/", CreateClip).WithValidation<CreateClipRequest>();
         group.MapPost("/{id:guid}/upload-url", GetUploadUrl);
         group.MapPost("/{id:guid}/complete", CompleteClip);

--- a/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Problems;
@@ -11,7 +12,9 @@ public static class LikesEndpoints
 {
     public static IEndpointRouteBuilder MapLikesEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/clips").RequireAuthorization();
+        var group = app.MapGroup("/clips")
+            .RequireAuthorization()
+            .RequireRateLimiting(ClipsRateLimiting.ClipsWritePolicy);
         group.MapPost("/{id:guid}/like", LikeClip);
         group.MapDelete("/{id:guid}/like", UnlikeClip);
         return app;

--- a/server/src/GankedTV.Api/Problems/ProblemResults.cs
+++ b/server/src/GankedTV.Api/Problems/ProblemResults.cs
@@ -27,6 +27,9 @@ public static class ProblemResults
     public static IResult UnsupportedMediaType(string code, string? detail = null) =>
         Build(StatusCodes.Status415UnsupportedMediaType, code, detail);
 
+    public static IResult TooManyRequests(string code, string? detail = null) =>
+        Build(StatusCodes.Status429TooManyRequests, code, detail);
+
     public static IResult Internal(string code, string? detail = null) =>
         Build(StatusCodes.Status500InternalServerError, code, detail);
 

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -5,6 +5,7 @@ using GankedTV.Api.Auth.Passwords;
 using GankedTV.Api.Auth.Providers;
 using GankedTV.Api.Auth.State;
 using GankedTV.Api.Auth.Tokens;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Configuration;
 using GankedTV.Api.Data;
 using GankedTV.Api.Endpoints;
@@ -220,7 +221,9 @@ builder.Services.AddScoped<IRefreshTokenService, RefreshTokenService>();
 builder.Services.AddScoped<UserUpsertService>();
 builder.Services.AddScoped<CredentialAuthService>();
 
-builder.Services.AddRateLimiter(opts => opts.AddCredentialsPolicy());
+builder.Services.AddRateLimiter(opts => opts
+    .AddCredentialsPolicy()
+    .AddClipsWritePolicy());
 
 builder.Services.AddSingleton<IOAuthProvider, DiscordOAuthProvider>();
 builder.Services.AddSingleton<IOAuthProvider, GoogleOAuthProvider>();

--- a/server/tests/GankedTV.Api.Tests/Clips/ClipsRateLimitingTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Clips/ClipsRateLimitingTests.cs
@@ -1,0 +1,82 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Clips;
+
+// Covers branches in ResolvePartitionKey that the integration tests can't reach: the auth
+// middleware in the real pipeline runs before the limiter and rejects unauthenticated callers
+// with 401, so the per-IP and "unknown" fallbacks never execute through HTTP. These unit tests
+// drive the static helper directly with a constructed HttpContext to exercise every branch.
+public class ClipsRateLimitingTests
+{
+    [Fact]
+    public void ResolvePartitionKey_UsesSubClaim_WhenPresent()
+    {
+        var ctx = MakeContext(
+            claims: [new Claim(JwtRegisteredClaimNames.Sub, "user-123")],
+            remoteIp: IPAddress.Parse("10.0.0.1"));
+
+        ClipsRateLimiting.ResolvePartitionKey(ctx).Should().Be("u:user-123");
+    }
+
+    [Fact]
+    public void ResolvePartitionKey_FallsBackToNameIdentifier_WhenSubMissing()
+    {
+        // Some JWT issuers / ClaimsPrincipal pipelines map `sub` to `ClaimTypes.NameIdentifier`
+        // instead of leaving it as the registered name. The helper mirrors the same precedence
+        // used by TryGetUserId in every authed endpoint, so they stay in lockstep.
+        var ctx = MakeContext(
+            claims: [new Claim(ClaimTypes.NameIdentifier, "nid-456")],
+            remoteIp: IPAddress.Parse("10.0.0.2"));
+
+        ClipsRateLimiting.ResolvePartitionKey(ctx).Should().Be("u:nid-456");
+    }
+
+    [Fact]
+    public void ResolvePartitionKey_FallsBackToRemoteIp_WhenNoUserClaim()
+    {
+        // Defensive path: if RequireAuthorization were ever removed from a /clips group, an
+        // unauthenticated caller would reach the limiter. Partition by IP rather than by null,
+        // which would collapse every anonymous caller into one shared bucket.
+        var ctx = MakeContext(claims: [], remoteIp: IPAddress.Parse("198.51.100.7"));
+
+        ClipsRateLimiting.ResolvePartitionKey(ctx).Should().Be("ip:198.51.100.7");
+    }
+
+    [Fact]
+    public void ResolvePartitionKey_FallsBackToUnknown_WhenNoClaimsAndNoRemoteIp()
+    {
+        // RemoteIpAddress is null on test rigs / unrecognised proxies. Without a stable string
+        // bucket here, the partition function would throw or null-bucket every such caller.
+        var ctx = MakeContext(claims: [], remoteIp: null);
+
+        ClipsRateLimiting.ResolvePartitionKey(ctx).Should().Be("ip:unknown");
+    }
+
+    [Fact]
+    public void ResolvePartitionKey_TreatsEmptySubAsMissing()
+    {
+        // ClaimsPrincipal.FindFirst returns the claim even when its Value is empty. Treating an
+        // empty sub as present would partition every such caller into the literal "u:" bucket.
+        var ctx = MakeContext(
+            claims: [new Claim(JwtRegisteredClaimNames.Sub, "")],
+            remoteIp: IPAddress.Parse("203.0.113.4"));
+
+        ClipsRateLimiting.ResolvePartitionKey(ctx).Should().Be("ip:203.0.113.4");
+    }
+
+    private static HttpContext MakeContext(IEnumerable<Claim> claims, IPAddress? remoteIp)
+    {
+        var ctx = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test")),
+        };
+        ctx.Connection.RemoteIpAddress = remoteIp;
+        return ctx;
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsRateLimitTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/AuthEndpointsRateLimitTests.cs
@@ -1,8 +1,11 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using FluentAssertions;
 using GankedTV.Api.Auth;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Auth;
+using GankedTV.Api.Problems;
 using GankedTV.Api.Tests.TestSupport;
 
 namespace GankedTV.Api.Tests.Integration.Endpoints;
@@ -48,5 +51,12 @@ public class AuthEndpointsRateLimitTests : IAsyncLifetime
             "/auth/login",
             new LoginRequest("nobody@example.com", "wrong-password-12345"));
         blocked.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        // ClipsRateLimiting installs a global OnRejected handler that shapes every limiter
+        // rejection — including this credentials policy — into the project's RFC 7807 envelope.
+        // Pin that contract here so a future refactor that splits OnRejected per-policy can't
+        // silently regress the auth-login error body.
+        blocked.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await blocked.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be(ClipsRateLimiting.RateLimitedCode);
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsRateLimitTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsRateLimitTests.cs
@@ -116,6 +116,12 @@ public class ClipsRateLimitTests : IAsyncLifetime
 
         var blocked = await client.PostAsync($"/clips/{clipId}/like", content: null);
         blocked.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        // OnRejected is global on RateLimiterOptions, so the envelope fires regardless of which
+        // policy or endpoint group rejected — assert it here too so the contract is pinned for
+        // the likes path on its own, not just transitively via the create test.
+        blocked.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await blocked.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be(ClipsRateLimiting.RateLimitedCode);
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsRateLimitTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsRateLimitTests.cs
@@ -91,6 +91,11 @@ public class ClipsRateLimitTests : IAsyncLifetime
         blocked.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
         var body = await blocked.Content.ReadFromJsonAsync<JsonElement>();
         body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be(ClipsRateLimiting.RateLimitedCode);
+
+        // Retry-After is set from the lease metadata (fixed window + AutoReplenishment emits it).
+        // Asserted here rather than in every 429 test — pinning it once proves the OnRejected
+        // header path runs.
+        blocked.Headers.RetryAfter.Should().NotBeNull();
     }
 
     [Fact]
@@ -122,6 +127,41 @@ public class ClipsRateLimitTests : IAsyncLifetime
         blocked.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
         var body = await blocked.Content.ReadFromJsonAsync<JsonElement>();
         body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be(ClipsRateLimiting.RateLimitedCode);
+    }
+
+    [Fact]
+    public async Task MixedWrites_ShareBucket_AcrossEndpointGroups()
+    {
+        // The three /clips write groups (Upload, Mutate, Likes) all attach ClipsWritePolicy by
+        // name, so one user shares one bucket across the entire write surface. Pin that as an
+        // intentional contract: a developer attaching the policy to a fourth group later can't
+        // accidentally widen the per-user budget without breaking this test.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("rl-author");
+        var (_, fanToken) = await SeedUserAndIssueTokenAsync("rl-fan");
+        var clipId = await SeedClipAsync(authorId);
+        using var client = ClientWithBearer(fanToken);
+
+        // Split the permit between two endpoint groups (POST /clips → Upload group,
+        // POST/DELETE /{id}/like → Likes group). Sum stays at WritePermitLimit.
+        var half = ClipsRateLimiting.WritePermitLimit / 2;
+        for (var i = 0; i < half; i++)
+        {
+            var create = await client.PostAsJsonAsync("/clips", new { title = $"mix-{i}" });
+            create.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        for (var i = 0; i < ClipsRateLimiting.WritePermitLimit - half; i++)
+        {
+            var like = (i % 2 == 0)
+                ? await client.PostAsync($"/clips/{clipId}/like", content: null)
+                : await client.DeleteAsync($"/clips/{clipId}/like");
+            like.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        // One more request — from EITHER group — must 429. Picking the like path here proves
+        // the bucket carries state across groups, not just within the group the budget was spent in.
+        var blocked = await client.PostAsync($"/clips/{clipId}/like", content: null);
+        blocked.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsRateLimitTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsRateLimitTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class ClipsRateLimitTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public ClipsRateLimitTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        // Substituting IObjectStorageService keeps these tests away from real S3 — they only
+        // care about how many requests the limiter accepts, not what the upload-url handler
+        // does with the response.
+        _storage = Substitute.For<IObjectStorageService>();
+        // A fresh factory per test gives each case its own in-process rate-limiter state, so
+        // a 31st request in one test doesn't leak into another.
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+            _factory = null;
+        }
+    }
+
+    private Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username) =>
+        AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+
+    private HttpClient ClientWithBearer(string token) =>
+        AuthTestHelpers.CreateBearerClient(_factory!, token);
+
+    private async Task<Guid> SeedClipAsync(Guid ownerId)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = ownerId,
+            Title = "rl-target",
+            VideoKey = $"clips/{ownerId}/{id}.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
+            Status = "ready",
+            Visibility = "public",
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task CreateClip_ExceedsWritePermitLimit_Returns429WithProblemEnvelope()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("rl-creator");
+        using var client = ClientWithBearer(token);
+
+        // Each accepted POST returns 200 with a draft clip. We don't care about the body —
+        // only that the limiter lets exactly PermitLimit requests through, then blocks.
+        for (var i = 0; i < ClipsRateLimiting.WritePermitLimit; i++)
+        {
+            var ok = await client.PostAsJsonAsync("/clips", new { title = $"clip-{i}" });
+            ok.StatusCode.Should().Be(HttpStatusCode.OK, $"request #{i + 1} should be allowed");
+        }
+
+        var blocked = await client.PostAsJsonAsync("/clips", new { title = "over-limit" });
+        blocked.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+
+        // RFC 7807 envelope with the machine-readable `code` extension — same shape every
+        // other 4xx in the API emits.
+        blocked.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await blocked.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty(ProblemResults.CodeKey).GetString().Should().Be(ClipsRateLimiting.RateLimitedCode);
+    }
+
+    [Fact]
+    public async Task Like_ExceedsWritePermitLimit_Returns429()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("rl-author");
+        var (_, fanToken) = await SeedUserAndIssueTokenAsync("rl-fan");
+        var clipId = await SeedClipAsync(authorId);
+        using var client = ClientWithBearer(fanToken);
+
+        // Alternate like/unlike so the same single clip can absorb every accepted hit without
+        // a unique-key collision — the rate limiter cares about the request count, not the
+        // semantics of the underlying operation. Confirms the policy covers the likes group
+        // in addition to /clips POST.
+        for (var i = 0; i < ClipsRateLimiting.WritePermitLimit; i++)
+        {
+            var resp = (i % 2 == 0)
+                ? await client.PostAsync($"/clips/{clipId}/like", content: null)
+                : await client.DeleteAsync($"/clips/{clipId}/like");
+            resp.StatusCode.Should().Be(HttpStatusCode.OK, $"request #{i + 1} should be allowed");
+        }
+
+        var blocked = await client.PostAsync($"/clips/{clipId}/like", content: null);
+        blocked.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public async Task TwoUsers_DoNotShareBucket()
+    {
+        await _fx.ResetAsync();
+        var (_, tokenA) = await SeedUserAndIssueTokenAsync("rl-user-a");
+        var (_, tokenB) = await SeedUserAndIssueTokenAsync("rl-user-b");
+        using var clientA = ClientWithBearer(tokenA);
+        using var clientB = ClientWithBearer(tokenB);
+
+        // Each user fires the full PermitLimit through their own bucket. If the policy were
+        // partitioning by IP instead of by sub, the shared 127.0.0.1 bucket would collapse
+        // both clients into one and the second user's last request would 429.
+        for (var i = 0; i < ClipsRateLimiting.WritePermitLimit; i++)
+        {
+            var a = await clientA.PostAsJsonAsync("/clips", new { title = $"a-{i}" });
+            a.StatusCode.Should().Be(HttpStatusCode.OK);
+            var b = await clientB.PostAsJsonAsync("/clips", new { title = $"b-{i}" });
+            b.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Pre-launch hardening for clip writes. Adds a 30/min fixed-window rate limiter to the clip mutation endpoints (the same in-process pattern the auth flow already uses for `/auth/login` and `/auth/register`), so a compromised or scripted token can't trivially abuse `POST /clips`, `PATCH/DELETE /clips/{id}`, or the like/unlike pair before public launch.

## What's here

- New `ClipsWritePolicy` in `Clips/ClipsRateLimiting.cs` — fixed window, partitioned by JWT `sub` claim (per-user buckets), with defensive IP / `"unknown"` fallbacks for the case where a future change drops `RequireAuthorization()` from a `/clips` group.
- Attached at group level on `ClipsUploadEndpoints`, `ClipsMutateEndpoints`, and `LikesEndpoints` — covers the five endpoints in the issue plus the upload-flow companions (`upload-url`, `complete`) which are server-side writes in the same flow.
- A single global `OnRejected` handler emits the project's standard RFC 7807 envelope with `code = "rate_limited"`. Side-effect: `/auth/login` 429 responses now also carry this body instead of being empty — no test relied on the empty body, but flagging in case any frontend code did.
- Integration tests (`ClipsRateLimitTests`): 31st `POST /clips` returns 429 with the envelope; 31st like/unlike returns 429; two distinct users do not share a bucket.
- Unit tests (`ClipsRateLimitingTests`) for the partition-key fallbacks the HTTP path can't reach (`Sub` missing, no claims, no IP, empty `Sub` value).

Closes #74

## How to test manually

```bash
make up
make server   # in one shell

# in another, mint a dev JWT via POST /dev/token (or use OAuth), then:
for i in (seq 1 31)
  curl -s -o /dev/null -w "%{http_code}\n" \
    -H "Authorization: Bearer $TOKEN" \
    -X POST http://localhost:5050/clips \
    -H 'Content-Type: application/json' \
    -d '{"title":"smoke","visibility":"public"}'
end
# expect: 30 × 200, then 429

# inspect the rejection body
curl -i -H "Authorization: Bearer $TOKEN" \
  -X POST http://localhost:5050/clips \
  -H 'Content-Type: application/json' \
  -d '{"title":"x"}'
# expect: Content-Type: application/problem+json
#         body extension `code` = "rate_limited"

# wait 60s, fire one more — should be 200 again (window replenished)
```

## Checklist

- [ ] Verified manually with a real token against `make server`
- [ ] Confirm SPA renders a sensible message when a clip create/like is rejected with 429 (this is a previously-impossible status code for these endpoints)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to clip write operations (create, update, delete) and like/unlike actions
  * Rate limits are enforced per-user when authenticated or per-IP when anonymous
  * Rate-limited responses return HTTP 429 with standardized error details

* **Tests**
  * Added comprehensive integration tests validating rate-limit behavior across endpoints and users

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->