### PR TITLE
[server][web] Game detail page: GET /games/{slug} + /game/:slug view 

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
@@ -9,9 +9,6 @@ public static class ClipMappings
     public static AuthorSummary ToAuthorSummary(this User user) =>
         new(user.Id, user.Username, user.AvatarUrl);
 
-    public static GameSummary ToGameSummary(this Game game) =>
-        new(game.Id, game.Name, game.Slug, game.Tag);
-
     public static CreateClipResponse ToCreateClipResponse(this CreateClipResult result) =>
         new(result.ClipId);
 

--- a/server/src/GankedTV.Api/Contracts/Games/GameDetail.cs
+++ b/server/src/GankedTV.Api/Contracts/Games/GameDetail.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Games;
+
+public sealed record GameDetail(int Id, string Name, string Slug, string Tag, string? CoverUrl, int ClipCount);

--- a/server/src/GankedTV.Api/Contracts/Games/GameMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Games/GameMappings.cs
@@ -1,0 +1,12 @@
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Contracts.Games;
+
+public static class GameMappings
+{
+    public static GameSummary ToGameSummary(this Game game) =>
+        new(game.Id, game.Name, game.Slug, game.Tag);
+
+    public static GameDetail ToDetail(this Game game, int clipCount) =>
+        new(game.Id, game.Name, game.Slug, game.Tag, game.CoverUrl, clipCount);
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -18,8 +18,11 @@ namespace GankedTV.Api.Endpoints;
 
 public static class ClipsReadEndpoints
 {
-    private const int DefaultLimit = 20;
-    private const int MaxLimit = 100;
+    // Feed-prefixed because BuildFeedPageAsync is called from GamesEndpoints too;
+    // a generic DefaultLimit/MaxLimit would collide with the same-named (different
+    // value) constants there. Internal so the helper is callable cross-class.
+    internal const int FeedDefaultLimit = 20;
+    internal const int FeedMaxLimit = 100;
     private static readonly TimeSpan VideoUrlLifetime = TimeSpan.FromHours(1);
     // Thumbnail URLs ride the same 1-hour signed window as video URLs — keeping the
     // two lifetimes aligned means a feed page that's still fresh enough to play the
@@ -44,14 +47,32 @@ public static class ClipsReadEndpoints
         IOptions<S3Options> s3,
         CancellationToken ct)
     {
-        var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+        var baseQuery = db.Clips.AsNoTracking()
+            .Where(c => c.Visibility == "public" && c.Status == "ready");
+        var response = await BuildFeedPageAsync(baseQuery, cursor, limit, principal, db, storage, s3, ct);
+        return Results.Ok(response);
+    }
+
+    // Shared cursor-paginated feed builder. Callers pass a pre-filtered IQueryable<Clip>
+    // (e.g. global feed, per-game feed) and this owns ordering, keyset cursoring,
+    // includes, likedByMe lookup, thumbnail signing, and nextCursor minting.
+    internal static async Task<ClipFeedResponse> BuildFeedPageAsync(
+        IQueryable<Clip> baseQuery,
+        string? cursor,
+        int? limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        var clampedLimit = Math.Clamp(limit ?? FeedDefaultLimit, 1, FeedMaxLimit);
 
         // Invalid cursor values silently fall back to "no cursor" rather than 400-ing; the
         // client's next-page fetch shouldn't be broken by a corrupted query string.
         var hasCursor = TryParseCursor(cursor, out var cursorCreatedAt, out var cursorId);
 
-        var query = db.Clips.AsNoTracking()
-            .Where(c => c.Visibility == "public" && c.Status == "ready");
+        var query = baseQuery;
         if (hasCursor)
         {
             // Composite (CreatedAt, Id) keyset: two clips sharing the same created_at (bulk imports,
@@ -84,7 +105,7 @@ public static class ClipsReadEndpoints
             .ToList();
         var nextCursor = hasMore ? BuildCursor(page[^1].CreatedAt, page[^1].Id) : null;
 
-        return Results.Ok(new ClipFeedResponse(items, nextCursor));
+        return new ClipFeedResponse(items, nextCursor);
     }
 
     // Public Ready clips always have a thumbnail (the worker is the only path to Ready

--- a/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
@@ -1,6 +1,10 @@
+using System.Security.Claims;
 using GankedTV.Api.Contracts.Games;
 using GankedTV.Api.Data;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace GankedTV.Api.Endpoints;
 
@@ -13,6 +17,8 @@ public static class GamesEndpoints
     {
         var group = app.MapGroup("/games");
         group.MapGet("/", GetGames);
+        group.MapGet("/{slug}", GetBySlug);
+        group.MapGet("/{slug}/clips", GetClipsForGame);
         return app;
     }
 
@@ -48,5 +54,56 @@ public static class GamesEndpoints
             .ToListAsync(ct);
 
         return Results.Ok(rows);
+    }
+
+    private static async Task<IResult> GetBySlug(
+        string slug,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        // One round-trip: project the entity together with a correlated COUNT scoped
+        // to the same visibility/status filter the clips list uses, so the header
+        // count matches the number of clips a user can actually scroll through.
+        var row = await db.Games.AsNoTracking()
+            .Where(g => g.Slug == slug)
+            .Select(g => new
+            {
+                Game = g,
+                ClipCount = db.Clips.Count(c =>
+                    c.GameId == g.Id && c.Visibility == "public" && c.Status == "ready"),
+            })
+            .FirstOrDefaultAsync(ct);
+
+        return row is null
+            ? ProblemResults.NotFound("not_found")
+            : Results.Ok(row.Game.ToDetail(row.ClipCount));
+    }
+
+    private static async Task<IResult> GetClipsForGame(
+        string slug,
+        string? cursor,
+        int? limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        // Distinguish "no such game" (404) from "game exists but has no clips" (200, empty page)
+        // so the client can pick the right empty state.
+        var gameId = await db.Games.AsNoTracking()
+            .Where(g => g.Slug == slug)
+            .Select(g => (int?)g.Id)
+            .FirstOrDefaultAsync(ct);
+
+        if (gameId is null)
+            return ProblemResults.NotFound("not_found");
+
+        var baseQuery = db.Clips.AsNoTracking()
+            .Where(c => c.GameId == gameId && c.Visibility == "public" && c.Status == "ready");
+
+        var response = await ClipsReadEndpoints.BuildFeedPageAsync(
+            baseQuery, cursor, limit, principal, db, storage, s3, ct);
+        return Results.Ok(response);
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/GamesEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/GamesEndpointsTests.cs
@@ -303,6 +303,30 @@ public class GamesEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetClipsForGame_LimitClampedToMax()
+    {
+        // BuildFeedPageAsync owns the clamp (FeedMaxLimit=100), but the per-game
+        // route also routes through it — pin the behaviour here so a future
+        // tweak to the helper or the route doesn't silently uncap the page size.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var gameId = await GetGameIdBySlugAsync("valorant");
+
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedClipAsync(userId, now.AddSeconds(-i), gameId);
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant/clips?limit=999999");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(5);
+    }
+
+    [Fact]
     public async Task GetClipsForGame_InvalidCursor_FallsBackToFirstPage()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/GamesEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/GamesEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
@@ -151,6 +152,216 @@ public class GamesEndpointsTests : IAsyncLifetime
         // Verify both that auth isn't required AND that the endpoint is healthy —
         // a 5xx would also `NotBe(Unauthorized)` and silently pass.
         resp.IsSuccessStatusCode.Should().BeTrue($"got {(int)resp.StatusCode}");
+    }
+
+    // ---- GET /games/{slug} ----
+
+    [Fact]
+    public async Task GetGameBySlug_Returns200WithDetailAndClipCount()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var gameId = await GetGameIdBySlugAsync("valorant");
+
+        // 3 public/ready clips count; non-public + non-ready do not.
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddMinutes(-1), gameId);
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddMinutes(-2), gameId);
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddMinutes(-3), gameId);
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, gameId, status: "processing");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, gameId, visibility: "unlisted");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetInt32().Should().Be(gameId);
+        body.GetProperty("slug").GetString().Should().Be("valorant");
+        body.GetProperty("name").GetString().Should().Be("Valorant");
+        body.GetProperty("tag").GetString().Should().NotBeNullOrEmpty();
+        body.GetProperty("clipCount").GetInt32().Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetGameBySlug_NoClips_ReturnsZeroCount()
+    {
+        await _fx.ResetAsync();
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("clipCount").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetGameBySlug_UnknownSlug_Returns404()
+    {
+        await _fx.ResetAsync();
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/does-not-exist");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ---- GET /games/{slug}/clips ----
+
+    [Fact]
+    public async Task GetClipsForGame_FiltersByGameAndVisibility()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var targetGameId = await GetGameIdBySlugAsync("valorant");
+        var otherGameId = await GetGameIdBySlugAsync("apex-legends");
+
+        var now = DateTimeOffset.UtcNow;
+        var (target1, _) = await SeedClipAsync(userId, now.AddMinutes(-1), targetGameId);
+        var (target2, _) = await SeedClipAsync(userId, now.AddMinutes(-2), targetGameId);
+        await SeedClipAsync(userId, now, otherGameId); // wrong game
+        await SeedClipAsync(userId, now, targetGameId, status: "processing"); // not ready
+        await SeedClipAsync(userId, now, targetGameId, visibility: "unlisted"); // not public
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant/clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(target1, target2);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GetClipsForGame_CursorPagination_NoDuplicatesAtBoundary()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var gameId = await GetGameIdBySlugAsync("valorant");
+
+        // Seed 4 clips; the middle two share the exact CreatedAt to exercise the
+        // composite (CreatedAt, Id) keyset across the page boundary.
+        var now = DateTimeOffset.UtcNow;
+        var shared = now.AddMinutes(-2);
+        var seeded = new List<Guid>();
+        var (a, _) = await SeedClipAsync(userId, now.AddMinutes(-1), gameId);
+        seeded.Add(a);
+        var (b, _) = await SeedClipAsync(userId, shared, gameId);
+        seeded.Add(b);
+        var (c, _) = await SeedClipAsync(userId, shared, gameId);
+        seeded.Add(c);
+        var (d, _) = await SeedClipAsync(userId, now.AddMinutes(-3), gameId);
+        seeded.Add(d);
+
+        using var client = _factory!.CreateClient();
+
+        var first = await client.GetAsync("/games/valorant/clips?limit=2");
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>();
+        firstBody.GetProperty("items").GetArrayLength().Should().Be(2);
+        var nextCursor = firstBody.GetProperty("nextCursor").GetString();
+        nextCursor.Should().NotBeNullOrEmpty();
+
+        var second = await client.GetAsync(
+            $"/games/valorant/clips?limit=2&cursor={Uri.EscapeDataString(nextCursor!)}");
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+
+        var returned = firstBody.GetProperty("items").EnumerateArray()
+            .Concat(secondBody.GetProperty("items").EnumerateArray())
+            .Select(e => e.GetProperty("id").GetGuid())
+            .ToList();
+        returned.Should().BeEquivalentTo(seeded);
+        returned.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public async Task GetClipsForGame_UnknownSlug_Returns404()
+    {
+        await _fx.ResetAsync();
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/does-not-exist/clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetClipsForGame_EmptyGame_Returns200WithEmptyItemsAndNullCursor()
+    {
+        await _fx.ResetAsync();
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant/clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GetClipsForGame_InvalidCursor_FallsBackToFirstPage()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, gameId);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant/clips?cursor=not-a-real-cursor");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(1);
+    }
+
+    // ---- helpers ----
+
+    private async Task<Guid> SeedUserAsync(string username = "games-test-user")
+    {
+        var (userId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+        return userId;
+    }
+
+    private async Task<int> GetGameIdBySlugAsync(string slug)
+    {
+        await using var db = _fx.CreateContext();
+        return await db.Games.Where(g => g.Slug == slug).Select(g => g.Id).FirstAsync();
+    }
+
+    private async Task<(Guid id, string shareCode)> SeedClipAsync(
+        Guid userId,
+        DateTimeOffset createdAt,
+        int? gameId,
+        string status = "ready",
+        string visibility = "public")
+    {
+        var id = Guid.NewGuid();
+        var shareCode = ShareCodeGenerator.Next();
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            GameId = gameId,
+            Title = $"clip-{id:N}".Substring(0, 20),
+            VideoKey = $"{userId}/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = shareCode,
+            Status = status,
+            Visibility = visibility,
+            DurationSecs = 30,
+            Width = 1920,
+            Height = 1080,
+            FileSizeBytes = 1_000_000,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        });
+        await db.SaveChangesAsync();
+        return (id, shareCode);
     }
 
     [Fact]

--- a/web/src/api/__tests__/games.spec.ts
+++ b/web/src/api/__tests__/games.spec.ts
@@ -61,6 +61,87 @@ describe('api/games', () => {
     })
   })
 
+  describe('getBySlug()', () => {
+    it('GETs /games/{slug} with the slug URL-encoded', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          jsonResponse({
+            id: 1,
+            name: 'Valorant',
+            slug: 'valorant',
+            tag: 'VALORANT',
+            coverUrl: null,
+            clipCount: 0,
+          }),
+        ),
+      )
+
+      await games.getBySlug('rocket league')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/games/rocket%20league`)
+    })
+
+    it('returns the parsed detail', async () => {
+      const body = {
+        id: 7,
+        name: 'Rocket League',
+        slug: 'rocket-league',
+        tag: 'RL',
+        coverUrl: 'https://cdn.test/rl.jpg',
+        clipCount: 42,
+      }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(body)),
+      )
+
+      const result = await games.getBySlug('rocket-league')
+
+      expect(result).toEqual(body)
+    })
+  })
+
+  describe('clips()', () => {
+    it('GETs /games/{slug}/clips with no query when no cursor/limit', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await games.clips('valorant')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/games/valorant/clips`)
+    })
+
+    it('passes cursor and limit through as query params', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await games.clips('valorant', { cursor: 'abc=', limit: 20 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      // URLSearchParams encodes '=' as '%3D'.
+      expect(url).toBe(`${BASE_URL}/games/valorant/clips?cursor=abc%3D&limit=20`)
+    })
+
+    it('skips cursor when null', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await games.clips('valorant', { cursor: null, limit: 10 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/games/valorant/clips?limit=10`)
+    })
+  })
+
   describe('search()', () => {
     it('URL-encodes the search term', async () => {
       vi.stubGlobal(

--- a/web/src/api/games.ts
+++ b/web/src/api/games.ts
@@ -1,4 +1,5 @@
 import { api } from './client'
+import type { ClipFeedPage, ClipFeedQuery } from './clips'
 
 export interface GameListItem {
   id: number
@@ -6,6 +7,15 @@ export interface GameListItem {
   slug: string
   tag: string
   coverUrl: string | null
+}
+
+export interface GameDetail {
+  id: number
+  name: string
+  slug: string
+  tag: string
+  coverUrl: string | null
+  clipCount: number
 }
 
 export const games = {
@@ -18,5 +28,17 @@ export const games = {
     const params = new URLSearchParams({ search: query })
     if (limit !== undefined) params.set('limit', String(limit))
     return api<GameListItem[]>(`/games?${params.toString()}`)
+  },
+
+  getBySlug(slug: string): Promise<GameDetail> {
+    return api<GameDetail>(`/games/${encodeURIComponent(slug)}`)
+  },
+
+  clips(slug: string, query: ClipFeedQuery = {}): Promise<ClipFeedPage> {
+    const params = new URLSearchParams()
+    if (query.cursor) params.set('cursor', query.cursor)
+    if (query.limit !== undefined) params.set('limit', String(query.limit))
+    const qs = params.toString()
+    return api<ClipFeedPage>(`/games/${encodeURIComponent(slug)}/clips${qs ? `?${qs}` : ''}`)
   },
 }

--- a/web/src/components/ClipCard.vue
+++ b/web/src/components/ClipCard.vue
@@ -35,14 +35,19 @@ function onKeydown(e: KeyboardEvent) {
         alt=""
         class="h-full w-full object-cover transition-transform duration-400 group-hover:scale-104"
       />
-      <!-- Game tag — top-left. Links to /game/:slug; .stop prevents the card
-           click from also firing and routing to the clip detail. -->
+      <!-- Game tag — top-left. Links to /game/:slug. The handlers stop both
+           pointer and keyboard activation from bubbling to the parent article,
+           whose @click + @keydown otherwise route to the clip detail instead.
+           Enter fires the link's native synthetic click; Space we preventDefault
+           so it doesn't scroll the page on top of the navigation. -->
       <RouterLink
         v-if="props.clip.game"
         :to="{ name: 'game-detail', params: { slug: props.clip.game.slug } }"
         :aria-label="`Browse ${props.clip.game.name} clips`"
         class="absolute left-2 top-2 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-brand"
         @click.stop
+        @keydown.enter.stop
+        @keydown.space.prevent.stop
       >
         <GameTag :tag="props.clip.game.tag" />
       </RouterLink>

--- a/web/src/components/ClipCard.vue
+++ b/web/src/components/ClipCard.vue
@@ -35,10 +35,17 @@ function onKeydown(e: KeyboardEvent) {
         alt=""
         class="h-full w-full object-cover transition-transform duration-400 group-hover:scale-104"
       />
-      <!-- Game tag — top-left -->
-      <div v-if="props.clip.game" class="absolute left-2 top-2">
+      <!-- Game tag — top-left. Links to /game/:slug; .stop prevents the card
+           click from also firing and routing to the clip detail. -->
+      <RouterLink
+        v-if="props.clip.game"
+        :to="{ name: 'game-detail', params: { slug: props.clip.game.slug } }"
+        :aria-label="`Browse ${props.clip.game.name} clips`"
+        class="absolute left-2 top-2 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        @click.stop
+      >
         <GameTag :tag="props.clip.game.tag" />
-      </div>
+      </RouterLink>
       <!-- Duration — bottom-right -->
       <DurationBadge :seconds="props.clip.durationSecs" class="absolute bottom-2 right-2" />
     </div>

--- a/web/src/components/__tests__/ClipCard.spec.ts
+++ b/web/src/components/__tests__/ClipCard.spec.ts
@@ -1,7 +1,23 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { defineComponent, h } from 'vue'
 import ClipCard from '../ClipCard.vue'
 import type { ClipFeedItem } from '@/api/clips'
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: defineComponent({ render: () => h('div') }) },
+      {
+        path: '/game/:slug',
+        name: 'game-detail',
+        component: defineComponent({ render: () => h('div') }),
+      },
+    ],
+  })
+}
 
 function makeClip(overrides: Partial<ClipFeedItem> = {}): ClipFeedItem {
   return {
@@ -24,33 +40,67 @@ function makeClip(overrides: Partial<ClipFeedItem> = {}): ClipFeedItem {
 describe('ClipCard', () => {
   it('renders the clip title', () => {
     const clip = makeClip()
-    const wrapper = mount(ClipCard, { props: { clip } })
+    const wrapper = mount(ClipCard, { props: { clip }, global: { plugins: [makeRouter()] } })
     expect(wrapper.text()).toContain(clip.title)
   })
 
   it('renders the game tag when game is set', () => {
-    const wrapper = mount(ClipCard, { props: { clip: makeClip() } })
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip() },
+      global: { plugins: [makeRouter()] },
+    })
     expect(wrapper.text()).toContain('VALORANT')
   })
 
   it('omits the game tag when game is null', () => {
-    const wrapper = mount(ClipCard, { props: { clip: makeClip({ game: null }) } })
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip({ game: null }) },
+      global: { plugins: [makeRouter()] },
+    })
     expect(wrapper.text()).not.toContain('VALORANT')
   })
 
   it('renders the formatted duration', () => {
-    const wrapper = mount(ClipCard, { props: { clip: makeClip() } })
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip() },
+      global: { plugins: [makeRouter()] },
+    })
     expect(wrapper.text()).toContain('0:42')
   })
 
   it('renders the @username in neon', () => {
-    const wrapper = mount(ClipCard, { props: { clip: makeClip() } })
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip() },
+      global: { plugins: [makeRouter()] },
+    })
     expect(wrapper.text()).toContain('@phantomveil')
   })
 
   it('emits click when the article is clicked', async () => {
-    const wrapper = mount(ClipCard, { props: { clip: makeClip() } })
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip() },
+      global: { plugins: [makeRouter()] },
+    })
     await wrapper.find('article').trigger('click')
     expect(wrapper.emitted('click')).toBeTruthy()
+  })
+
+  it('renders the game tag as a link to /game/:slug', () => {
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip() },
+      global: { plugins: [makeRouter()] },
+    })
+    const link = wrapper.find('a')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBe('/game/valorant')
+  })
+
+  it('does not emit card click when the game-tag link is clicked', async () => {
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip() },
+      global: { plugins: [makeRouter()] },
+    })
+    await wrapper.find('a').trigger('click')
+    expect(wrapper.emitted('click')).toBeFalsy()
   })
 })

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -37,6 +37,11 @@ const router = createRouter({
       component: () => import('@/views/GamesView.vue'),
     },
     {
+      path: '/game/:slug',
+      name: 'game-detail',
+      component: () => import('@/views/GameView.vue'),
+    },
+    {
       path: '/trending',
       name: 'trending',
       component: () => import('@/views/TrendingView.vue'),

--- a/web/src/views/GameView.vue
+++ b/web/src/views/GameView.vue
@@ -33,12 +33,24 @@ const paginationErrored = ref(false)
 const sentinel = ref<HTMLElement | null>(null)
 let observer: IntersectionObserver | null = null
 
+// Monotonic request token. Bumped at the start of every loadAll (i.e. on mount
+// and every slug change). Each in-flight fetch captures the token at entry and
+// bails when it resolves if a newer loadAll has superseded it — otherwise a
+// stale response for slug A would stomp state belonging to slug B after a fast
+// nav. Also gates loading.value clear-down so a stale finally doesn't flip
+// loading off mid-load for the current request.
+let requestId = 0
+
 async function loadGame() {
   const s = slug.value
   if (!s) return
+  const token = requestId
   try {
-    game.value = await games.getBySlug(s)
+    const result = await games.getBySlug(s)
+    if (token !== requestId) return
+    game.value = result
   } catch (err) {
+    if (token !== requestId) return
     if (err instanceof ApiError && err.status === 404) {
       notFound.value = true
     } else {
@@ -51,14 +63,17 @@ async function loadGame() {
 async function loadMore() {
   const s = slug.value
   if (!s || loading.value || reachedEnd.value || notFound.value) return
+  const token = requestId
   loading.value = true
   paginationErrored.value = false
   try {
     const page = await games.clips(s, { cursor: cursor.value, limit: 20 })
+    if (token !== requestId) return
     items.value.push(...page.items)
     cursor.value = page.nextCursor
     if (page.nextCursor === null) reachedEnd.value = true
   } catch (err) {
+    if (token !== requestId) return
     if (items.value.length === 0) {
       // First-page failure (game lookup may have succeeded). Treat 404 here as
       // the same "game does not exist" branch so we don't render a broken header.
@@ -72,7 +87,7 @@ async function loadMore() {
     }
     console.error('game-detail: load failed', err)
   } finally {
-    loading.value = false
+    if (token === requestId) loading.value = false
   }
 }
 
@@ -95,6 +110,7 @@ function detachObserver() {
 }
 
 async function loadAll() {
+  const token = ++requestId
   errored.value = false
   notFound.value = false
   paginationErrored.value = false
@@ -111,16 +127,20 @@ async function loadAll() {
     // a 500 on /games/{slug} can set errored=true while /games/{slug}/clips
     // succeeds and silently populates items behind the error panel.
     await loadGame()
+    if (token !== requestId) return
     if (notFound.value || errored.value) return
     await loadMore()
   } catch {
     // individual handlers already set the right flag
   } finally {
-    initialLoading.value = false
-    // Defer observer attachment to next tick so the sentinel is in the DOM
-    // (it's only rendered when game is loaded and !errored).
-    if (!notFound.value && !errored.value && !reachedEnd.value) {
-      requestAnimationFrame(attachObserver)
+    // Bare `return` in finally is unsafe (masks throws), so gate via if-block.
+    if (token === requestId) {
+      initialLoading.value = false
+      // Defer observer attachment to next tick so the sentinel is in the DOM
+      // (it's only rendered when game is loaded and !errored).
+      if (!notFound.value && !errored.value && !reachedEnd.value) {
+        requestAnimationFrame(attachObserver)
+      }
     }
   }
 }

--- a/web/src/views/GameView.vue
+++ b/web/src/views/GameView.vue
@@ -1,0 +1,245 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { games, type GameDetail } from '@/api/games'
+import type { ClipFeedItem } from '@/api/clips'
+import { ApiError } from '@/api/client'
+import ClipCard from '@/components/ClipCard.vue'
+import GameTag from '@/components/GameTag.vue'
+import PageHeader from '@/components/PageHeader.vue'
+import StatusPanel from '@/components/StatusPanel.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const slug = computed(() => {
+  const raw = route.params.slug
+  return Array.isArray(raw) ? raw[0] : raw
+})
+
+const game = ref<GameDetail | null>(null)
+const items = ref<ClipFeedItem[]>([])
+const cursor = ref<string | null>(null)
+// Hit-end flag: distinguishes "more pages exist" (cursor !== null) from "first
+// page returned an empty list but the game does exist". Needed so the observer
+// doesn't keep firing forever and so the empty-state copy renders correctly.
+const reachedEnd = ref(false)
+const loading = ref(false)
+const initialLoading = ref(true)
+const errored = ref(false)
+const notFound = ref(false)
+const paginationErrored = ref(false)
+
+const sentinel = ref<HTMLElement | null>(null)
+let observer: IntersectionObserver | null = null
+
+async function loadGame() {
+  const s = slug.value
+  if (!s) return
+  try {
+    game.value = await games.getBySlug(s)
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound.value = true
+    } else {
+      errored.value = true
+    }
+    throw err
+  }
+}
+
+async function loadMore() {
+  const s = slug.value
+  if (!s || loading.value || reachedEnd.value || notFound.value) return
+  loading.value = true
+  paginationErrored.value = false
+  try {
+    const page = await games.clips(s, { cursor: cursor.value, limit: 20 })
+    items.value.push(...page.items)
+    cursor.value = page.nextCursor
+    if (page.nextCursor === null) reachedEnd.value = true
+  } catch (err) {
+    if (items.value.length === 0) {
+      // First-page failure (game lookup may have succeeded). Treat 404 here as
+      // the same "game does not exist" branch so we don't render a broken header.
+      if (err instanceof ApiError && err.status === 404) {
+        notFound.value = true
+      } else {
+        errored.value = true
+      }
+    } else {
+      paginationErrored.value = true
+    }
+    console.error('game-detail: load failed', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+function attachObserver() {
+  if (observer || !sentinel.value || reachedEnd.value) return
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((e) => e.isIntersecting)) loadMore()
+    },
+    // rootMargin pre-fetches the next page ~400px before the sentinel actually
+    // enters the viewport so the user rarely sees a loading gap.
+    { rootMargin: '400px' },
+  )
+  observer.observe(sentinel.value)
+}
+
+function detachObserver() {
+  observer?.disconnect()
+  observer = null
+}
+
+async function loadAll() {
+  errored.value = false
+  notFound.value = false
+  paginationErrored.value = false
+  reachedEnd.value = false
+  initialLoading.value = true
+  game.value = null
+  items.value = []
+  cursor.value = null
+  detachObserver()
+
+  try {
+    // Sequenced (not Promise.all) so that a failed game lookup short-circuits
+    // before the clips fetch fires. Parallelising the two creates a race where
+    // a 500 on /games/{slug} can set errored=true while /games/{slug}/clips
+    // succeeds and silently populates items behind the error panel.
+    await loadGame()
+    if (notFound.value || errored.value) return
+    await loadMore()
+  } catch {
+    // individual handlers already set the right flag
+  } finally {
+    initialLoading.value = false
+    // Defer observer attachment to next tick so the sentinel is in the DOM
+    // (it's only rendered when game is loaded and !errored).
+    if (!notFound.value && !errored.value && !reachedEnd.value) {
+      requestAnimationFrame(attachObserver)
+    }
+  }
+}
+
+function retry() {
+  loadAll()
+}
+
+onMounted(loadAll)
+onBeforeUnmount(detachObserver)
+
+// Client-side nav between two /game/:slug URLs must reset state and reload.
+watch(slug, () => {
+  loadAll()
+})
+</script>
+
+<template>
+  <main
+    class="mx-auto max-w-360 px-6 pt-8 pb-30 max-[899px]:px-3.5 max-[899px]:pt-4 max-[899px]:pb-20"
+  >
+    <!-- Not-found state -->
+    <StatusPanel v-if="notFound" kind="empty" message="No game with that slug.">
+      <RouterLink
+        to="/games"
+        class="rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+      >
+        Back to games
+      </RouterLink>
+    </StatusPanel>
+
+    <!-- Initial error -->
+    <StatusPanel v-else-if="errored" kind="error" message="Couldn't load this game.">
+      <button
+        class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="retry"
+      >
+        Retry
+      </button>
+    </StatusPanel>
+
+    <!-- Initial loading -->
+    <StatusPanel v-else-if="initialLoading && !game" kind="loading" message="Loading…" />
+
+    <template v-else-if="game">
+      <!-- Header -->
+      <section
+        class="relative mb-10 overflow-hidden rounded-lg border border-border bg-surface-raised"
+      >
+        <div
+          v-if="game.coverUrl"
+          class="absolute inset-0 bg-cover bg-center opacity-30"
+          :style="{ backgroundImage: `url(${game.coverUrl})` }"
+          aria-hidden="true"
+        ></div>
+        <div
+          class="absolute inset-0 bg-[linear-gradient(180deg,transparent_0%,var(--color-surface-raised)_100%)]"
+          aria-hidden="true"
+        ></div>
+        <div class="relative px-8 py-10 max-[899px]:px-5 max-[899px]:py-7">
+          <PageHeader :title="game.name" pulse>
+            <template #caption>
+              Game · {{ game.clipCount }} clip{{ game.clipCount === 1 ? '' : 's' }}
+            </template>
+            <div class="mt-3 flex items-center gap-3">
+              <GameTag :tag="game.tag" size="md" />
+              <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-text-muted">
+                /{{ game.slug }}
+              </span>
+            </div>
+          </PageHeader>
+        </div>
+      </section>
+
+      <!-- Clip grid -->
+      <div v-if="items.length" class="feed-grid">
+        <ClipCard
+          v-for="clip in items"
+          :key="clip.id"
+          :clip="clip"
+          @click="router.push({ name: 'clip', params: { id: clip.id } })"
+        />
+      </div>
+
+      <!-- Empty -->
+      <StatusPanel v-else-if="reachedEnd" kind="empty" message="No clips for this game yet.">
+        <RouterLink
+          to="/upload"
+          class="rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        >
+          Upload a clip
+        </RouterLink>
+      </StatusPanel>
+
+      <!-- Sentinel (only when there's more to load) -->
+      <div
+        v-if="!reachedEnd"
+        ref="sentinel"
+        class="mt-8 flex items-center justify-center py-6"
+        aria-hidden="true"
+      >
+        <span v-if="loading" class="font-mono text-[11px] uppercase tracking-widest text-text-muted"
+          >Loading more…</span
+        >
+      </div>
+
+      <!-- Pagination error (inline retry, keep loaded clips on screen) -->
+      <div v-if="paginationErrored" class="mt-2 flex flex-col items-center gap-2">
+        <span class="font-mono text-[11px] uppercase tracking-widest text-text-muted">
+          Couldn't load more — try again.
+        </span>
+        <button
+          :disabled="loading"
+          @click="loadMore"
+          class="cursor-pointer rounded-sm border border-border bg-surface-raised px-6 py-2.5 font-mono text-[11px] uppercase tracking-[0.08em] text-text-primary transition-colors duration-150 hover:border-brand-light disabled:opacity-50"
+        >
+          Retry
+        </button>
+      </div>
+    </template>
+  </main>
+</template>

--- a/web/src/views/GameView.vue
+++ b/web/src/views/GameView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { games, type GameDetail } from '@/api/games'
 import type { ClipFeedItem } from '@/api/clips'
 import { ApiError } from '@/api/client'
+import { useAuthStore } from '@/stores/auth'
 import ClipCard from '@/components/ClipCard.vue'
 import GameTag from '@/components/GameTag.vue'
 import PageHeader from '@/components/PageHeader.vue'
@@ -11,6 +12,7 @@ import StatusPanel from '@/components/StatusPanel.vue'
 
 const route = useRoute()
 const router = useRouter()
+const auth = useAuthStore()
 
 const slug = computed(() => {
   const raw = route.params.slug
@@ -67,7 +69,9 @@ async function loadMore() {
   loading.value = true
   paginationErrored.value = false
   try {
-    const page = await games.clips(s, { cursor: cursor.value, limit: 20 })
+    // No explicit limit — server defaults match the global feed (FeedDefaultLimit=20)
+    // so we don't fork the value across client + server.
+    const page = await games.clips(s, { cursor: cursor.value })
     if (token !== requestId) return
     items.value.push(...page.items)
     cursor.value = page.nextCursor
@@ -83,11 +87,22 @@ async function loadMore() {
         errored.value = true
       }
     } else {
+      // Detach the observer so micro-scrolls past the sentinel don't silently
+      // hammer the failing endpoint. The Retry button is the only way out — it
+      // clears paginationErrored and re-attaches the observer.
       paginationErrored.value = true
+      detachObserver()
     }
     console.error('game-detail: load failed', err)
   } finally {
     if (token === requestId) loading.value = false
+  }
+}
+
+async function retryLoadMore() {
+  await loadMore()
+  if (!paginationErrored.value && !reachedEnd.value) {
+    attachObserver()
   }
 }
 
@@ -119,6 +134,11 @@ async function loadAll() {
   game.value = null
   items.value = []
   cursor.value = null
+  // Clear here too: an in-flight loadMore for the previous slug may still own
+  // loading=true, and its finally won't clear it (token mismatch). Without this
+  // reset, the new slug's loadMore would early-return on `loading.value` and
+  // wedge the page in a permanent loading state.
+  loading.value = false
   detachObserver()
 
   try {
@@ -190,12 +210,16 @@ watch(slug, () => {
       <section
         class="relative mb-10 overflow-hidden rounded-lg border border-border bg-surface-raised"
       >
-        <div
+        <!-- Cover rendered as <img> rather than background-image so the URL
+             can't break out of a CSS string (a coverUrl containing `");
+             content:url("` would otherwise escape the url() value). -->
+        <img
           v-if="game.coverUrl"
-          class="absolute inset-0 bg-cover bg-center opacity-30"
-          :style="{ backgroundImage: `url(${game.coverUrl})` }"
+          :src="game.coverUrl"
+          alt=""
+          class="absolute inset-0 h-full w-full object-cover opacity-30"
           aria-hidden="true"
-        ></div>
+        />
         <div
           class="absolute inset-0 bg-[linear-gradient(180deg,transparent_0%,var(--color-surface-raised)_100%)]"
           aria-hidden="true"
@@ -225,9 +249,11 @@ watch(slug, () => {
         />
       </div>
 
-      <!-- Empty -->
+      <!-- Empty. CTA only shown to authenticated users — /upload requires auth
+           and would otherwise bounce visitors through login. -->
       <StatusPanel v-else-if="reachedEnd" kind="empty" message="No clips for this game yet.">
         <RouterLink
+          v-if="auth.isAuthenticated"
           to="/upload"
           class="rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
         >
@@ -235,26 +261,28 @@ watch(slug, () => {
         </RouterLink>
       </StatusPanel>
 
-      <!-- Sentinel (only when there's more to load) -->
+      <!-- Sentinel: an empty observation target. aria-hidden so screen readers
+           skip the layout div; the live-region below carries the loading text. -->
+      <div v-if="!reachedEnd" ref="sentinel" class="mt-8 py-6" aria-hidden="true"></div>
       <div
-        v-if="!reachedEnd"
-        ref="sentinel"
-        class="mt-8 flex items-center justify-center py-6"
-        aria-hidden="true"
+        v-if="loading && !reachedEnd"
+        role="status"
+        aria-live="polite"
+        class="-mt-6 flex items-center justify-center py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
       >
-        <span v-if="loading" class="font-mono text-[11px] uppercase tracking-widest text-text-muted"
-          >Loading more…</span
-        >
+        Loading more…
       </div>
 
-      <!-- Pagination error (inline retry, keep loaded clips on screen) -->
+      <!-- Pagination error (inline retry, keep loaded clips on screen). The
+           observer is detached when paginationErrored flips, so the only way
+           back to loading is this button — retryLoadMore re-attaches on success. -->
       <div v-if="paginationErrored" class="mt-2 flex flex-col items-center gap-2">
         <span class="font-mono text-[11px] uppercase tracking-widest text-text-muted">
           Couldn't load more — try again.
         </span>
         <button
           :disabled="loading"
-          @click="loadMore"
+          @click="retryLoadMore"
           class="cursor-pointer rounded-sm border border-border bg-surface-raised px-6 py-2.5 font-mono text-[11px] uppercase tracking-[0.08em] text-text-primary transition-colors duration-150 hover:border-brand-light disabled:opacity-50"
         >
           Retry

--- a/web/src/views/GamesView.vue
+++ b/web/src/views/GamesView.vue
@@ -15,23 +15,9 @@ const allClips = ref<ClipFeedItem[]>([])
 const loading = ref(false)
 const errored = ref(false)
 
-// 'all' shows the entire feed grid; selecting a game filters client-side off the
-// loaded feed page. Per-game endpoints with their own pagination are out of scope
-// for this PR — see the backlog for `GET /games/{slug}/clips`.
-//
-// The selected game is driven by the URL (?game=<slug>) so the watcher below is
-// the single source of truth — tile clicks call `selectGame()` which only
-// updates the route. Back/forward and deep links Just Work as a side effect.
-const active = computed<'all' | string>(() => {
-  const q = router.currentRoute.value.query.game
-  return typeof q === 'string' && q ? q : 'all'
-})
-
-function selectGame(slug: 'all' | string) {
-  const next = slug === 'all' ? undefined : slug
-  router.replace({ query: { ...router.currentRoute.value.query, game: next } })
-}
-
+// Per-game clip counts are derived from the loaded feed page — fine as a rough
+// indicator on the catalog tiles. The authoritative count for a game lives on
+// the game-detail page (clipCount on GameDetail).
 const clipCountByGame = computed(() => {
   const counts = new Map<string, number>()
   for (const c of allClips.value) {
@@ -40,16 +26,7 @@ const clipCountByGame = computed(() => {
   return counts
 })
 
-const filteredClips = computed(() => {
-  if (active.value === 'all') return allClips.value.slice(0, 12)
-  return allClips.value.filter((c) => c.game?.slug === active.value).slice(0, 12)
-})
-
-const sectionTitle = computed(() => {
-  if (active.value === 'all') return 'Featured across all games'
-  const g = allGames.value.find((x) => x.slug === active.value)
-  return g ? `Top in ${g.name}` : 'Top clips'
-})
+const featuredClips = computed(() => allClips.value.slice(0, 12))
 
 async function load() {
   loading.value = true
@@ -68,10 +45,7 @@ async function load() {
 onMounted(load)
 
 const tileBase =
-  'min-h-27.5 cursor-pointer rounded-md border p-4 text-left transition-[border-color,box-shadow] duration-150 hover:border-border-hover'
-const tileInactive = 'border-border bg-surface-raised'
-const tileActive = 'border-brand shadow-[0_14px_40px_-14px_var(--color-brand-glow)]'
-const tileActiveAll = `${tileActive} bg-brand`
+  'min-h-27.5 block rounded-md border border-border bg-surface-raised p-4 text-left no-underline transition-[border-color,box-shadow] duration-150 hover:border-brand hover:shadow-[0_14px_40px_-14px_var(--color-brand-glow)]'
 </script>
 
 <template>
@@ -81,7 +55,7 @@ const tileActiveAll = `${tileActive} bg-brand`
         Library · {{ allGames.length }} games · {{ allClips.length }} clips loaded
       </template>
       <p class="m-0 mt-2 max-w-[56ch] text-[15px] leading-normal text-text-secondary">
-        Every clip is tagged with its game. Pick a game to filter the feed.
+        Every clip is tagged with its game. Pick one to see all its clips.
       </p>
     </PageHeader>
 
@@ -95,35 +69,13 @@ const tileActiveAll = `${tileActive} bg-brand`
     </StatusPanel>
 
     <template v-else>
-      <!-- Game tiles -->
+      <!-- Game tiles — each links to /game/:slug -->
       <div class="mt-8 grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3.5">
-        <button
-          :class="[tileBase, active === 'all' ? tileActiveAll : tileInactive]"
-          :aria-pressed="active === 'all'"
-          @click="selectGame('all')"
-        >
-          <div class="flex h-full flex-col justify-between gap-2">
-            <span class="font-heading text-xl font-bold leading-none uppercase text-white">
-              All Games
-            </span>
-            <div class="flex flex-col gap-0.75">
-              <span class="font-mono text-[10px] tracking-[0.08em] text-neon">
-                {{ allClips.length }} clips
-              </span>
-            </div>
-          </div>
-        </button>
-
-        <button
+        <RouterLink
           v-for="g in allGames"
           :key="g.id"
-          :class="[
-            tileBase,
-            'relative overflow-hidden',
-            active === g.slug ? tileActive : 'border-border bg-surface-raised',
-          ]"
-          :aria-pressed="active === g.slug"
-          @click="selectGame(g.slug)"
+          :to="{ name: 'game-detail', params: { slug: g.slug } }"
+          :class="[tileBase, 'relative overflow-hidden']"
         >
           <div class="relative flex h-full flex-col justify-between gap-2">
             <span class="font-heading text-xl font-bold leading-none uppercase text-text-primary">
@@ -136,27 +88,27 @@ const tileActiveAll = `${tileActive} bg-brand`
               </span>
             </div>
           </div>
-        </button>
+        </RouterLink>
       </div>
 
-      <!-- Clip section -->
+      <!-- Featured clips teaser -->
       <div class="mt-12">
         <div class="mb-5 flex items-baseline justify-between gap-4">
           <h2
             class="section-title-bar m-0 inline-flex items-center gap-3.5 font-heading text-2xl font-bold uppercase tracking-[0.02em] text-text-primary"
           >
-            {{ sectionTitle }}
+            Featured across all games
           </h2>
         </div>
 
         <StatusPanel
-          v-if="loading && filteredClips.length === 0"
+          v-if="loading && featuredClips.length === 0"
           kind="loading"
           message="Loading…"
         />
-        <div v-else-if="filteredClips.length" class="feed-grid">
+        <div v-else-if="featuredClips.length" class="feed-grid">
           <ClipCard
-            v-for="clip in filteredClips"
+            v-for="clip in featuredClips"
             :key="clip.id"
             :clip="clip"
             @click="router.push({ name: 'clip', params: { id: clip.id } })"
@@ -166,7 +118,7 @@ const tileActiveAll = `${tileActive} bg-brand`
           v-else
           class="rounded-md border border-border bg-surface-raised p-8 text-center font-mono text-sm uppercase tracking-widest text-text-muted"
         >
-          {{ active === 'all' ? 'No clips yet.' : 'No recent clips for this game.' }}
+          No clips yet.
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Summary

Phase 3 (Discovery) — the per-game landing page so clicking a game in the catalog finally goes somewhere. Adds `/games/{slug}` + `/games/{slug}/clips` on the server and a `/game/:slug` view on the web with an infinite-scroll grid of that game's clips.

## What's here

**Server**
- `GET /games/{slug}` → `GameDetail` (id, name, slug, tag, coverUrl, clipCount). 404 on unknown slug. `clipCount` matches the same `visibility='public' AND status='ready'` filter the clip list uses, so the header number equals what the user can actually scroll through.
- `GET /games/{slug}/clips` → cursor-paginated `ClipFeedResponse` for that game. 404 on unknown slug (distinguishes "no game" from "empty page").
- Extracted `ClipsReadEndpoints.BuildFeedPageAsync` so the global feed and per-game feed share the same keyset pagination (composite `(CreatedAt, Id)` cursor, `limit+1` fetch, likedByMe lookup, thumbnail signing). Zero duplicated pagination logic.
- New `Contracts/Games/GameMappings.cs` holds `ToGameSummary` (moved from `ClipMappings.cs`) and `ToDetail(clipCount)`. Mappers now live next to their DTOs per PLAN.md §11.

**Web**
- New `/game/:slug` route → `GameView.vue`: cover-image header, infinite scroll via `IntersectionObserver` (pre-fetches ~400px before the sentinel enters the viewport), separate first-load / not-found / pagination-error states, and a `watch(slug)` so navigating between two game pages resets state correctly.
- `games.getBySlug` / `games.clips` added to the API client, reusing `ClipFeedPage`/`ClipFeedQuery` from `clips.ts`.
- Game chip on `ClipCard.vue` wraps in a `RouterLink` to `game-detail` (with `@click.stop` so it doesn't bubble to the card's clip-open click).
- `GamesView.vue` tiles now navigate to `/game/:slug` instead of filtering in place — the previous filter mechanic was an explicit placeholder until the per-game endpoint existed.

**Tests**
- 8 new server integration tests covering detail+count, zero-count, 404s on both routes, game/visibility filtering, cursor boundary with shared `CreatedAt`, empty page, and invalid-cursor fallback. Existing 37 `ClipsReadEndpointsTests` still pass — guards the helper refactor.
- New web tests for `games.getBySlug` / `games.clips` URL construction and the ClipCard chip-as-link behavior.

Closes #83

## How to test manually

```bash
make migrate                # share_code column is required for the feed query
make up && make server      # one terminal
cd web && bun dev           # another

# API smoke
curl -s http://localhost:5050/games/valorant | jq
curl -s 'http://localhost:5050/games/valorant/clips?limit=10' | jq
curl -i http://localhost:5050/games/does-not-exist 2>&1 | head -1  # 404

# Browser walkthrough
open http://localhost:5173/games          # tile click routes to /game/:slug
open http://localhost:5173/game/valorant  # header + grid; scroll past bottom loads next page
open http://localhost:5173/game/no-such   # 404 panel + "Back to games"
open http://localhost:5173/               # game chip on any clip card → /game/:slug
```

To exercise the IntersectionObserver-driven infinite scroll you need ≥21 clips on one game — the dev seed has fewer, so seed extras if needed.

## Checklist

- [ ] Migrations applied (`make migrate`)
- [ ] Verified game tile + game chip both route to `/game/:slug`
- [ ] Verified infinite scroll loads a second page (needs ≥21 clips)
- [ ] Verified unknown slug returns the 404 panel with "Back to games"

## Follow-up

#90 tracks IGDB metadata backfill so `coverUrl` actually gets populated — the header in this PR already renders covers when present, it just degrades to text today because the seeded games have null `cover_url`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added game detail pages accessible via game navigation, displaying clips with infinite scroll pagination
  * Converted game browsing: Game cards now link to dedicated detail views instead of in-feed filtering
  * Game tag overlays on clip cards now navigate to the game's detail page

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->