### PR TITLE
[server][web] Comments: schema + endpoints + comments section on clip detail

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Comments/CommentItem.cs
+++ b/server/src/GankedTV.Api/Contracts/Comments/CommentItem.cs
@@ -1,0 +1,19 @@
+using GankedTV.Api.Contracts.Clips;
+
+namespace GankedTV.Api.Contracts.Comments;
+
+/// <summary>
+/// A single comment. For soft-deleted comments <see cref="Body"/> is <c>null</c> and
+/// <see cref="Deleted"/> is <c>true</c> so the UI can render a <c>[deleted]</c> placeholder
+/// while keeping the thread structure intact. <see cref="Replies"/> carries the first page of
+/// inline replies for a top-level comment (empty for replies themselves).
+/// </summary>
+public sealed record CommentItem(
+    Guid Id,
+    string? Body,
+    AuthorSummary Author,
+    Guid? ParentId,
+    DateTimeOffset CreatedAt,
+    int ReplyCount,
+    IReadOnlyList<CommentItem> Replies,
+    bool Deleted);

--- a/server/src/GankedTV.Api/Contracts/Comments/CommentItem.cs
+++ b/server/src/GankedTV.Api/Contracts/Comments/CommentItem.cs
@@ -6,7 +6,9 @@ namespace GankedTV.Api.Contracts.Comments;
 /// A single comment. For soft-deleted comments <see cref="Body"/> is <c>null</c> and
 /// <see cref="Deleted"/> is <c>true</c> so the UI can render a <c>[deleted]</c> placeholder
 /// while keeping the thread structure intact. <see cref="Replies"/> carries the first page of
-/// inline replies for a top-level comment (empty for replies themselves).
+/// inline replies for a top-level comment (empty for replies themselves);
+/// <see cref="RepliesNextCursor"/> is the cursor to fetch the next page via
+/// <c>GET /comments/{id}/replies</c>, or <c>null</c> when the inline preview is exhaustive.
 /// </summary>
 public sealed record CommentItem(
     Guid Id,
@@ -16,4 +18,5 @@ public sealed record CommentItem(
     DateTimeOffset CreatedAt,
     int ReplyCount,
     IReadOnlyList<CommentItem> Replies,
+    string? RepliesNextCursor,
     bool Deleted);

--- a/server/src/GankedTV.Api/Contracts/Comments/CommentListResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Comments/CommentListResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Comments;
+
+public sealed record CommentListResponse(IReadOnlyList<CommentItem> Items, string? NextCursor);

--- a/server/src/GankedTV.Api/Contracts/Comments/CommentMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Comments/CommentMappings.cs
@@ -1,0 +1,29 @@
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Contracts.Comments;
+
+public static class CommentMappings
+{
+    private static readonly IReadOnlyList<CommentItem> NoReplies = [];
+
+    /// <summary>
+    /// Maps a comment to its API shape. Soft-deleted comments surface a <c>null</c> body and
+    /// <c>Deleted = true</c>. The caller supplies <paramref name="replyCount"/> and the
+    /// inline <paramref name="replies"/> page (both default to empty for a reply or a
+    /// freshly-created comment).
+    /// </summary>
+    public static CommentItem ToItem(
+        this Comment comment,
+        int replyCount = 0,
+        IReadOnlyList<CommentItem>? replies = null) =>
+        new(
+            comment.Id,
+            comment.DeletedAt is null ? comment.Body : null,
+            comment.User.ToAuthorSummary(),
+            comment.ParentId,
+            comment.CreatedAt,
+            replyCount,
+            replies ?? NoReplies,
+            comment.DeletedAt is not null);
+}

--- a/server/src/GankedTV.Api/Contracts/Comments/CommentMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Comments/CommentMappings.cs
@@ -9,14 +9,16 @@ public static class CommentMappings
 
     /// <summary>
     /// Maps a comment to its API shape. Soft-deleted comments surface a <c>null</c> body and
-    /// <c>Deleted = true</c>. The caller supplies <paramref name="replyCount"/> and the
-    /// inline <paramref name="replies"/> page (both default to empty for a reply or a
-    /// freshly-created comment).
+    /// <c>Deleted = true</c>. The caller supplies <paramref name="replyCount"/>, the inline
+    /// <paramref name="replies"/> page, and <paramref name="repliesNextCursor"/> — the cursor
+    /// to fetch the next page of replies (or <c>null</c> when the preview is exhaustive). All
+    /// default to empty/null for a reply or a freshly-created comment.
     /// </summary>
     public static CommentItem ToItem(
         this Comment comment,
         int replyCount = 0,
-        IReadOnlyList<CommentItem>? replies = null) =>
+        IReadOnlyList<CommentItem>? replies = null,
+        string? repliesNextCursor = null) =>
         new(
             comment.Id,
             comment.DeletedAt is null ? comment.Body : null,
@@ -25,5 +27,6 @@ public static class CommentMappings
             comment.CreatedAt,
             replyCount,
             replies ?? NoReplies,
+            repliesNextCursor,
             comment.DeletedAt is not null);
 }

--- a/server/src/GankedTV.Api/Contracts/Comments/CreateCommentRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Comments/CreateCommentRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using GankedTV.Api.Validation;
+
+namespace GankedTV.Api.Contracts.Comments;
+
+public sealed record CreateCommentRequest(
+    [property: Required]
+    [property: StringLength(CommentValidationLimits.MaxBodyLength, MinimumLength = 1)]
+    string? Body,
+    // null = top-level comment; set = reply to a top-level comment on the same clip.
+    Guid? ParentId);

--- a/server/src/GankedTV.Api/Data/Entities/Comment.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Comment.cs
@@ -1,0 +1,24 @@
+namespace GankedTV.Api.Data.Entities;
+
+public class Comment
+{
+    public Guid Id { get; set; }
+    public Guid ClipId { get; set; }
+    public Guid UserId { get; set; }
+
+    // null = top-level comment; set = reply. Threads are flat two-level: a reply's parent is
+    // always a top-level comment (ParentId.ParentId is null), enforced at the endpoint layer.
+    public Guid? ParentId { get; set; }
+    public required string Body { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    // Soft-delete: preserves thread structure so replies don't collapse. A deleted comment
+    // renders as a `[deleted]` placeholder with Body surfaced as null in the API.
+    public DateTimeOffset? DeletedAt { get; set; }
+
+    public Clip Clip { get; set; } = null!;
+    public User User { get; set; } = null!;
+    public Comment? Parent { get; set; }
+    public ICollection<Comment> Replies { get; set; } = [];
+}

--- a/server/src/GankedTV.Api/Data/Entities/User.cs
+++ b/server/src/GankedTV.Api/Data/Entities/User.cs
@@ -18,4 +18,5 @@ public class User
     public ICollection<Like> Likes { get; set; } = [];
     public ICollection<Follow> Following { get; set; } = [];
     public ICollection<Follow> Followers { get; set; } = [];
+    public ICollection<Comment> Comments { get; set; } = [];
 }

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -238,6 +238,9 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             // Drives the top-level listing for a clip (ordered by created_at) and reply lookups.
             e.HasIndex(c => new { c.ClipId, c.CreatedAt }).HasDatabaseName("idx_comments_clip_id");
             e.HasIndex(c => new { c.ParentId, c.CreatedAt }).HasDatabaseName("idx_comments_parent_id");
+            // EF auto-generates an index on the UserId FK; name it explicitly to match the
+            // `idx_*` convention used elsewhere (otherwise it lands as `ix_comments_user_id`).
+            e.HasIndex(c => c.UserId).HasDatabaseName("idx_comments_user_id");
         });
 
         modelBuilder.Entity<RefreshToken>(e =>

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -10,6 +10,7 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
     public DbSet<Clip> Clips => Set<Clip>();
     public DbSet<Like> Likes => Set<Like>();
     public DbSet<Follow> Follows => Set<Follow>();
+    public DbSet<Comment> Comments => Set<Comment>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
     public DbSet<Tag> Tags => Set<Tag>();
     public DbSet<ClipTag> ClipTags => Set<ClipTag>();
@@ -206,6 +207,36 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             e.HasIndex(f => new { f.FollowerId, f.CreatedAt })
                 .IsDescending(false, true)
                 .HasDatabaseName("idx_follows_follower_created_at");
+        });
+
+        modelBuilder.Entity<Comment>(e =>
+        {
+            e.HasKey(c => c.Id);
+            e.Property(c => c.Id).HasDefaultValueSql("gen_random_uuid()");
+            e.Property(c => c.Body).HasMaxLength(2000);
+            e.Property(c => c.CreatedAt).HasDefaultValueSql("now()");
+            e.Property(c => c.UpdatedAt).HasDefaultValueSql("now()");
+
+            e.HasOne(c => c.Clip)
+                .WithMany()
+                .HasForeignKey(c => c.ClipId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(c => c.User)
+                .WithMany(u => u.Comments)
+                .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Self-referencing parent → replies. Cascade only fires on a real (hard) delete of
+            // a parent row; the app soft-deletes (DeletedAt) so threads stay intact in practice.
+            e.HasOne(c => c.Parent)
+                .WithMany(c => c.Replies)
+                .HasForeignKey(c => c.ParentId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Drives the top-level listing for a clip (ordered by created_at) and reply lookups.
+            e.HasIndex(c => new { c.ClipId, c.CreatedAt }).HasDatabaseName("idx_comments_clip_id");
+            e.HasIndex(c => new { c.ParentId, c.CreatedAt }).HasDatabaseName("idx_comments_parent_id");
         });
 
         modelBuilder.Entity<RefreshToken>(e =>

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -1,4 +1,5 @@
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Validation;
 using Microsoft.EntityFrameworkCore;
 
 namespace GankedTV.Api.Data;
@@ -213,7 +214,7 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
         {
             e.HasKey(c => c.Id);
             e.Property(c => c.Id).HasDefaultValueSql("gen_random_uuid()");
-            e.Property(c => c.Body).HasMaxLength(2000);
+            e.Property(c => c.Body).HasMaxLength(CommentValidationLimits.MaxBodyLength);
             e.Property(c => c.CreatedAt).HasDefaultValueSql("now()");
             e.Property(c => c.UpdatedAt).HasDefaultValueSql("now()");
 

--- a/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.Designer.cs
@@ -210,7 +210,7 @@ namespace GankedTV.Api.Data.Migrations
                         .HasName("pk_comments");
 
                     b.HasIndex("UserId")
-                        .HasDatabaseName("ix_comments_user_id");
+                        .HasDatabaseName("idx_comments_user_id");
 
                     b.HasIndex("ClipId", "CreatedAt")
                         .HasDatabaseName("idx_comments_clip_id");

--- a/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.Designer.cs
@@ -3,18 +3,20 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using NpgsqlTypes;
 
 #nullable disable
 
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522163557_AddComments")]
+    partial class AddComments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -72,13 +74,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.Property<DateTimeOffset?>("ProcessingStartedAt")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("processing_started_at");
-
-                    b.Property<NpgsqlTsVector>("SearchVector")
-                        .IsRequired()
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("tsvector")
-                        .HasColumnName("search_vector")
-                        .HasComputedColumnSql("setweight(to_tsvector('simple', coalesce(title, '')), 'A') || setweight(to_tsvector('simple', coalesce(description, '')), 'B')", true);
 
                     b.Property<string>("ShareCode")
                         .IsRequired()
@@ -147,11 +142,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.HasIndex("GameId")
                         .HasDatabaseName("idx_clips_game_id");
 
-                    b.HasIndex("SearchVector")
-                        .HasDatabaseName("idx_clips_search_vector");
-
-                    NpgsqlIndexBuilderExtensions.HasMethod(b.HasIndex("SearchVector"), "GIN");
-
                     b.HasIndex("ShareCode")
                         .IsUnique()
                         .HasDatabaseName("idx_clips_share_code");
@@ -172,25 +162,6 @@ namespace GankedTV.Api.Data.Migrations
                         .HasFilter("status = 'processing'");
 
                     b.ToTable("clips", (string)null);
-                });
-
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.ClipTag", b =>
-                {
-                    b.Property<Guid>("ClipId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("clip_id");
-
-                    b.Property<int>("TagId")
-                        .HasColumnType("integer")
-                        .HasColumnName("tag_id");
-
-                    b.HasKey("ClipId", "TagId")
-                        .HasName("pk_clip_tags");
-
-                    b.HasIndex("TagId", "ClipId")
-                        .HasDatabaseName("idx_clip_tags_tag");
-
-                    b.ToTable("clip_tags", (string)null);
                 });
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Comment", b =>
@@ -250,39 +221,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.ToTable("comments", (string)null);
                 });
 
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Follow", b =>
-                {
-                    b.Property<Guid>("FollowerId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("follower_id");
-
-                    b.Property<Guid>("FolloweeId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("followee_id");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at")
-                        .HasDefaultValueSql("now()");
-
-                    b.HasKey("FollowerId", "FolloweeId")
-                        .HasName("pk_follows");
-
-                    b.HasIndex("FolloweeId", "CreatedAt")
-                        .IsDescending(false, true)
-                        .HasDatabaseName("idx_follows_followee_created_at");
-
-                    b.HasIndex("FollowerId", "CreatedAt")
-                        .IsDescending(false, true)
-                        .HasDatabaseName("idx_follows_follower_created_at");
-
-                    b.ToTable("follows", null, t =>
-                        {
-                            t.HasCheckConstraint("ck_follows_no_self", "follower_id <> followee_id");
-                        });
-                });
-
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Game", b =>
                 {
                     b.Property<int>("Id")
@@ -317,13 +255,6 @@ namespace GankedTV.Api.Data.Migrations
                         .HasColumnType("character varying(255)")
                         .HasColumnName("name");
 
-                    b.Property<NpgsqlTsVector>("SearchVector")
-                        .IsRequired()
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("tsvector")
-                        .HasColumnName("search_vector")
-                        .HasComputedColumnSql("to_tsvector('simple', coalesce(name, ''))", true);
-
                     b.Property<string>("Slug")
                         .IsRequired()
                         .HasMaxLength(255)
@@ -341,11 +272,6 @@ namespace GankedTV.Api.Data.Migrations
 
                     b.HasIndex("Name")
                         .HasDatabaseName("idx_games_name");
-
-                    b.HasIndex("SearchVector")
-                        .HasDatabaseName("idx_games_search_vector");
-
-                    NpgsqlIndexBuilderExtensions.HasMethod(b.HasIndex("SearchVector"), "GIN");
 
                     b.HasIndex("Slug")
                         .IsUnique()
@@ -504,43 +430,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.ToTable("refresh_tokens", (string)null);
                 });
 
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Tag", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at")
-                        .HasDefaultValueSql("now()");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(24)
-                        .HasColumnType("character varying(24)")
-                        .HasColumnName("name");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasMaxLength(24)
-                        .HasColumnType("character varying(24)")
-                        .HasColumnName("slug");
-
-                    b.HasKey("Id")
-                        .HasName("pk_tags");
-
-                    b.HasIndex("Slug")
-                        .IsUnique()
-                        .HasDatabaseName("idx_tags_slug");
-
-                    b.ToTable("tags", (string)null);
-                });
-
             modelBuilder.Entity("GankedTV.Api.Data.Entities.User", b =>
                 {
                     b.Property<Guid>("Id")
@@ -646,27 +535,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.ClipTag", b =>
-                {
-                    b.HasOne("GankedTV.Api.Data.Entities.Clip", "Clip")
-                        .WithMany("ClipTags")
-                        .HasForeignKey("ClipId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_clip_tags_clips_clip_id");
-
-                    b.HasOne("GankedTV.Api.Data.Entities.Tag", "Tag")
-                        .WithMany("ClipTags")
-                        .HasForeignKey("TagId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_clip_tags_tags_tag_id");
-
-                    b.Navigation("Clip");
-
-                    b.Navigation("Tag");
-                });
-
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Comment", b =>
                 {
                     b.HasOne("GankedTV.Api.Data.Entities.Clip", "Clip")
@@ -694,27 +562,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.Navigation("Parent");
 
                     b.Navigation("User");
-                });
-
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Follow", b =>
-                {
-                    b.HasOne("GankedTV.Api.Data.Entities.User", "Followee")
-                        .WithMany("Followers")
-                        .HasForeignKey("FolloweeId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_follows_users_followee_id");
-
-                    b.HasOne("GankedTV.Api.Data.Entities.User", "Follower")
-                        .WithMany("Following")
-                        .HasForeignKey("FollowerId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_follows_users_follower_id");
-
-                    b.Navigation("Followee");
-
-                    b.Navigation("Follower");
                 });
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Like", b =>
@@ -752,8 +599,6 @@ namespace GankedTV.Api.Data.Migrations
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Clip", b =>
                 {
-                    b.Navigation("ClipTags");
-
                     b.Navigation("Likes");
                 });
 
@@ -762,20 +607,11 @@ namespace GankedTV.Api.Data.Migrations
                     b.Navigation("Replies");
                 });
 
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Tag", b =>
-                {
-                    b.Navigation("ClipTags");
-                });
-
             modelBuilder.Entity("GankedTV.Api.Data.Entities.User", b =>
                 {
                     b.Navigation("Clips");
 
                     b.Navigation("Comments");
-
-                    b.Navigation("Followers");
-
-                    b.Navigation("Following");
 
                     b.Navigation("Likes");
                 });

--- a/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.cs
@@ -58,7 +58,7 @@ namespace GankedTV.Api.Data.Migrations
                 columns: new[] { "parent_id", "created_at" });
 
             migrationBuilder.CreateIndex(
-                name: "ix_comments_user_id",
+                name: "idx_comments_user_id",
                 table: "comments",
                 column: "user_id");
         }

--- a/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522163557_AddComments.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddComments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "comments",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    clip_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    parent_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    body = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_comments", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_comments_clips_clip_id",
+                        column: x => x.clip_id,
+                        principalTable: "clips",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_comments_comments_parent_id",
+                        column: x => x.parent_id,
+                        principalTable: "comments",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_comments_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_comments_clip_id",
+                table: "comments",
+                columns: new[] { "clip_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_comments_parent_id",
+                table: "comments",
+                columns: new[] { "parent_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comments_user_id",
+                table: "comments",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "comments");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Data/Migrations/GankedTvDbContextModelSnapshot.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/GankedTvDbContextModelSnapshot.cs
@@ -239,7 +239,7 @@ namespace GankedTV.Api.Data.Migrations
                         .HasName("pk_comments");
 
                     b.HasIndex("UserId")
-                        .HasDatabaseName("ix_comments_user_id");
+                        .HasDatabaseName("idx_comments_user_id");
 
                     b.HasIndex("ClipId", "CreatedAt")
                         .HasDatabaseName("idx_comments_clip_id");

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -6,6 +6,7 @@ using GankedTV.Api.Auth;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Pagination;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
@@ -83,7 +84,7 @@ public static class ClipsReadEndpoints
 
         // Invalid cursor values silently fall back to "no cursor" rather than 400-ing; the
         // client's next-page fetch shouldn't be broken by a corrupted query string.
-        var hasCursor = FeedCursor.TryParse(cursor, out var cursorCreatedAt, out var cursorId);
+        var hasCursor = KeysetCursor.TryParse(cursor, out var cursorCreatedAt, out var cursorId);
 
         var query = baseQuery;
         if (hasCursor)
@@ -108,7 +109,7 @@ public static class ClipsReadEndpoints
         var page = hasMore ? rows.GetRange(0, clampedLimit) : rows;
 
         var items = await ProjectFeedItemsAsync(page, principal, db, storage, s3, ct);
-        var nextCursor = hasMore ? FeedCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
+        var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
 
         return new ClipFeedResponse(items, nextCursor);
     }

--- a/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
@@ -133,9 +133,9 @@ public static class CommentsEndpoints
 
         var items = page.Select(c =>
         {
-            var replies = repliesByParent.GetValueOrDefault(c.Id) ?? [];
-            var preview = replies.Take(ReplyPreviewCount).Select(r => r.ToItem()).ToList();
-            return c.ToItem(replyCount: replies.Count, replies: preview);
+            var entry = repliesByParent.GetValueOrDefault(c.Id);
+            var preview = (entry.Preview ?? []).Select(r => r.ToItem()).ToList();
+            return c.ToItem(replyCount: entry.Count, replies: preview);
         }).ToList();
 
         var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
@@ -214,10 +214,11 @@ public static class CommentsEndpoints
         return Results.NoContent();
     }
 
-    // Loads all live replies for the given top-level comment ids in one query, grouped by parent.
-    // Ordered oldest-first so the inline preview shows the start of each thread; the full list is
-    // small enough to group in memory (parents are bounded by the page limit).
-    private static async Task<Dictionary<Guid, List<Comment>>> LoadRepliesForParentsAsync(
+    // For each top-level comment id, returns the total live-reply count plus the oldest few replies
+    // for the inline preview — never the full reply set, which is unbounded for a popular comment.
+    // Two targeted queries (a grouped count, and a top-N-per-parent slice) keep both bounded
+    // regardless of how many replies a thread has accumulated.
+    private static async Task<Dictionary<Guid, (int Count, List<Comment> Preview)>> LoadRepliesForParentsAsync(
         GankedTvDbContext db,
         IEnumerable<Guid> parentIds,
         CancellationToken ct)
@@ -228,15 +229,35 @@ public static class CommentsEndpoints
             return [];
         }
 
-        var replies = await db.Comments.AsNoTracking()
+        var counts = await db.Comments.AsNoTracking()
             .Where(r => r.ParentId != null && ids.Contains(r.ParentId.Value) && r.DeletedAt == null)
+            .GroupBy(r => r.ParentId!.Value)
+            .Select(g => new { ParentId = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+
+        // Top-N-per-parent: keep a reply only if its id is among the oldest ReplyPreviewCount for
+        // its parent. The correlated subquery translates to a per-parent lateral slice in Postgres,
+        // so we materialize at most ReplyPreviewCount rows per parent instead of every reply.
+        var previews = await db.Comments.AsNoTracking()
+            .Where(r => r.ParentId != null && ids.Contains(r.ParentId.Value) && r.DeletedAt == null)
+            .Where(r => db.Comments
+                .Where(x => x.ParentId == r.ParentId && x.DeletedAt == null)
+                .OrderBy(x => x.CreatedAt)
+                .ThenBy(x => x.Id)
+                .Select(x => x.Id)
+                .Take(ReplyPreviewCount)
+                .Contains(r.Id))
             .OrderBy(r => r.CreatedAt)
             .ThenBy(r => r.Id)
             .Include(r => r.User)
             .ToListAsync(ct);
 
-        return replies
+        var previewsByParent = previews
             .GroupBy(r => r.ParentId!.Value)
             .ToDictionary(g => g.Key, g => g.ToList());
+
+        return counts.ToDictionary(
+            c => c.ParentId,
+            c => (c.Count, previewsByParent.GetValueOrDefault(c.ParentId) ?? []));
     }
 }

--- a/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
@@ -1,0 +1,242 @@
+using System.Security.Claims;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Contracts.Comments;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Pagination;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Validation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class CommentsEndpoints
+{
+    private const int DefaultLimit = 20;
+    private const int MaxLimit = 100;
+    // How many replies ride inline on each top-level comment in the list response; the UI
+    // calls GET /comments/{id}/replies to page through the rest ("Show more replies").
+    private const int ReplyPreviewCount = 3;
+
+    public static IEndpointRouteBuilder MapCommentsEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/clips/{clipId:guid}/comments", ListComments);
+        app.MapGet("/comments/{id:guid}/replies", ListReplies);
+
+        app.MapPost("/clips/{clipId:guid}/comments", CreateComment)
+            .RequireAuthorization()
+            .RequireRateLimiting(ClipsRateLimiting.ClipsWritePolicy)
+            .WithValidation<CreateCommentRequest>();
+
+        app.MapDelete("/comments/{id:guid}", DeleteComment)
+            .RequireAuthorization()
+            .RequireRateLimiting(ClipsRateLimiting.ClipsWritePolicy);
+
+        return app;
+    }
+
+    private static async Task<IResult> CreateComment(
+        Guid clipId,
+        // Nullable so a literal JSON `null` body reaches WithValidation<T>, which shapes it into
+        // the same 400 envelope as a missing field rather than a framework-generated 400.
+        [FromBody] CreateCommentRequest? req,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        // Defensive: WithValidation<T> already 400s a null/empty/whitespace body before we get
+        // here ([Required] trims and rejects whitespace; [StringLength] caps at 2000).
+        if (req?.Body is null)
+        {
+            return ProblemResults.InvalidBody();
+        }
+
+        var body = req.Body.Trim();
+
+        if (!await db.Clips.AnyAsync(c => c.Id == clipId, ct))
+        {
+            return ProblemResults.NotFound("not_found");
+        }
+
+        if (req.ParentId is { } parentId)
+        {
+            // The parent must exist, belong to this same clip, and itself be top-level — threads
+            // are flat two-level (depth 0 → 1), so replying to a reply is rejected.
+            var parent = await db.Comments.AsNoTracking()
+                .Where(c => c.Id == parentId)
+                .Select(c => new { c.ClipId, c.ParentId })
+                .FirstOrDefaultAsync(ct);
+
+            if (parent is null || parent.ClipId != clipId || parent.ParentId is not null)
+            {
+                return ProblemResults.BadRequest("invalid_parent");
+            }
+        }
+
+        var comment = new Comment
+        {
+            ClipId = clipId,
+            UserId = userId,
+            ParentId = req.ParentId,
+            Body = body,
+        };
+        db.Comments.Add(comment);
+        await db.SaveChangesAsync(ct);
+
+        // Author is needed for the response shape; the authenticated user always exists.
+        comment.User = (await db.Users.FindAsync([userId], ct))!;
+
+        return Results.Json(comment.ToItem(), statusCode: StatusCodes.Status201Created);
+    }
+
+    private static async Task<IResult> ListComments(
+        Guid clipId,
+        string? cursor,
+        int? limit,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+        var hasCursor = KeysetCursor.TryParse(cursor, out var cursorCreatedAt, out var cursorId);
+
+        // Top-level only. A soft-deleted top-level comment is still shown if it has at least one
+        // live reply (so the thread doesn't collapse — rendered as `[deleted]`); a deleted
+        // comment with no live replies is dropped entirely.
+        var query = db.Comments.AsNoTracking()
+            .Where(c => c.ClipId == clipId && c.ParentId == null)
+            .Where(c => c.DeletedAt == null || c.Replies.Any(r => r.DeletedAt == null));
+
+        if (hasCursor)
+        {
+            query = query.Where(c =>
+                c.CreatedAt < cursorCreatedAt
+                || (c.CreatedAt == cursorCreatedAt && c.Id.CompareTo(cursorId) < 0));
+        }
+
+        var rows = await query
+            .OrderByDescending(c => c.CreatedAt)
+            .ThenByDescending(c => c.Id)
+            .Include(c => c.User)
+            .Take(clampedLimit + 1)
+            .ToListAsync(ct);
+
+        var hasMore = rows.Count > clampedLimit;
+        var page = hasMore ? rows.GetRange(0, clampedLimit) : rows;
+
+        var repliesByParent = await LoadRepliesForParentsAsync(db, page.Select(c => c.Id), ct);
+
+        var items = page.Select(c =>
+        {
+            var replies = repliesByParent.GetValueOrDefault(c.Id) ?? [];
+            var preview = replies.Take(ReplyPreviewCount).Select(r => r.ToItem()).ToList();
+            return c.ToItem(replyCount: replies.Count, replies: preview);
+        }).ToList();
+
+        var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
+        return Results.Ok(new CommentListResponse(items, nextCursor));
+    }
+
+    private static async Task<IResult> ListReplies(
+        Guid id,
+        string? cursor,
+        int? limit,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+        var hasCursor = KeysetCursor.TryParse(cursor, out var cursorCreatedAt, out var cursorId);
+
+        // Replies read oldest-first (chronological thread), so the cursor pages forward in
+        // ascending order — the opposite direction from the descending top-level feed.
+        var query = db.Comments.AsNoTracking()
+            .Where(c => c.ParentId == id && c.DeletedAt == null);
+
+        if (hasCursor)
+        {
+            query = query.Where(c =>
+                c.CreatedAt > cursorCreatedAt
+                || (c.CreatedAt == cursorCreatedAt && c.Id.CompareTo(cursorId) > 0));
+        }
+
+        var rows = await query
+            .OrderBy(c => c.CreatedAt)
+            .ThenBy(c => c.Id)
+            .Include(c => c.User)
+            .Take(clampedLimit + 1)
+            .ToListAsync(ct);
+
+        var hasMore = rows.Count > clampedLimit;
+        var page = hasMore ? rows.GetRange(0, clampedLimit) : rows;
+
+        var items = page.Select(c => c.ToItem()).ToList();
+        var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
+        return Results.Ok(new CommentListResponse(items, nextCursor));
+    }
+
+    private static async Task<IResult> DeleteComment(
+        Guid id,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        var comment = await db.Comments.FirstOrDefaultAsync(c => c.Id == id, ct);
+        if (comment is null)
+        {
+            return ProblemResults.NotFound("not_found");
+        }
+
+        if (comment.UserId != userId)
+        {
+            return ProblemResults.Forbidden("forbidden");
+        }
+
+        // Soft-delete: keep the row so replies stay anchored. Idempotent — deleting an
+        // already-deleted comment is a no-op that still returns 204.
+        if (comment.DeletedAt is null)
+        {
+            var now = DateTimeOffset.UtcNow;
+            comment.DeletedAt = now;
+            comment.UpdatedAt = now;
+            await db.SaveChangesAsync(ct);
+        }
+
+        return Results.NoContent();
+    }
+
+    // Loads all live replies for the given top-level comment ids in one query, grouped by parent.
+    // Ordered oldest-first so the inline preview shows the start of each thread; the full list is
+    // small enough to group in memory (parents are bounded by the page limit).
+    private static async Task<Dictionary<Guid, List<Comment>>> LoadRepliesForParentsAsync(
+        GankedTvDbContext db,
+        IEnumerable<Guid> parentIds,
+        CancellationToken ct)
+    {
+        var ids = parentIds as IReadOnlyCollection<Guid> ?? parentIds.ToList();
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        var replies = await db.Comments.AsNoTracking()
+            .Where(r => r.ParentId != null && ids.Contains(r.ParentId.Value) && r.DeletedAt == null)
+            .OrderBy(r => r.CreatedAt)
+            .ThenBy(r => r.Id)
+            .Include(r => r.User)
+            .ToListAsync(ct);
+
+        return replies
+            .GroupBy(r => r.ParentId!.Value)
+            .ToDictionary(g => g.Key, g => g.ToList());
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
@@ -1,3 +1,4 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Comments;
@@ -45,7 +46,7 @@ public static class CommentsEndpoints
         GankedTvDbContext db,
         CancellationToken ct)
     {
-        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        if (!TryGetUserId(principal, out var userId))
         {
             return ProblemResults.Unauthorized("unauthorized");
         }
@@ -134,8 +135,15 @@ public static class CommentsEndpoints
         var items = page.Select(c =>
         {
             var entry = repliesByParent.GetValueOrDefault(c.Id);
-            var preview = (entry.Preview ?? []).Select(r => r.ToItem()).ToList();
-            return c.ToItem(replyCount: entry.Count, replies: preview);
+            var previewRows = entry.Preview ?? [];
+            var preview = previewRows.Select(r => r.ToItem()).ToList();
+            // When the thread has more replies than fit in the inline preview, hand back a
+            // cursor anchored on the last preview row. The web client seeds its per-thread
+            // cursor from this so "show more replies" doesn't re-fetch the preview rows.
+            var repliesNextCursor = entry.Count > previewRows.Count && previewRows.Count > 0
+                ? KeysetCursor.Build(previewRows[^1].CreatedAt, previewRows[^1].Id)
+                : null;
+            return c.ToItem(replyCount: entry.Count, replies: preview, repliesNextCursor: repliesNextCursor);
         }).ToList();
 
         var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
@@ -185,7 +193,7 @@ public static class CommentsEndpoints
         GankedTvDbContext db,
         CancellationToken ct)
     {
-        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        if (!TryGetUserId(principal, out var userId))
         {
             return ProblemResults.Unauthorized("unauthorized");
         }
@@ -259,5 +267,16 @@ public static class CommentsEndpoints
         return counts.ToDictionary(
             c => c.ParentId,
             c => (c.Count, previewsByParent.GetValueOrDefault(c.ParentId) ?? []));
+    }
+
+    // Mirrors the local helper in every other endpoint module (ClipsRead/Mutate, Likes, Auth, Me).
+    // Lifting this into a shared auth helper is a worthwhile follow-up across all callers, but
+    // this PR keeps the change scoped — comments no longer reach across to ClipsReadEndpoints.
+    private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
+    {
+        userId = default;
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out userId);
     }
 }

--- a/server/src/GankedTV.Api/Endpoints/FollowsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/FollowsEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using GankedTV.Api.Contracts.Users;
 using GankedTV.Api.Data;
+using GankedTV.Api.Pagination;
 using GankedTV.Api.Problems;
 using Microsoft.EntityFrameworkCore;
 
@@ -97,7 +98,7 @@ public static class FollowsEndpoints
         if (target is null) return ProblemResults.NotFound("not_found");
 
         var clampedLimit = Math.Clamp(limit ?? FollowListDefaultLimit, 1, FollowListMaxLimit);
-        var hasCursor = FeedCursor.TryParse(cursor, out var cAt, out var cId);
+        var hasCursor = KeysetCursor.TryParse(cursor, out var cAt, out var cId);
 
         // Followers of target: rows where FolloweeId == target.Id; pagination keyset is
         // (CreatedAt, FollowerId) — the "other side" of the row, matching what the
@@ -120,7 +121,7 @@ public static class FollowsEndpoints
         var items = page
             .Select(f => new UserSummary(f.Follower.Id, f.Follower.Username, f.Follower.AvatarUrl))
             .ToList();
-        var nextCursor = hasMore ? FeedCursor.Build(page[^1].CreatedAt, page[^1].FollowerId) : null;
+        var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].FollowerId) : null;
 
         return Results.Ok(new UserSummaryPage(items, nextCursor));
     }
@@ -133,7 +134,7 @@ public static class FollowsEndpoints
         if (target is null) return ProblemResults.NotFound("not_found");
 
         var clampedLimit = Math.Clamp(limit ?? FollowListDefaultLimit, 1, FollowListMaxLimit);
-        var hasCursor = FeedCursor.TryParse(cursor, out var cAt, out var cId);
+        var hasCursor = KeysetCursor.TryParse(cursor, out var cAt, out var cId);
 
         var query = db.Follows.AsNoTracking().Where(f => f.FollowerId == target.Id);
         if (hasCursor)
@@ -153,7 +154,7 @@ public static class FollowsEndpoints
         var items = page
             .Select(f => new UserSummary(f.Followee.Id, f.Followee.Username, f.Followee.AvatarUrl))
             .ToList();
-        var nextCursor = hasMore ? FeedCursor.Build(page[^1].CreatedAt, page[^1].FolloweeId) : null;
+        var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].FolloweeId) : null;
 
         return Results.Ok(new UserSummaryPage(items, nextCursor));
     }

--- a/server/src/GankedTV.Api/Pagination/KeysetCursor.cs
+++ b/server/src/GankedTV.Api/Pagination/KeysetCursor.cs
@@ -2,22 +2,33 @@ using System.Buffers.Text;
 using System.Globalization;
 using System.Text;
 
-namespace GankedTV.Api.Endpoints;
+namespace GankedTV.Api.Pagination;
 
-// Shared keyset-cursor helper used by every cursor-paginated list that orders by
-// (CreatedAt desc, Guid desc). Base64Url so the raw token survives a query string
-// without client-side escaping — DateTimeOffset.ToString("O") includes `+` and `:`
-// which URL decoders mangle.
-internal static class FeedCursor
+/// <summary>
+/// Encodes/decodes a composite <c>(CreatedAt, Id)</c> keyset cursor as an opaque, URL-safe
+/// token. The <c>(CreatedAt, Id)</c> pair (rather than <c>CreatedAt</c> alone) keeps paging
+/// deterministic when two rows share the same <c>created_at</c> — bulk imports, seed scripts,
+/// or same-microsecond inserts would otherwise skip the second row.
+/// </summary>
+public static class KeysetCursor
 {
     private const char Separator = '_';
 
+    /// <summary>
+    /// Builds a Base64Url-encoded cursor token. Base64Url keeps the token safe to drop into a
+    /// query string without client-side escaping: <c>DateTimeOffset.ToString("O")</c> contains
+    /// <c>+</c> (which decoders turn into a space) and <c>:</c>, so encoding keeps it opaque.
+    /// </summary>
     public static string Build(DateTimeOffset createdAt, Guid id)
     {
         var payload = $"{createdAt.ToString("O", CultureInfo.InvariantCulture)}{Separator}{id:D}";
         return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
     }
 
+    /// <summary>
+    /// Parses a cursor token. Returns <c>false</c> for null/empty/corrupt input so callers can
+    /// silently fall back to "no cursor" rather than 400-ing on a malformed query string.
+    /// </summary>
     public static bool TryParse(string? raw, out DateTimeOffset createdAt, out Guid id)
     {
         createdAt = default;

--- a/server/src/GankedTV.Api/Pagination/KeysetCursor.cs
+++ b/server/src/GankedTV.Api/Pagination/KeysetCursor.cs
@@ -40,8 +40,10 @@ public static class KeysetCursor
         {
             bytes = Base64Url.DecodeFromChars(raw);
         }
-        catch (FormatException)
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
         {
+            // FormatException covers invalid Base64Url; ArgumentException covers overflow paths
+            // some runtimes can surface. Either way, treat a corrupt cursor as "no cursor".
             return false;
         }
 

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -371,6 +371,7 @@ app.MapClipsUploadEndpoints();
 app.MapClipsReadEndpoints();
 app.MapClipsMutateEndpoints();
 app.MapLikesEndpoints();
+app.MapCommentsEndpoints();
 app.MapUsersEndpoints();
 app.MapFollowsEndpoints();
 app.MapGamesEndpoints();

--- a/server/src/GankedTV.Api/Validation/CommentValidationLimits.cs
+++ b/server/src/GankedTV.Api/Validation/CommentValidationLimits.cs
@@ -1,0 +1,11 @@
+namespace GankedTV.Api.Validation;
+
+/// <summary>
+/// Compile-time limits for comment bodies, for use in
+/// <c>System.ComponentModel.DataAnnotations</c> attributes (which require constant args).
+/// Mirrors the <c>body VARCHAR(2000)</c> column.
+/// </summary>
+public static class CommentValidationLimits
+{
+    public const int MaxBodyLength = 2000;
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
@@ -175,6 +175,7 @@ public class CommentsEndpointsTests : IAsyncLifetime
         var clipId = await SeedClipAsync(userId);
         using var client = ClientWithBearer(token);
 
+        var before = DateTimeOffset.UtcNow;
         var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "  first!  " });
 
         resp.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -184,6 +185,11 @@ public class CommentsEndpointsTests : IAsyncLifetime
         item.GetProperty("replyCount").GetInt32().Should().Be(0);
         item.GetProperty("deleted").GetBoolean().Should().BeFalse();
         item.GetProperty("author").GetProperty("username").GetString().Should().Be("author");
+        // Lock down that the response carries a DB-generated createdAt (not the default value)
+        // — easy to regress if HasDefaultValueSql wiring is ever changed.
+        var createdAt = item.GetProperty("createdAt").GetDateTimeOffset();
+        createdAt.Should().BeOnOrAfter(before.AddSeconds(-1));
+        createdAt.Should().BeOnOrBefore(DateTimeOffset.UtcNow.AddSeconds(1));
     }
 
     [Fact]
@@ -294,6 +300,34 @@ public class CommentsEndpointsTests : IAsyncLifetime
         first.GetProperty("replies").GetArrayLength().Should().Be(3);
         // Inline preview is oldest-first.
         first.GetProperty("replies")[0].GetProperty("body").GetString().Should().Be("r0");
+        // With more replies than fit in the preview, the response carries a cursor that pages
+        // forward from the last preview row — letting the UI fetch r3 without re-fetching r0..r2.
+        var nextCursor = first.GetProperty("repliesNextCursor").GetString();
+        nextCursor.Should().NotBeNullOrEmpty();
+        var nextPage = await (await client.GetAsync($"/comments/{top}/replies?cursor={nextCursor}"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        nextPage.GetProperty("items").GetArrayLength().Should().Be(1);
+        nextPage.GetProperty("items")[0].GetProperty("body").GetString().Should().Be("r3");
+    }
+
+    [Fact]
+    public async Task List_RepliesFitInPreview_RepliesNextCursorIsNull()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var baseTime = DateTimeOffset.UtcNow;
+        var top = await SeedCommentAsync(clipId, userId, "top", createdAt: baseTime);
+        // 2 replies fit in the preview (cap 3) — the response should not surface a "more" cursor.
+        for (var i = 0; i < 2; i++)
+            await SeedCommentAsync(clipId, userId, $"r{i}", parentId: top, createdAt: baseTime.AddSeconds(i + 1));
+        using var client = _factory!.CreateClient();
+
+        var body = await (await client.GetAsync($"/clips/{clipId}/comments"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var first = body.GetProperty("items")[0];
+        first.GetProperty("replyCount").GetInt32().Should().Be(2);
+        first.GetProperty("repliesNextCursor").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
     [Fact]
@@ -353,6 +387,31 @@ public class CommentsEndpointsTests : IAsyncLifetime
         secondPage.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
+    [Fact]
+    public async Task List_LimitOutOfRange_IsClamped()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var baseTime = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 3; i++)
+            await SeedCommentAsync(clipId, userId, $"c{i}", createdAt: baseTime.AddSeconds(i));
+        using var client = _factory!.CreateClient();
+
+        // limit=0 clamps up to the minimum (1) — the endpoint shouldn't 400 on degenerate input.
+        var low = await (await client.GetAsync($"/clips/{clipId}/comments?limit=0"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        low.GetProperty("items").GetArrayLength().Should().Be(1);
+        low.GetProperty("nextCursor").GetString().Should().NotBeNullOrEmpty();
+
+        // limit=10000 clamps down to MaxLimit (100); seeded data is well under that, so we expect
+        // the endpoint to accept the request and return everything without paging.
+        var high = await (await client.GetAsync($"/clips/{clipId}/comments?limit=10000"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        high.GetProperty("items").GetArrayLength().Should().Be(3);
+        high.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
     // ---- GET /comments/{id}/replies ----
 
     [Fact]
@@ -380,6 +439,29 @@ public class CommentsEndpointsTests : IAsyncLifetime
             .Content.ReadFromJsonAsync<JsonElement>();
         secondPage.GetProperty("items").GetArrayLength().Should().Be(1); // r2 only; dead excluded
         secondPage.GetProperty("items")[0].GetProperty("body").GetString().Should().Be("r2");
+    }
+
+    [Fact]
+    public async Task ListReplies_LimitOutOfRange_IsClamped()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var top = await SeedCommentAsync(clipId, userId, "top");
+        var baseTime = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 3; i++)
+            await SeedCommentAsync(clipId, userId, $"r{i}", parentId: top, createdAt: baseTime.AddSeconds(i));
+        using var client = _factory!.CreateClient();
+
+        var low = await (await client.GetAsync($"/comments/{top}/replies?limit=0"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        low.GetProperty("items").GetArrayLength().Should().Be(1);
+        low.GetProperty("nextCursor").GetString().Should().NotBeNullOrEmpty();
+
+        var high = await (await client.GetAsync($"/comments/{top}/replies?limit=10000"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        high.GetProperty("items").GetArrayLength().Should().Be(3);
+        high.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
     // ---- DELETE /comments/{id} ----

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
@@ -6,6 +6,7 @@ using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
+using GankedTV.Api.Validation;
 using NSubstitute;
 
 namespace GankedTV.Api.Tests.Integration.Endpoints;
@@ -134,6 +135,34 @@ public class CommentsEndpointsTests : IAsyncLifetime
         // [Required] trims before validating, so a whitespace-only body is rejected as a
         // validation problem (400) the same as an empty one.
         var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "   " });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Create_MaxBodyLength_Returns201()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        var body = new string('x', CommentValidationLimits.MaxBodyLength);
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Create_ExceedsMaxBodyLength_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        var body = new string('x', CommentValidationLimits.MaxBodyLength + 1);
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body });
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
@@ -1,0 +1,427 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class CommentsEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public CommentsEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "owner") =>
+        AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+
+    private HttpClient ClientWithBearer(string token) =>
+        AuthTestHelpers.CreateBearerClient(_factory!, token);
+
+    private async Task<Guid> SeedClipAsync(Guid userId)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = "seed",
+            VideoKey = $"clips/{userId}/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = ShareCodeGenerator.Next(),
+            Status = "ready",
+            Visibility = "public",
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    private async Task<Guid> SeedCommentAsync(
+        Guid clipId,
+        Guid userId,
+        string body = "hello",
+        Guid? parentId = null,
+        DateTimeOffset? createdAt = null,
+        DateTimeOffset? deletedAt = null)
+    {
+        var id = Guid.NewGuid();
+        var seeded = createdAt ?? DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Comments.Add(new Comment
+        {
+            Id = id,
+            ClipId = clipId,
+            UserId = userId,
+            ParentId = parentId,
+            Body = body,
+            CreatedAt = seeded,
+            UpdatedAt = seeded,
+            DeletedAt = deletedAt,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    // ---- POST /clips/{id}/comments ----
+
+    [Fact]
+    public async Task Create_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync($"/clips/{Guid.NewGuid()}/comments", new { body = "hi" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Create_ClipMissing_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync($"/clips/{Guid.NewGuid()}/comments", new { body = "hi" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_EmptyBody_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Create_WhitespaceBody_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        // [Required] trims before validating, so a whitespace-only body is rejected as a
+        // validation problem (400) the same as an empty one.
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "   " });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Create_TopLevel_Returns201WithItem()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync("author");
+        var clipId = await SeedClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "  first!  " });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var item = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        item.GetProperty("body").GetString().Should().Be("first!"); // trimmed
+        item.GetProperty("parentId").ValueKind.Should().Be(JsonValueKind.Null);
+        item.GetProperty("replyCount").GetInt32().Should().Be(0);
+        item.GetProperty("deleted").GetBoolean().Should().BeFalse();
+        item.GetProperty("author").GetProperty("username").GetString().Should().Be("author");
+    }
+
+    [Fact]
+    public async Task Create_Reply_Returns201()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var parentId = await SeedCommentAsync(clipId, userId, "top");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync(
+            $"/clips/{clipId}/comments", new { body = "reply", parentId });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var item = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        item.GetProperty("parentId").GetGuid().Should().Be(parentId);
+    }
+
+    [Fact]
+    public async Task Create_ReplyToReply_Returns400InvalidParent()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var topId = await SeedCommentAsync(clipId, userId, "top");
+        var replyId = await SeedCommentAsync(clipId, userId, "reply", parentId: topId);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync(
+            $"/clips/{clipId}/comments", new { body = "nested", parentId = replyId });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_parent");
+    }
+
+    [Fact]
+    public async Task Create_ParentFromDifferentClip_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipA = await SeedClipAsync(userId);
+        var clipB = await SeedClipAsync(userId);
+        var parentOnB = await SeedCommentAsync(clipB, userId, "on B");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync(
+            $"/clips/{clipA}/comments", new { body = "x", parentId = parentOnB });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_parent");
+    }
+
+    [Fact]
+    public async Task Create_ParentMissing_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync(
+            $"/clips/{clipId}/comments", new { body = "x", parentId = Guid.NewGuid() });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ---- GET /clips/{id}/comments ----
+
+    [Fact]
+    public async Task List_Empty_Returns200WithNoItems()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync($"/clips/{clipId}/comments");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task List_ReturnsTopLevelWithInlineRepliesAndCount()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var baseTime = DateTimeOffset.UtcNow;
+        var top = await SeedCommentAsync(clipId, userId, "top", createdAt: baseTime);
+        // 4 replies — preview caps at 3 but replyCount reflects all live replies.
+        for (var i = 0; i < 4; i++)
+            await SeedCommentAsync(clipId, userId, $"r{i}", parentId: top, createdAt: baseTime.AddSeconds(i + 1));
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync($"/clips/{clipId}/comments");
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        var first = items[0];
+        first.GetProperty("replyCount").GetInt32().Should().Be(4);
+        first.GetProperty("replies").GetArrayLength().Should().Be(3);
+        // Inline preview is oldest-first.
+        first.GetProperty("replies")[0].GetProperty("body").GetString().Should().Be("r0");
+    }
+
+    [Fact]
+    public async Task List_SoftDeletedTopLevelWithReplies_StillAppearsAsDeleted()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var top = await SeedCommentAsync(clipId, userId, "secret", deletedAt: DateTimeOffset.UtcNow);
+        await SeedCommentAsync(clipId, userId, "reply", parentId: top);
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync($"/clips/{clipId}/comments");
+
+        var items = (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("deleted").GetBoolean().Should().BeTrue();
+        items[0].GetProperty("body").ValueKind.Should().Be(JsonValueKind.Null);
+        items[0].GetProperty("replyCount").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task List_SoftDeletedTopLevelWithoutReplies_Excluded()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        await SeedCommentAsync(clipId, userId, "gone", deletedAt: DateTimeOffset.UtcNow);
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync($"/clips/{clipId}/comments");
+
+        var items = (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("items");
+        items.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task List_Paginates_WithCursor()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var baseTime = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 3; i++)
+            await SeedCommentAsync(clipId, userId, $"c{i}", createdAt: baseTime.AddSeconds(i));
+        using var client = _factory!.CreateClient();
+
+        var firstPage = await (await client.GetAsync($"/clips/{clipId}/comments?limit=2"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        firstPage.GetProperty("items").GetArrayLength().Should().Be(2);
+        var cursor = firstPage.GetProperty("nextCursor").GetString();
+        cursor.Should().NotBeNullOrEmpty();
+
+        var secondPage = await (await client.GetAsync($"/clips/{clipId}/comments?limit=2&cursor={cursor}"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        secondPage.GetProperty("items").GetArrayLength().Should().Be(1);
+        secondPage.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    // ---- GET /comments/{id}/replies ----
+
+    [Fact]
+    public async Task ListReplies_ReturnsRepliesOldestFirst_AndPaginates()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var top = await SeedCommentAsync(clipId, userId, "top");
+        var baseTime = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 3; i++)
+            await SeedCommentAsync(clipId, userId, $"r{i}", parentId: top, createdAt: baseTime.AddSeconds(i));
+        // A deleted reply must be filtered out.
+        await SeedCommentAsync(clipId, userId, "dead", parentId: top,
+            createdAt: baseTime.AddSeconds(10), deletedAt: DateTimeOffset.UtcNow);
+        using var client = _factory!.CreateClient();
+
+        var firstPage = await (await client.GetAsync($"/comments/{top}/replies?limit=2"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        firstPage.GetProperty("items").GetArrayLength().Should().Be(2);
+        firstPage.GetProperty("items")[0].GetProperty("body").GetString().Should().Be("r0");
+        var cursor = firstPage.GetProperty("nextCursor").GetString();
+
+        var secondPage = await (await client.GetAsync($"/comments/{top}/replies?limit=2&cursor={cursor}"))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        secondPage.GetProperty("items").GetArrayLength().Should().Be(1); // r2 only; dead excluded
+        secondPage.GetProperty("items")[0].GetProperty("body").GetString().Should().Be("r2");
+    }
+
+    // ---- DELETE /comments/{id} ----
+
+    [Fact]
+    public async Task Delete_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.DeleteAsync($"/comments/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Delete_Missing_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.DeleteAsync($"/comments/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_NonAuthor_Returns403()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, _) = await SeedUserAndIssueTokenAsync("owner");
+        var (_, otherToken) = await SeedUserAndIssueTokenAsync("other");
+        var clipId = await SeedClipAsync(ownerId);
+        var commentId = await SeedCommentAsync(clipId, ownerId, "mine");
+        using var client = ClientWithBearer(otherToken);
+
+        var resp = await client.DeleteAsync($"/comments/{commentId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Delete_Author_Returns204_AndSoftDeletes()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var commentId = await SeedCommentAsync(clipId, userId, "bye");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.DeleteAsync($"/comments/{commentId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await using var db = _fx.CreateContext();
+        var row = await db.Comments.FindAsync(commentId);
+        row!.DeletedAt.Should().NotBeNull();
+        row.Body.Should().Be("bye"); // body retained in DB; nulled only in the API shape
+    }
+
+    [Fact]
+    public async Task Delete_AlreadyDeleted_IsIdempotent()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId);
+        var commentId = await SeedCommentAsync(clipId, userId, "bye", deletedAt: DateTimeOffset.UtcNow);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.DeleteAsync($"/comments/{commentId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/FollowsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/FollowsEndpointsTests.cs
@@ -257,7 +257,7 @@ public class FollowsEndpointsTests : IAsyncLifetime
     {
         // Mirrors the clip feed's forgive-and-fall-back stance: a corrupted cursor
         // (truncated, wrong base64, mangled by a client) returns the first page rather
-        // than 400-ing the pagination flow. FeedCursor.TryParse handles the parse;
+        // than 400-ing the pagination flow. KeysetCursor.TryParse handles the parse;
         // this exercises the wiring through the endpoint.
         await _fx.ResetAsync();
         var (targetId, _) = await SeedUserAndIssueTokenAsync("target");

--- a/web/src/api/__tests__/comments.spec.ts
+++ b/web/src/api/__tests__/comments.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { comments } from '../comments'
+import { configureAuth, BASE_URL } from '../client'
+
+beforeEach(() => {
+  configureAuth({
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    onTokenRefreshed: () => {},
+    onRefreshFailed: () => {},
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+const CLIP_ID = 'a4f1e2c0-0000-0000-0000-000000000001'
+const COMMENT_ID = 'b5f2e3d1-0000-0000-0000-000000000002'
+
+describe('api/comments', () => {
+  describe('list()', () => {
+    it('GETs /clips/{id}/comments without params when no query is supplied', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      const result = await comments.list(CLIP_ID)
+
+      expect(result).toEqual({ items: [], nextCursor: null })
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/clips/${CLIP_ID}/comments`)
+    })
+
+    it('encodes cursor and limit into the query string', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await comments.list(CLIP_ID, { cursor: 'abc=', limit: 5 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('cursor=abc%3D')
+      expect(url).toContain('limit=5')
+      expect(url.startsWith(`${BASE_URL}/clips/${CLIP_ID}/comments?`)).toBe(true)
+    })
+
+    it('URI-encodes the clip id path segment', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await comments.list('weird id/with?chars')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/clips/${encodeURIComponent('weird id/with?chars')}/comments`)
+    })
+  })
+
+  describe('listReplies()', () => {
+    it('GETs /comments/{id}/replies and forwards the cursor', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await comments.listReplies(COMMENT_ID, { cursor: 'cur1' })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/comments/${COMMENT_ID}/replies?cursor=cur1`)
+    })
+  })
+
+  describe('create()', () => {
+    it('POSTs a top-level comment body and returns the created item', async () => {
+      const created = {
+        id: 'new-id',
+        body: 'first!',
+        author: { id: 'u', username: 'zoe', avatarUrl: null },
+        parentId: null,
+        createdAt: '2026-05-22T12:00:00Z',
+        replyCount: 0,
+        replies: [],
+        deleted: false,
+      }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(created, 201)),
+      )
+
+      const result = await comments.create(CLIP_ID, { body: 'first!' })
+
+      expect(result).toEqual(created)
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips/${CLIP_ID}/comments`)
+      expect(init.method).toBe('POST')
+      expect(new Headers(init.headers).get('Content-Type')).toBe('application/json')
+      expect(JSON.parse(String(init.body))).toEqual({ body: 'first!' })
+    })
+
+    it('includes parentId when replying', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({}, 201)),
+      )
+
+      await comments.create(CLIP_ID, { body: 'nice', parentId: COMMENT_ID })
+
+      const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(JSON.parse(String(init.body))).toEqual({ body: 'nice', parentId: COMMENT_ID })
+    })
+
+    it('sends the bearer token when one is configured', async () => {
+      configureAuth({
+        getAccessToken: () => 'tok-xyz',
+        getRefreshToken: () => null,
+        onTokenRefreshed: () => {},
+        onRefreshFailed: () => {},
+      })
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({}, 201)),
+      )
+
+      await comments.create(CLIP_ID, { body: 'hi' })
+
+      const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(new Headers(init.headers).get('Authorization')).toBe('Bearer tok-xyz')
+    })
+
+    it('throws ApiError on non-2xx with the response body', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ code: 'invalid_parent' }, 400)),
+      )
+
+      await expect(comments.create(CLIP_ID, { body: 'x', parentId: 'p' })).rejects.toMatchObject({
+        status: 400,
+        body: { code: 'invalid_parent' },
+      })
+    })
+  })
+
+  describe('delete()', () => {
+    it('DELETEs /comments/{id} and resolves to undefined on 204', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      )
+
+      const result = await comments.delete(COMMENT_ID)
+
+      expect(result).toBeUndefined()
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/comments/${COMMENT_ID}`)
+      expect(init.method).toBe('DELETE')
+    })
+
+    it('throws ApiError on 403 with the response body', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ code: 'forbidden' }, 403)),
+      )
+
+      await expect(comments.delete(COMMENT_ID)).rejects.toMatchObject({
+        status: 403,
+        body: { code: 'forbidden' },
+      })
+    })
+  })
+})

--- a/web/src/api/comments.ts
+++ b/web/src/api/comments.ts
@@ -13,6 +13,10 @@ export interface CommentItem {
   replyCount: number
   // First page of inline replies on a top-level comment (oldest-first; empty for replies).
   replies: CommentItem[]
+  // Cursor to fetch the next page of replies (oldest-first) when more exist beyond the
+  // inline preview; null when the preview is exhaustive. Lets the UI page from after the
+  // preview instead of re-fetching it.
+  repliesNextCursor: string | null
   deleted: boolean
 }
 

--- a/web/src/api/comments.ts
+++ b/web/src/api/comments.ts
@@ -1,0 +1,65 @@
+import { api } from './client'
+import type { AuthorSummary } from './clips'
+
+export interface CommentItem {
+  id: string
+  // null when the comment is soft-deleted — render a `[deleted]` placeholder.
+  body: string | null
+  author: AuthorSummary
+  // null for a top-level comment; set to the top-level comment id for a reply.
+  parentId: string | null
+  createdAt: string
+  // Total live replies on a top-level comment (0 for replies themselves).
+  replyCount: number
+  // First page of inline replies on a top-level comment (oldest-first; empty for replies).
+  replies: CommentItem[]
+  deleted: boolean
+}
+
+export interface CommentListResponse {
+  items: CommentItem[]
+  nextCursor: string | null
+}
+
+export interface CommentListQuery {
+  cursor?: string | null
+  limit?: number
+}
+
+export interface CreateCommentBody {
+  body: string
+  parentId?: string | null
+}
+
+function buildQuery(query: CommentListQuery): string {
+  const params = new URLSearchParams()
+  if (query.cursor) params.set('cursor', query.cursor)
+  if (query.limit !== undefined) params.set('limit', String(query.limit))
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export const comments = {
+  list(clipId: string, query: CommentListQuery = {}): Promise<CommentListResponse> {
+    return api<CommentListResponse>(
+      `/clips/${encodeURIComponent(clipId)}/comments${buildQuery(query)}`,
+    )
+  },
+
+  listReplies(commentId: string, query: CommentListQuery = {}): Promise<CommentListResponse> {
+    return api<CommentListResponse>(
+      `/comments/${encodeURIComponent(commentId)}/replies${buildQuery(query)}`,
+    )
+  },
+
+  create(clipId: string, body: CreateCommentBody): Promise<CommentItem> {
+    return api<CommentItem>(`/clips/${encodeURIComponent(clipId)}/comments`, {
+      method: 'POST',
+      body,
+    })
+  },
+
+  delete(commentId: string): Promise<void> {
+    return api<void>(`/comments/${encodeURIComponent(commentId)}`, { method: 'DELETE' })
+  },
+}

--- a/web/src/components/CommentItem.vue
+++ b/web/src/components/CommentItem.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { CommentItem } from '@/api/comments'
+import { formatRelativeTime } from '@/lib/format'
+import UserAvatar from '@/components/UserAvatar.vue'
+
+const props = defineProps<{
+  comment: CommentItem
+  currentUserId: string | null
+  // Top-level rows expose a Reply affordance; replies (one level deep) do not.
+  canReply: boolean
+}>()
+
+const emit = defineEmits<{
+  delete: [id: string]
+  reply: [id: string]
+}>()
+
+const isOwn = computed(
+  () => !props.comment.deleted && props.currentUserId === props.comment.author.id,
+)
+</script>
+
+<template>
+  <div class="flex gap-3">
+    <UserAvatar :user="comment.author" :size="32" class="mt-0.5" />
+    <div class="min-w-0 flex-1">
+      <div class="flex items-baseline gap-2">
+        <span class="font-mono text-[13px] font-semibold text-text-primary">{{
+          comment.author.username
+        }}</span>
+        <span class="font-mono text-[11px] text-text-muted">{{
+          formatRelativeTime(comment.createdAt)
+        }}</span>
+      </div>
+
+      <p
+        v-if="comment.deleted"
+        class="mt-0.5 font-body text-sm italic leading-relaxed text-text-muted"
+      >
+        [deleted]
+      </p>
+      <p
+        v-else
+        class="mt-0.5 whitespace-pre-wrap break-words font-body text-sm leading-relaxed text-text-secondary"
+      >
+        {{ comment.body }}
+      </p>
+
+      <div class="mt-1 flex items-center gap-3">
+        <button
+          v-if="canReply"
+          type="button"
+          class="cursor-pointer font-mono text-[11px] uppercase tracking-wider text-text-muted transition-colors duration-150 hover:text-text-primary"
+          @click="emit('reply', comment.id)"
+        >
+          Reply
+        </button>
+        <button
+          v-if="isOwn"
+          type="button"
+          class="cursor-pointer font-mono text-[11px] uppercase tracking-wider text-text-muted transition-colors duration-150 hover:text-[color:var(--color-error)]"
+          @click="emit('delete', comment.id)"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/CommentsSection.vue
+++ b/web/src/components/CommentsSection.vue
@@ -53,10 +53,12 @@ async function load() {
   errored.value = false
   threads.value = []
   nextCursor.value = null
+  replyCursors.value = {}
   try {
     const page = await comments.list(props.clipId)
     threads.value = page.items
     nextCursor.value = page.nextCursor
+    seedReplyCursors(page.items)
   } catch {
     errored.value = true
   } finally {
@@ -71,6 +73,7 @@ async function loadMore() {
     const page = await comments.list(props.clipId, { cursor: nextCursor.value })
     threads.value.push(...page.items)
     nextCursor.value = page.nextCursor
+    seedReplyCursors(page.items)
   } catch {
     actionError.value = 'Could not load more comments — try again.'
   } finally {
@@ -82,6 +85,35 @@ function goLogin() {
   router.push({ name: 'login', query: { redirect: route.fullPath } })
 }
 
+// `crypto.randomUUID` keeps temp ids unique even on rapid double-submits (the previous
+// `temp-${Date.now()}` collides at millisecond granularity).
+function buildOptimistic(body: string, parentId: string | null): CommentItem {
+  // postComment / postReply both gate on `auth.user` before calling this, so `auth.user!`
+  // is safe here.
+  const user = auth.user!
+  return {
+    id: `temp-${crypto.randomUUID()}`,
+    body,
+    author: { id: user.id, username: user.username, avatarUrl: user.avatarUrl },
+    parentId,
+    createdAt: new Date().toISOString(),
+    replyCount: 0,
+    replies: [],
+    repliesNextCursor: null,
+    deleted: false,
+  }
+}
+
+// Seed the per-thread "show more replies" cursor from each thread's inline preview so the
+// first click pages forward instead of re-fetching the preview rows the server already sent.
+function seedReplyCursors(threadsToSeed: CommentItem[]) {
+  for (const thread of threadsToSeed) {
+    if (thread.repliesNextCursor) {
+      replyCursors.value[thread.id] = thread.repliesNextCursor
+    }
+  }
+}
+
 async function postComment() {
   const body = newBody.value.trim()
   if (!body || posting.value || !auth.user) return
@@ -89,26 +121,16 @@ async function postComment() {
   posting.value = true
   actionError.value = ''
   // Optimistic: show the comment immediately under a temp id, reconcile on response.
-  const tempId = `temp-${Date.now()}`
-  const optimistic: CommentItem = {
-    id: tempId,
-    body,
-    author: { id: auth.user.id, username: auth.user.username, avatarUrl: auth.user.avatarUrl },
-    parentId: null,
-    createdAt: new Date().toISOString(),
-    replyCount: 0,
-    replies: [],
-    deleted: false,
-  }
+  const optimistic = buildOptimistic(body, null)
   threads.value.unshift(optimistic)
   newBody.value = ''
 
   try {
     const created = await comments.create(props.clipId, { body })
-    const idx = threads.value.findIndex((c) => c.id === tempId)
+    const idx = threads.value.findIndex((c) => c.id === optimistic.id)
     if (idx !== -1) threads.value[idx] = created
   } catch {
-    threads.value = threads.value.filter((c) => c.id !== tempId)
+    threads.value = threads.value.filter((c) => c.id !== optimistic.id)
     newBody.value = body
     actionError.value = 'Could not post your comment — try again.'
   } finally {
@@ -124,20 +146,31 @@ function toggleReply(commentId: string) {
 
 async function postReply(parentId: string) {
   const body = replyBody.value.trim()
-  if (!body || replyPosting.value) return
+  if (!body || replyPosting.value || !auth.user) return
+
+  const thread = threads.value.find((c) => c.id === parentId)
+  if (!thread) return
 
   replyPosting.value = true
   actionError.value = ''
+  // Optimistic: render the reply immediately and reconcile on response, matching postComment.
+  const optimistic = buildOptimistic(body, parentId)
+  thread.replies.push(optimistic)
+  thread.replyCount += 1
+  replyingTo.value = null
+  replyBody.value = ''
+
   try {
     const created = await comments.create(props.clipId, { body, parentId })
-    const thread = threads.value.find((c) => c.id === parentId)
-    if (thread) {
-      thread.replies.push(created)
-      thread.replyCount += 1
-    }
-    replyingTo.value = null
-    replyBody.value = ''
+    const idx = thread.replies.findIndex((r) => r.id === optimistic.id)
+    if (idx !== -1) thread.replies[idx] = created
   } catch {
+    const idx = thread.replies.findIndex((r) => r.id === optimistic.id)
+    if (idx !== -1) thread.replies.splice(idx, 1)
+    thread.replyCount = Math.max(0, thread.replyCount - 1)
+    // Reopen the composer with the failed body so the user can retry without retyping.
+    replyingTo.value = parentId
+    replyBody.value = body
     actionError.value = 'Could not post your reply — try again.'
   } finally {
     replyPosting.value = false
@@ -221,6 +254,7 @@ function markDeleted(id: string) {
           rows="2"
           maxlength="2000"
           placeholder="Add a comment…"
+          aria-label="Add a comment"
           :class="inputClass"
           class="resize-y"
         />
@@ -278,6 +312,7 @@ function markDeleted(id: string) {
             rows="2"
             maxlength="2000"
             placeholder="Write a reply…"
+            aria-label="Write a reply"
             :class="inputClass"
             class="resize-y"
           />

--- a/web/src/components/CommentsSection.vue
+++ b/web/src/components/CommentsSection.vue
@@ -1,0 +1,340 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ApiError } from '@/api/client'
+import { comments, type CommentItem } from '@/api/comments'
+import { useAuthStore } from '@/stores/auth'
+import CommentItemRow from '@/components/CommentItem.vue'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
+
+const props = defineProps<{ clipId: string }>()
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const currentUserId = computed(() => auth.user?.id ?? null)
+
+const threads = ref<CommentItem[]>([])
+const nextCursor = ref<string | null>(null)
+const loading = ref(false)
+const loadingMore = ref(false)
+const errored = ref(false)
+const actionError = ref('')
+
+// Top-level composer
+const newBody = ref('')
+const posting = ref(false)
+
+// Per-thread reply state
+const replyingTo = ref<string | null>(null)
+const replyBody = ref('')
+const replyPosting = ref(false)
+// Cursor for paging additional replies on a thread ("Show more replies").
+const replyCursors = ref<Record<string, string | null>>({})
+
+// Delete confirmation
+const pendingDelete = ref<string | null>(null)
+const deleting = ref(false)
+
+const inputClass =
+  'w-full rounded-md border border-border bg-surface-raised px-3.5 py-2.5 font-body text-sm text-text-primary outline-none placeholder:text-text-muted focus:border-border-hover transition-colors duration-150'
+
+watch(
+  () => props.clipId,
+  () => load(),
+  { immediate: true },
+)
+
+async function load() {
+  loading.value = true
+  errored.value = false
+  threads.value = []
+  try {
+    const page = await comments.list(props.clipId)
+    threads.value = page.items
+    nextCursor.value = page.nextCursor
+  } catch {
+    errored.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadMore() {
+  if (!nextCursor.value || loadingMore.value) return
+  loadingMore.value = true
+  try {
+    const page = await comments.list(props.clipId, { cursor: nextCursor.value })
+    threads.value.push(...page.items)
+    nextCursor.value = page.nextCursor
+  } catch {
+    actionError.value = 'Could not load more comments — try again.'
+  } finally {
+    loadingMore.value = false
+  }
+}
+
+function goLogin() {
+  router.push({ name: 'login', query: { redirect: route.fullPath } })
+}
+
+async function postComment() {
+  const body = newBody.value.trim()
+  if (!body || posting.value || !auth.user) return
+
+  posting.value = true
+  actionError.value = ''
+  // Optimistic: show the comment immediately under a temp id, reconcile on response.
+  const tempId = `temp-${Date.now()}`
+  const optimistic: CommentItem = {
+    id: tempId,
+    body,
+    author: { id: auth.user.id, username: auth.user.username, avatarUrl: auth.user.avatarUrl },
+    parentId: null,
+    createdAt: new Date().toISOString(),
+    replyCount: 0,
+    replies: [],
+    deleted: false,
+  }
+  threads.value.unshift(optimistic)
+  newBody.value = ''
+
+  try {
+    const created = await comments.create(props.clipId, { body })
+    const idx = threads.value.findIndex((c) => c.id === tempId)
+    if (idx !== -1) threads.value[idx] = created
+  } catch {
+    threads.value = threads.value.filter((c) => c.id !== tempId)
+    newBody.value = body
+    actionError.value = 'Could not post your comment — try again.'
+  } finally {
+    posting.value = false
+  }
+}
+
+function toggleReply(commentId: string) {
+  if (!auth.user) return goLogin()
+  replyingTo.value = replyingTo.value === commentId ? null : commentId
+  replyBody.value = ''
+}
+
+async function postReply(parentId: string) {
+  const body = replyBody.value.trim()
+  if (!body || replyPosting.value) return
+
+  replyPosting.value = true
+  actionError.value = ''
+  try {
+    const created = await comments.create(props.clipId, { body, parentId })
+    const thread = threads.value.find((c) => c.id === parentId)
+    if (thread) {
+      thread.replies.push(created)
+      thread.replyCount += 1
+    }
+    replyingTo.value = null
+    replyBody.value = ''
+  } catch {
+    actionError.value = 'Could not post your reply — try again.'
+  } finally {
+    replyPosting.value = false
+  }
+}
+
+async function showMoreReplies(thread: CommentItem) {
+  try {
+    const page = await comments.listReplies(thread.id, {
+      cursor: replyCursors.value[thread.id] ?? undefined,
+    })
+    const known = new Set(thread.replies.map((r) => r.id))
+    for (const reply of page.items) {
+      if (!known.has(reply.id)) thread.replies.push(reply)
+    }
+    replyCursors.value[thread.id] = page.nextCursor
+  } catch {
+    actionError.value = 'Could not load replies — try again.'
+  }
+}
+
+function requestDelete(commentId: string) {
+  pendingDelete.value = commentId
+}
+
+async function confirmDelete() {
+  const id = pendingDelete.value
+  if (!id) return
+  deleting.value = true
+  try {
+    await comments.delete(id)
+    markDeleted(id)
+    pendingDelete.value = null
+  } catch (err) {
+    // A 404 means it's already gone — treat as success so the UI converges.
+    if (err instanceof ApiError && err.status === 404) {
+      markDeleted(id)
+      pendingDelete.value = null
+    } else {
+      actionError.value = 'Could not delete the comment — try again.'
+    }
+  } finally {
+    deleting.value = false
+  }
+}
+
+// Soft-delete in place: top-level rows stay visible as `[deleted]` so replies don't
+// collapse; a deleted reply is dropped (the server excludes it on the next load).
+function markDeleted(id: string) {
+  for (const thread of threads.value) {
+    if (thread.id === id) {
+      thread.deleted = true
+      thread.body = null
+      return
+    }
+    const idx = thread.replies.findIndex((r) => r.id === id)
+    if (idx !== -1) {
+      thread.replies.splice(idx, 1)
+      thread.replyCount = Math.max(0, thread.replyCount - 1)
+      return
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="mt-6">
+    <h2 class="mb-3 font-heading text-lg font-bold uppercase tracking-[0.04em] text-text-primary">
+      Comments
+    </h2>
+
+    <!-- Composer / login CTA -->
+    <div class="mb-5">
+      <form v-if="auth.isAuthenticated" @submit.prevent="postComment">
+        <textarea
+          v-model="newBody"
+          rows="2"
+          maxlength="2000"
+          placeholder="Add a comment…"
+          :class="inputClass"
+          class="resize-y"
+        />
+        <div class="mt-2 flex justify-end">
+          <button
+            type="submit"
+            :disabled="posting || newBody.trim().length === 0"
+            class="cursor-pointer rounded-md bg-brand px-4 py-2 font-heading text-sm font-bold uppercase tracking-wider text-white transition-all duration-150 hover:bg-brand-light disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {{ posting ? 'Posting…' : 'Comment' }}
+          </button>
+        </div>
+      </form>
+      <button
+        v-else
+        type="button"
+        class="cursor-pointer rounded-md border border-border bg-surface-raised px-4 py-2.5 font-mono text-[13px] text-text-secondary transition-colors duration-150 hover:text-text-primary"
+        @click="goLogin"
+      >
+        Log in to comment
+      </button>
+    </div>
+
+    <p v-if="actionError" class="mb-3 font-mono text-[12px] text-[color:var(--color-error)]">
+      {{ actionError }}
+    </p>
+
+    <!-- List -->
+    <div v-if="loading" class="font-mono text-[12px] text-text-muted">Loading comments…</div>
+    <div v-else-if="errored" class="font-mono text-[12px] text-[color:var(--color-error)]">
+      Could not load comments.
+    </div>
+    <div v-else-if="threads.length === 0" class="font-mono text-[12px] text-text-muted">
+      No comments yet. Be the first.
+    </div>
+
+    <ul v-else class="flex flex-col gap-5">
+      <li v-for="thread in threads" :key="thread.id">
+        <CommentItemRow
+          :comment="thread"
+          :current-user-id="currentUserId"
+          :can-reply="auth.isAuthenticated"
+          @reply="toggleReply"
+          @delete="requestDelete"
+        />
+
+        <!-- Reply composer -->
+        <form
+          v-if="replyingTo === thread.id"
+          class="mt-2 pl-11"
+          @submit.prevent="postReply(thread.id)"
+        >
+          <textarea
+            v-model="replyBody"
+            rows="2"
+            maxlength="2000"
+            placeholder="Write a reply…"
+            :class="inputClass"
+            class="resize-y"
+          />
+          <div class="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              class="cursor-pointer rounded-md border border-border bg-surface-overlay px-3 py-1.5 font-heading text-xs font-bold uppercase tracking-wider text-text-secondary transition-colors duration-150 hover:text-text-primary"
+              @click="replyingTo = null"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              :disabled="replyPosting || replyBody.trim().length === 0"
+              class="cursor-pointer rounded-md bg-brand px-3 py-1.5 font-heading text-xs font-bold uppercase tracking-wider text-white transition-all duration-150 hover:bg-brand-light disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {{ replyPosting ? 'Replying…' : 'Reply' }}
+            </button>
+          </div>
+        </form>
+
+        <!-- Replies -->
+        <ul v-if="thread.replies.length > 0" class="mt-3 flex flex-col gap-4 pl-11">
+          <li v-for="reply in thread.replies" :key="reply.id">
+            <CommentItemRow
+              :comment="reply"
+              :current-user-id="currentUserId"
+              :can-reply="false"
+              @delete="requestDelete"
+            />
+          </li>
+        </ul>
+
+        <button
+          v-if="thread.replyCount > thread.replies.length"
+          type="button"
+          class="mt-2 ml-11 cursor-pointer font-mono text-[11px] uppercase tracking-wider text-brand-light transition-colors duration-150 hover:text-brand"
+          @click="showMoreReplies(thread)"
+        >
+          Show {{ thread.replyCount - thread.replies.length }} more
+          {{ thread.replyCount - thread.replies.length === 1 ? 'reply' : 'replies' }}
+        </button>
+      </li>
+    </ul>
+
+    <button
+      v-if="nextCursor"
+      type="button"
+      :disabled="loadingMore"
+      class="mt-5 cursor-pointer rounded-md border border-border bg-surface-raised px-4 py-2 font-mono text-[12px] text-text-secondary transition-colors duration-150 hover:text-text-primary disabled:opacity-50"
+      @click="loadMore"
+    >
+      {{ loadingMore ? 'Loading…' : 'Load more comments' }}
+    </button>
+
+    <ConfirmDialog
+      :open="pendingDelete !== null"
+      title="Delete comment?"
+      body="This removes your comment. Replies stay visible as [deleted]."
+      confirm-label="Delete"
+      variant="danger"
+      :busy="deleting"
+      @cancel="pendingDelete = null"
+      @confirm="confirmDelete"
+    />
+  </section>
+</template>

--- a/web/src/components/CommentsSection.vue
+++ b/web/src/components/CommentsSection.vue
@@ -42,6 +42,11 @@ const deleting = ref(false)
 const inputClass =
   'w-full rounded-md border border-border bg-surface-raised px-3.5 py-2.5 font-body text-sm text-text-primary outline-none placeholder:text-text-muted focus:border-border-hover transition-colors duration-150'
 
+// Monotonic token guarding against stale list/loadMore responses when props.clipId
+// flips mid-request. Captured pre-await; any response whose token no longer matches
+// the latest is silently dropped so it can't overwrite the new clip's state.
+let latestRequestId = 0
+
 watch(
   () => props.clipId,
   () => load(),
@@ -49,6 +54,7 @@ watch(
 )
 
 async function load() {
+  const requestId = ++latestRequestId
   loading.value = true
   errored.value = false
   threads.value = []
@@ -56,28 +62,33 @@ async function load() {
   replyCursors.value = {}
   try {
     const page = await comments.list(props.clipId)
+    if (requestId !== latestRequestId) return
     threads.value = page.items
     nextCursor.value = page.nextCursor
     seedReplyCursors(page.items)
   } catch {
+    if (requestId !== latestRequestId) return
     errored.value = true
   } finally {
-    loading.value = false
+    if (requestId === latestRequestId) loading.value = false
   }
 }
 
 async function loadMore() {
   if (!nextCursor.value || loadingMore.value) return
+  const requestId = ++latestRequestId
   loadingMore.value = true
   try {
     const page = await comments.list(props.clipId, { cursor: nextCursor.value })
+    if (requestId !== latestRequestId) return
     threads.value.push(...page.items)
     nextCursor.value = page.nextCursor
     seedReplyCursors(page.items)
   } catch {
+    if (requestId !== latestRequestId) return
     actionError.value = 'Could not load more comments — try again.'
   } finally {
-    loadingMore.value = false
+    if (requestId === latestRequestId) loadingMore.value = false
   }
 }
 

--- a/web/src/components/CommentsSection.vue
+++ b/web/src/components/CommentsSection.vue
@@ -32,6 +32,8 @@ const replyBody = ref('')
 const replyPosting = ref(false)
 // Cursor for paging additional replies on a thread ("Show more replies").
 const replyCursors = ref<Record<string, string | null>>({})
+// Per-thread in-flight guard so rapid "Show more" clicks can't fire overlapping requests.
+const replyLoading = ref<Record<string, boolean>>({})
 
 // Delete confirmation
 const pendingDelete = ref<string | null>(null)
@@ -50,6 +52,7 @@ async function load() {
   loading.value = true
   errored.value = false
   threads.value = []
+  nextCursor.value = null
   try {
     const page = await comments.list(props.clipId)
     threads.value = page.items
@@ -142,6 +145,8 @@ async function postReply(parentId: string) {
 }
 
 async function showMoreReplies(thread: CommentItem) {
+  if (replyLoading.value[thread.id]) return
+  replyLoading.value[thread.id] = true
   try {
     const page = await comments.listReplies(thread.id, {
       cursor: replyCursors.value[thread.id] ?? undefined,
@@ -153,6 +158,8 @@ async function showMoreReplies(thread: CommentItem) {
     replyCursors.value[thread.id] = page.nextCursor
   } catch {
     actionError.value = 'Could not load replies — try again.'
+  } finally {
+    replyLoading.value[thread.id] = false
   }
 }
 

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -14,6 +14,7 @@ import AuthorHandle from '@/components/AuthorHandle.vue'
 import StatusPanel from '@/components/StatusPanel.vue'
 import ClipEditDialog from '@/components/ClipEditDialog.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import CommentsSection from '@/components/CommentsSection.vue'
 import IconHeart from '@/components/icons/IconHeart.vue'
 import IconShare from '@/components/icons/IconShare.vue'
 import IconMoreVertical from '@/components/icons/IconMoreVertical.vue'
@@ -429,6 +430,9 @@ async function onConfirmDelete() {
         </div>
         <p class="text-sm leading-[1.6] text-text-secondary">{{ clip.description }}</p>
       </div>
+
+      <!-- Comments -->
+      <CommentsSection :clip-id="clip.id" />
     </div>
 
     <ClipEditDialog


### PR DESCRIPTION
## Summary

Adds clip comments so viewers can discuss clips on the detail page. Threads are flat two-level (top-level + one reply level) and deletes are soft so thread structure survives.

## What's here

- **Schema:** `comments` table + `Comment` entity, indexed on `(clip_id, created_at)` and `(parent_id, created_at)`.
- **Endpoints:** `POST`/`GET /clips/{id}/comments`, `GET /comments/{id}/replies`, `DELETE /comments/{id}` (author-only soft-delete). Replies are capped at depth 1 and validated against the parent's clip; writes reuse the #82 clips-write rate limiter.
- **Pagination:** extracted the keyset cursor codec out of `ClipsReadEndpoints` into a shared `KeysetCursor` and reused it for comment pagination.
- **Web:** comments API client + `CommentsSection`/`CommentItem` mounted in `ClipView` — auth-gated composer, optimistic post, threaded replies with "show more replies", and author-only delete that leaves a `[deleted]` placeholder.

Closes #84

## How to test manually

1. `make up && make seed`, then run the server (`make server`) and web (`cd web && bun dev`).
2. Open a clip detail page while signed out — the comments list renders but the composer is gated.
3. Sign in, post a top-level comment (appears optimistically), then reply to it; confirm replies stop at one level deep and "show more replies" paginates.
4. Delete your own comment — it should become a `[deleted]` placeholder while keeping any replies visible.
5. Confirm rate limiting kicks in on rapid posting (shared with #82).

## Checklist

- [ ] Verified manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full commenting system on clips with two-level threaded replies, inline reply previews, and per-thread “Show more replies”
  * Create comments/replies with client-side validation and optimistic UI (auto-reconcile/rollback)
  * Paginated comment and reply loading with opaque cursors and “Load more” controls
  * Delete own comments (soft-delete shown as “[deleted]”) and resilient UI handling of deletions
  * Comment author, avatar and relative timestamps shown in UI

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->