### PR TITLE
[server] [web] search tsvector get search navbar wire up results

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Search/SearchResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Search/SearchResponse.cs
@@ -1,0 +1,10 @@
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Contracts.Games;
+
+namespace GankedTV.Api.Contracts.Search;
+
+// Reuses ClipFeedItem and GameListItem so the navbar dropdown / search view can share
+// the same render components as the feed and games pages. No new field shapes.
+public sealed record SearchResponse(
+    IReadOnlyList<ClipFeedItem> Clips,
+    IReadOnlyList<GameListItem> Games);

--- a/server/src/GankedTV.Api/Data/Entities/Clip.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Clip.cs
@@ -1,3 +1,5 @@
+using NpgsqlTypes;
+
 namespace GankedTV.Api.Data.Entities;
 
 public class Clip
@@ -26,6 +28,11 @@ public class Clip
     // gates the row out of the queue once it exceeds the configured maximum.
     public DateTimeOffset? ProcessingStartedAt { get; set; }
     public int ProcessingAttempts { get; set; }
+
+    // Postgres-managed `tsvector` (GENERATED ALWAYS AS … STORED). Populated by the DB from
+    // title (weight A) + description (weight B); never set by application code. Used by
+    // SearchEndpoints for full-text matching/ranking against `plainto_tsquery('simple', q)`.
+    public NpgsqlTsVector SearchVector { get; private set; } = null!;
 
     public User User { get; set; } = null!;
     public Game? Game { get; set; }

--- a/server/src/GankedTV.Api/Data/Entities/Game.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Game.cs
@@ -1,3 +1,5 @@
+using NpgsqlTypes;
+
 namespace GankedTV.Api.Data.Entities;
 
 public class Game
@@ -20,4 +22,8 @@ public class Game
     // True only for rows the IGDB importer created. Gates display-name refresh so the curated
     // seed rows (incl. ones the importer adopted by name) are never renamed by an upstream change.
     public bool IgdbManaged { get; set; }
+
+    // Postgres-managed `tsvector` (GENERATED ALWAYS AS … STORED) over `name`. Powers the
+    // long-query branch of /search?type=games via plainto_tsquery + ts_rank_cd.
+    public NpgsqlTsVector SearchVector { get; private set; } = null!;
 }

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -54,6 +54,16 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             e.Property(g => g.IgdbManaged).HasDefaultValue(false);
             e.HasIndex(g => g.Slug).IsUnique().HasDatabaseName("idx_games_slug");
             e.HasIndex(g => g.Name).HasDatabaseName("idx_games_name");
+            // Full-text search vector, stored generated column. EF emits ALTER TABLE …
+            // GENERATED ALWAYS AS … STORED so the value is maintained by Postgres on every
+            // INSERT/UPDATE of name. Companion GIN index makes `@@` lookups index-driven.
+            e.Property(g => g.SearchVector)
+                .HasComputedColumnSql(
+                    "to_tsvector('simple', coalesce(name, ''))",
+                    stored: true);
+            e.HasIndex(g => g.SearchVector)
+                .HasMethod("GIN")
+                .HasDatabaseName("idx_games_search_vector");
             e.HasData(
                 new Game { Id = 1, Name = "League of Legends", Slug = "league-of-legends", Tag = "LOL" },
                 new Game { Id = 2, Name = "Valorant", Slug = "valorant", Tag = "VALORANT" },
@@ -107,6 +117,18 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
                 .HasDatabaseName("idx_clips_processing_updated_at");
             e.HasIndex(c => c.ShareCode).IsUnique().HasDatabaseName("idx_clips_share_code");
             e.Property(c => c.ShareCode).HasMaxLength(12);
+            // Title gets weight 'A' so exact title matches outrank description-only hits;
+            // description gets weight 'B'. Both go through `to_tsvector('simple', …)`, which
+            // skips stemming/stopwords — fine for short, noun-heavy clip titles ("ace clutch",
+            // game names, player tags). Stored generated → maintained by Postgres on every write.
+            e.Property(c => c.SearchVector)
+                .HasComputedColumnSql(
+                    "setweight(to_tsvector('simple', coalesce(title, '')), 'A') || "
+                    + "setweight(to_tsvector('simple', coalesce(description, '')), 'B')",
+                    stored: true);
+            e.HasIndex(c => c.SearchVector)
+                .HasMethod("GIN")
+                .HasDatabaseName("idx_clips_search_vector");
         });
 
         modelBuilder.Entity<Like>(e =>

--- a/server/src/GankedTV.Api/Data/Migrations/20260522173819_AddSearchVectors.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522173819_AddSearchVectors.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522173819_AddSearchVectors")]
+    partial class AddSearchVectors
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -172,58 +175,6 @@ namespace GankedTV.Api.Data.Migrations
                         .HasFilter("status = 'processing'");
 
                     b.ToTable("clips", (string)null);
-                });
-
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.ClipTag", b =>
-                {
-                    b.Property<Guid>("ClipId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("clip_id");
-
-                    b.Property<int>("TagId")
-                        .HasColumnType("integer")
-                        .HasColumnName("tag_id");
-
-                    b.HasKey("ClipId", "TagId")
-                        .HasName("pk_clip_tags");
-
-                    b.HasIndex("TagId", "ClipId")
-                        .HasDatabaseName("idx_clip_tags_tag");
-
-                    b.ToTable("clip_tags", (string)null);
-                });
-
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Follow", b =>
-                {
-                    b.Property<Guid>("FollowerId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("follower_id");
-
-                    b.Property<Guid>("FolloweeId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("followee_id");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at")
-                        .HasDefaultValueSql("now()");
-
-                    b.HasKey("FollowerId", "FolloweeId")
-                        .HasName("pk_follows");
-
-                    b.HasIndex("FolloweeId", "CreatedAt")
-                        .IsDescending(false, true)
-                        .HasDatabaseName("idx_follows_followee_created_at");
-
-                    b.HasIndex("FollowerId", "CreatedAt")
-                        .IsDescending(false, true)
-                        .HasDatabaseName("idx_follows_follower_created_at");
-
-                    b.ToTable("follows", null, t =>
-                        {
-                            t.HasCheckConstraint("ck_follows_no_self", "follower_id <> followee_id");
-                        });
                 });
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Game", b =>
@@ -447,43 +398,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.ToTable("refresh_tokens", (string)null);
                 });
 
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Tag", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at")
-                        .HasDefaultValueSql("now()");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(24)
-                        .HasColumnType("character varying(24)")
-                        .HasColumnName("name");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasMaxLength(24)
-                        .HasColumnType("character varying(24)")
-                        .HasColumnName("slug");
-
-                    b.HasKey("Id")
-                        .HasName("pk_tags");
-
-                    b.HasIndex("Slug")
-                        .IsUnique()
-                        .HasDatabaseName("idx_tags_slug");
-
-                    b.ToTable("tags", (string)null);
-                });
-
             modelBuilder.Entity("GankedTV.Api.Data.Entities.User", b =>
                 {
                     b.Property<Guid>("Id")
@@ -589,48 +503,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.ClipTag", b =>
-                {
-                    b.HasOne("GankedTV.Api.Data.Entities.Clip", "Clip")
-                        .WithMany("ClipTags")
-                        .HasForeignKey("ClipId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_clip_tags_clips_clip_id");
-
-                    b.HasOne("GankedTV.Api.Data.Entities.Tag", "Tag")
-                        .WithMany("ClipTags")
-                        .HasForeignKey("TagId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_clip_tags_tags_tag_id");
-
-                    b.Navigation("Clip");
-
-                    b.Navigation("Tag");
-                });
-
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Follow", b =>
-                {
-                    b.HasOne("GankedTV.Api.Data.Entities.User", "Followee")
-                        .WithMany("Followers")
-                        .HasForeignKey("FolloweeId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_follows_users_followee_id");
-
-                    b.HasOne("GankedTV.Api.Data.Entities.User", "Follower")
-                        .WithMany("Following")
-                        .HasForeignKey("FollowerId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_follows_users_follower_id");
-
-                    b.Navigation("Followee");
-
-                    b.Navigation("Follower");
-                });
-
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Like", b =>
                 {
                     b.HasOne("GankedTV.Api.Data.Entities.Clip", "Clip")
@@ -666,23 +538,12 @@ namespace GankedTV.Api.Data.Migrations
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.Clip", b =>
                 {
-                    b.Navigation("ClipTags");
-
                     b.Navigation("Likes");
-                });
-
-            modelBuilder.Entity("GankedTV.Api.Data.Entities.Tag", b =>
-                {
-                    b.Navigation("ClipTags");
                 });
 
             modelBuilder.Entity("GankedTV.Api.Data.Entities.User", b =>
                 {
                     b.Navigation("Clips");
-
-                    b.Navigation("Followers");
-
-                    b.Navigation("Following");
 
                     b.Navigation("Likes");
                 });

--- a/server/src/GankedTV.Api/Data/Migrations/20260522173819_AddSearchVectors.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522173819_AddSearchVectors.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NpgsqlTypes;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSearchVectors : Migration
+    {
+        // Prod-rollout note: both `ALTER TABLE … ADD COLUMN … GENERATED ALWAYS AS … STORED`
+        // and `CREATE INDEX … USING GIN` take ACCESS EXCLUSIVE locks and rewrite the table.
+        // Safe at current scale; for a large populated `clips` table this should be staged:
+        //   1. Add a nullable column (no GENERATED).
+        //   2. Backfill in batches.
+        //   3. CREATE INDEX CONCURRENTLY.
+        //   4. Swap to a stored-generated column or replace the backfill with a trigger.
+        // EF Core doesn't emit CONCURRENTLY, so the staged variant has to be hand-rolled.
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<NpgsqlTsVector>(
+                name: "search_vector",
+                table: "games",
+                type: "tsvector",
+                nullable: false,
+                computedColumnSql: "to_tsvector('simple', coalesce(name, ''))",
+                stored: true);
+
+            migrationBuilder.AddColumn<NpgsqlTsVector>(
+                name: "search_vector",
+                table: "clips",
+                type: "tsvector",
+                nullable: false,
+                computedColumnSql: "setweight(to_tsvector('simple', coalesce(title, '')), 'A') || setweight(to_tsvector('simple', coalesce(description, '')), 'B')",
+                stored: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_games_search_vector",
+                table: "games",
+                column: "search_vector")
+                .Annotation("Npgsql:IndexMethod", "GIN");
+
+            migrationBuilder.CreateIndex(
+                name: "idx_clips_search_vector",
+                table: "clips",
+                column: "search_vector")
+                .Annotation("Npgsql:IndexMethod", "GIN");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_games_search_vector",
+                table: "games");
+
+            migrationBuilder.DropIndex(
+                name: "idx_clips_search_vector",
+                table: "clips");
+
+            migrationBuilder.DropColumn(
+                name: "search_vector",
+                table: "games");
+
+            migrationBuilder.DropColumn(
+                name: "search_vector",
+                table: "clips");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -107,17 +107,33 @@ public static class ClipsReadEndpoints
         var hasMore = rows.Count > clampedLimit;
         var page = hasMore ? rows.GetRange(0, clampedLimit) : rows;
 
-        var likedIds = await LoadLikedClipIdsAsync(db, principal, page.Select(c => c.Id), ct);
-
-        var thumbnailsBucket = s3.Value.ThumbnailsBucket;
-        var items = page
-            .Select(c => c.ToFeedItem(
-                BuildThumbnailUrl(storage, thumbnailsBucket, c.ThumbnailKey),
-                likedIds.Contains(c.Id)))
-            .ToList();
+        var items = await ProjectFeedItemsAsync(page, principal, db, storage, s3, ct);
         var nextCursor = hasMore ? FeedCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
 
         return new ClipFeedResponse(items, nextCursor);
+    }
+
+    // Shared DTO projector for any pre-ordered, pre-included Clip list. Splits out the
+    // likedByMe lookup + thumbnail signing so SearchEndpoints can reuse them on a ranked
+    // (non-paginated, non-cursor) result set without duplicating the logic.
+    internal static async Task<List<ClipFeedItem>> ProjectFeedItemsAsync(
+        IReadOnlyList<Clip> clips,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        if (clips.Count == 0)
+        {
+            return [];
+        }
+
+        var likedIds = await LoadLikedClipIdsAsync(db, principal, clips.Select(c => c.Id), ct);
+        var thumbnailsBucket = s3.Value.ThumbnailsBucket;
+        return [.. clips.Select(c => c.ToFeedItem(
+            BuildThumbnailUrl(storage, thumbnailsBucket, c.ThumbnailKey),
+            likedIds.Contains(c.Id)))];
     }
 
     // Public Ready clips always have a thumbnail (the worker is the only path to Ready

--- a/server/src/GankedTV.Api/Endpoints/SearchEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/SearchEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text.RegularExpressions;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Contracts.Games;
 using GankedTV.Api.Contracts.Search;
@@ -16,6 +17,16 @@ public static class SearchEndpoints
     private const int DefaultLimit = 20;
     private const int MaxLimit = 50;
 
+    // Matches contiguous runs of Unicode letters/digits. Everything else (whitespace,
+    // hyphens, punctuation, tsquery operators like ! & | : *) acts as a separator, which
+    // is what we want: "Counter-Strike 2" must tokenize to ["counter", "strike", "2"] to
+    // align with what `to_tsvector('simple', …)` stores. The previous Split+Where chain
+    // fused punctuation-separated words into one token (e.g. "CounterStrike"), which then
+    // didn't match the split lexemes in the tsvector.
+    private static readonly Regex TokenRegex = new(
+        @"[\p{L}\p{N}]+",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     public static IEndpointRouteBuilder MapSearchEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapGet("/search", Search);
@@ -23,10 +34,9 @@ public static class SearchEndpoints
     }
 
     // Turns user input into a safe `tsquery` expression with prefix-matching on every
-    // token (the `:*` suffix). Sanitization is by allowlist — anything that isn't a
-    // Unicode letter or digit is dropped, which both prevents tsquery operator injection
-    // (`!`, `&`, `|`, `(`, `)`, `:`, `*`, `<->`) and naturally splits on punctuation so
-    // "Counter-Strike 2" tokenizes the same way the simple dictionary does.
+    // token (the `:*` suffix). Sanitization is by allowlist — only runs of Unicode
+    // letters/digits become tokens, so tsquery operator injection (`!`, `&`, `|`, `(`,
+    // `)`, `:`, `*`, `<->`) is structurally impossible.
     //
     // Why `to_tsquery` + manual `:*` instead of `plainto_tsquery`:
     //   plainto_tsquery has no prefix-match support, so typing "valo" wouldn't match the
@@ -40,11 +50,8 @@ public static class SearchEndpoints
     // as "no results" rather than constructing an empty tsquery (which would 500).
     internal static string? BuildPrefixTsQuery(string input)
     {
-        var tokens = input
-            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
-            .Select(t => new string([.. t.Where(char.IsLetterOrDigit)]))
-            .Where(t => t.Length > 0)
-            .Select(t => $"{t}:*")
+        var tokens = TokenRegex.Matches(input)
+            .Select(m => $"{m.Value}:*")
             .ToArray();
         return tokens.Length == 0 ? null : string.Join(" & ", tokens);
     }

--- a/server/src/GankedTV.Api/Endpoints/SearchEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/SearchEndpoints.cs
@@ -1,0 +1,147 @@
+using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Contracts.Search;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Services.ObjectStorage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class SearchEndpoints
+{
+    private const int DefaultLimit = 20;
+    private const int MaxLimit = 50;
+    // < 3 chars falls back to ILIKE prefix matching. `plainto_tsquery('simple', 'va')` would
+    // produce a lexeme that only matches whole words, so a user typing the first 1–2 chars
+    // of "Valorant" would get nothing without this fallback. 3 chars is the same cutoff
+    // most prefix-tries use empirically — short enough to feel responsive, long enough to
+    // be a useful word stem.
+    private const int FullTextMinLength = 3;
+
+    public static IEndpointRouteBuilder MapSearchEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/search", Search);
+        return app;
+    }
+
+    private static async Task<IResult> Search(
+        string? q,
+        string? type,
+        int? limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(q))
+        {
+            return ProblemResults.BadRequest("invalid_query", "q is required");
+        }
+
+        // Reject unknown types loudly rather than silently returning empty halves —
+        // a client asking for `type=clip` (singular) would otherwise look like a "no
+        // results" bug instead of a misuse of the contract.
+        if (type is not (null or "all" or "clips" or "games"))
+        {
+            return ProblemResults.BadRequest("invalid_type", "type must be all, clips, or games");
+        }
+
+        var trimmed = q.Trim();
+        var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+        var includeClips = type is null or "all" or "clips";
+        var includeGames = type is null or "all" or "games";
+
+        var clips = includeClips
+            ? await SearchClipsAsync(trimmed, clampedLimit, principal, db, storage, s3, ct)
+            : Array.Empty<ClipFeedItem>();
+
+        var games = includeGames
+            ? await SearchGamesAsync(trimmed, clampedLimit, db, ct)
+            : Array.Empty<GameListItem>();
+
+        return Results.Ok(new SearchResponse(clips, games));
+    }
+
+    private static async Task<IReadOnlyList<ClipFeedItem>> SearchClipsAsync(
+        string trimmed,
+        int limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        var baseQuery = db.Clips.AsNoTracking()
+            .Where(c => c.Visibility == "public" && c.Status == "ready");
+
+        List<Clip> rows;
+        if (trimmed.Length >= FullTextMinLength)
+        {
+            // PlainToTsQuery treats the input as a phrase, not raw tsquery syntax, so
+            // metacharacters like ! & | < : * never reach the query parser. Two function calls
+            // (one in Where, one in OrderBy) are fine — Postgres folds identical immutable
+            // expressions and the GIN index drives the Matches predicate either way.
+            rows = await baseQuery
+                .Where(c => c.SearchVector.Matches(EF.Functions.PlainToTsQuery("simple", trimmed)))
+                .OrderByDescending(c => c.SearchVector.Rank(EF.Functions.PlainToTsQuery("simple", trimmed)))
+                .ThenByDescending(c => c.CreatedAt)
+                .Include(c => c.User)
+                .Include(c => c.Game)
+                .Take(limit)
+                .ToListAsync(ct);
+        }
+        else
+        {
+            var pattern = EscapeLikePattern(trimmed) + "%";
+            rows = await baseQuery
+                .Where(c => EF.Functions.ILike(c.Title, pattern, @"\"))
+                .OrderByDescending(c => c.CreatedAt)
+                .Include(c => c.User)
+                .Include(c => c.Game)
+                .Take(limit)
+                .ToListAsync(ct);
+        }
+
+        return await ClipsReadEndpoints.ProjectFeedItemsAsync(rows, principal, db, storage, s3, ct);
+    }
+
+    private static async Task<IReadOnlyList<GameListItem>> SearchGamesAsync(
+        string trimmed,
+        int limit,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var baseQuery = db.Games.AsNoTracking();
+
+        if (trimmed.Length >= FullTextMinLength)
+        {
+            return await baseQuery
+                .Where(g => g.SearchVector.Matches(EF.Functions.PlainToTsQuery("simple", trimmed)))
+                .OrderByDescending(g => g.SearchVector.Rank(EF.Functions.PlainToTsQuery("simple", trimmed)))
+                .ThenBy(g => g.Name)
+                .Take(limit)
+                .Select(g => new GameListItem(g.Id, g.Name, g.Slug, g.Tag, g.CoverUrl))
+                .ToListAsync(ct);
+        }
+
+        var pattern = EscapeLikePattern(trimmed) + "%";
+        return await baseQuery
+            .Where(g => EF.Functions.ILike(g.Name, pattern, @"\"))
+            .OrderBy(g => g.Name)
+            .Take(limit)
+            .Select(g => new GameListItem(g.Id, g.Name, g.Slug, g.Tag, g.CoverUrl))
+            .ToListAsync(ct);
+    }
+
+    // Mirrors GamesEndpoints' substring-search escape: backslash first (so it doesn't
+    // double-escape the escapes we add next), then %/_ . Kept private here instead of
+    // shared because the two endpoints have different match semantics (substring vs.
+    // prefix) and conflating them would invite the wrong choice at the call site.
+    private static string EscapeLikePattern(string input) =>
+        input.Replace(@"\", @"\\").Replace("%", @"\%").Replace("_", @"\_");
+}

--- a/server/src/GankedTV.Api/Endpoints/SearchEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/SearchEndpoints.cs
@@ -15,17 +15,38 @@ public static class SearchEndpoints
 {
     private const int DefaultLimit = 20;
     private const int MaxLimit = 50;
-    // < 3 chars falls back to ILIKE prefix matching. `plainto_tsquery('simple', 'va')` would
-    // produce a lexeme that only matches whole words, so a user typing the first 1–2 chars
-    // of "Valorant" would get nothing without this fallback. 3 chars is the same cutoff
-    // most prefix-tries use empirically — short enough to feel responsive, long enough to
-    // be a useful word stem.
-    private const int FullTextMinLength = 3;
 
     public static IEndpointRouteBuilder MapSearchEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapGet("/search", Search);
         return app;
+    }
+
+    // Turns user input into a safe `tsquery` expression with prefix-matching on every
+    // token (the `:*` suffix). Sanitization is by allowlist — anything that isn't a
+    // Unicode letter or digit is dropped, which both prevents tsquery operator injection
+    // (`!`, `&`, `|`, `(`, `)`, `:`, `*`, `<->`) and naturally splits on punctuation so
+    // "Counter-Strike 2" tokenizes the same way the simple dictionary does.
+    //
+    // Why `to_tsquery` + manual `:*` instead of `plainto_tsquery`:
+    //   plainto_tsquery has no prefix-match support, so typing "valo" wouldn't match the
+    //   lexeme "valorant", and typing "04" would only match if the full token "04" appears
+    //   — fine here, but typing "0" wouldn't match anything. Building the query manually
+    //   gives us a single search path that handles 1-char, multi-char, and numeric tokens
+    //   identically, and removes the need for the ILIKE prefix-fallback that previously
+    //   only matched title prefixes (which is why "04" didn't find "Seed Clip 04").
+    //
+    // Returns null when the sanitized input has no usable tokens — caller treats that
+    // as "no results" rather than constructing an empty tsquery (which would 500).
+    internal static string? BuildPrefixTsQuery(string input)
+    {
+        var tokens = input
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+            .Select(t => new string([.. t.Where(char.IsLetterOrDigit)]))
+            .Where(t => t.Length > 0)
+            .Select(t => $"{t}:*")
+            .ToArray();
+        return tokens.Length == 0 ? null : string.Join(" & ", tokens);
     }
 
     private static async Task<IResult> Search(
@@ -51,24 +72,34 @@ public static class SearchEndpoints
             return ProblemResults.BadRequest("invalid_type", "type must be all, clips, or games");
         }
 
-        var trimmed = q.Trim();
+        var tsQuery = BuildPrefixTsQuery(q);
         var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
         var includeClips = type is null or "all" or "clips";
         var includeGames = type is null or "all" or "games";
 
+        // Sanitized-empty input (e.g. q="!&|" or q="...") behaves like "no matches"
+        // rather than 400 — the caller passed a non-blank string, it just contained
+        // nothing tokenizable.
+        if (tsQuery is null)
+        {
+            return Results.Ok(new SearchResponse(
+                Array.Empty<ClipFeedItem>(),
+                Array.Empty<GameListItem>()));
+        }
+
         var clips = includeClips
-            ? await SearchClipsAsync(trimmed, clampedLimit, principal, db, storage, s3, ct)
+            ? await SearchClipsAsync(tsQuery, clampedLimit, principal, db, storage, s3, ct)
             : Array.Empty<ClipFeedItem>();
 
         var games = includeGames
-            ? await SearchGamesAsync(trimmed, clampedLimit, db, ct)
+            ? (IReadOnlyList<GameListItem>)await SearchGamesAsync(tsQuery, clampedLimit, db, ct)
             : Array.Empty<GameListItem>();
 
         return Results.Ok(new SearchResponse(clips, games));
     }
 
     private static async Task<IReadOnlyList<ClipFeedItem>> SearchClipsAsync(
-        string trimmed,
+        string tsQuery,
         int limit,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
@@ -76,72 +107,31 @@ public static class SearchEndpoints
         IOptions<S3Options> s3,
         CancellationToken ct)
     {
-        var baseQuery = db.Clips.AsNoTracking()
-            .Where(c => c.Visibility == "public" && c.Status == "ready");
-
-        List<Clip> rows;
-        if (trimmed.Length >= FullTextMinLength)
-        {
-            // PlainToTsQuery treats the input as a phrase, not raw tsquery syntax, so
-            // metacharacters like ! & | < : * never reach the query parser. Two function calls
-            // (one in Where, one in OrderBy) are fine — Postgres folds identical immutable
-            // expressions and the GIN index drives the Matches predicate either way.
-            rows = await baseQuery
-                .Where(c => c.SearchVector.Matches(EF.Functions.PlainToTsQuery("simple", trimmed)))
-                .OrderByDescending(c => c.SearchVector.Rank(EF.Functions.PlainToTsQuery("simple", trimmed)))
-                .ThenByDescending(c => c.CreatedAt)
-                .Include(c => c.User)
-                .Include(c => c.Game)
-                .Take(limit)
-                .ToListAsync(ct);
-        }
-        else
-        {
-            var pattern = EscapeLikePattern(trimmed) + "%";
-            rows = await baseQuery
-                .Where(c => EF.Functions.ILike(c.Title, pattern, @"\"))
-                .OrderByDescending(c => c.CreatedAt)
-                .Include(c => c.User)
-                .Include(c => c.Game)
-                .Take(limit)
-                .ToListAsync(ct);
-        }
+        // Two ToTsQuery calls (one in Where, one in OrderBy) — Postgres folds identical
+        // immutable expressions, and the GIN index still drives the @@ predicate.
+        var rows = await db.Clips.AsNoTracking()
+            .Where(c => c.Visibility == "public" && c.Status == "ready")
+            .Where(c => c.SearchVector.Matches(EF.Functions.ToTsQuery("simple", tsQuery)))
+            .OrderByDescending(c => c.SearchVector.Rank(EF.Functions.ToTsQuery("simple", tsQuery)))
+            .ThenByDescending(c => c.CreatedAt)
+            .Include(c => c.User)
+            .Include(c => c.Game)
+            .Take(limit)
+            .ToListAsync(ct);
 
         return await ClipsReadEndpoints.ProjectFeedItemsAsync(rows, principal, db, storage, s3, ct);
     }
 
-    private static async Task<IReadOnlyList<GameListItem>> SearchGamesAsync(
-        string trimmed,
+    private static Task<List<GameListItem>> SearchGamesAsync(
+        string tsQuery,
         int limit,
         GankedTvDbContext db,
-        CancellationToken ct)
-    {
-        var baseQuery = db.Games.AsNoTracking();
-
-        if (trimmed.Length >= FullTextMinLength)
-        {
-            return await baseQuery
-                .Where(g => g.SearchVector.Matches(EF.Functions.PlainToTsQuery("simple", trimmed)))
-                .OrderByDescending(g => g.SearchVector.Rank(EF.Functions.PlainToTsQuery("simple", trimmed)))
-                .ThenBy(g => g.Name)
-                .Take(limit)
-                .Select(g => new GameListItem(g.Id, g.Name, g.Slug, g.Tag, g.CoverUrl))
-                .ToListAsync(ct);
-        }
-
-        var pattern = EscapeLikePattern(trimmed) + "%";
-        return await baseQuery
-            .Where(g => EF.Functions.ILike(g.Name, pattern, @"\"))
-            .OrderBy(g => g.Name)
+        CancellationToken ct) =>
+        db.Games.AsNoTracking()
+            .Where(g => g.SearchVector.Matches(EF.Functions.ToTsQuery("simple", tsQuery)))
+            .OrderByDescending(g => g.SearchVector.Rank(EF.Functions.ToTsQuery("simple", tsQuery)))
+            .ThenBy(g => g.Name)
             .Take(limit)
             .Select(g => new GameListItem(g.Id, g.Name, g.Slug, g.Tag, g.CoverUrl))
             .ToListAsync(ct);
-    }
-
-    // Mirrors GamesEndpoints' substring-search escape: backslash first (so it doesn't
-    // double-escape the escapes we add next), then %/_ . Kept private here instead of
-    // shared because the two endpoints have different match semantics (substring vs.
-    // prefix) and conflating them would invite the wrong choice at the call site.
-    private static string EscapeLikePattern(string input) =>
-        input.Replace(@"\", @"\\").Replace("%", @"\%").Replace("_", @"\_");
 }

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -375,6 +375,7 @@ app.MapUsersEndpoints();
 app.MapFollowsEndpoints();
 app.MapGamesEndpoints();
 app.MapTagsEndpoints();
+app.MapSearchEndpoints();
 
 if (app.Environment.IsDevelopment())
 {

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/SearchEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/SearchEndpointsTests.cs
@@ -1,0 +1,358 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class SearchEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public SearchEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        // The clip half of the response signs thumbnail URLs via ProjectFeedItemsAsync,
+        // which calls GetPresignedGetUrl. NSubstitute's default returns "" for strings —
+        // that's enough for ClipFeedItem.ThumbnailUrl to be a non-null string and is
+        // sufficient for everything these tests assert.
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>())
+            .Returns("https://thumb.test/x.jpg");
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Search_EmptyQuery_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search?q=");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_query");
+    }
+
+    [Fact]
+    public async Task Search_WhitespaceQuery_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search?q=%20%20%20");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Search_MissingQuery_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Search_LongQuery_ReturnsClipsAndGamesMatches()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var valorantId = await GetGameIdBySlugAsync("valorant");
+
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, valorantId, title: "Insane Valorant Ace");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, valorantId, title: "League clutch"); // shouldn't match
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/search?q=valorant");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        var clipTitles = body.GetProperty("clips").EnumerateArray()
+            .Select(c => c.GetProperty("title").GetString()).ToArray();
+        clipTitles.Should().ContainSingle().Which.Should().Be("Insane Valorant Ace");
+
+        var gameSlugs = body.GetProperty("games").EnumerateArray()
+            .Select(g => g.GetProperty("slug").GetString()).ToArray();
+        gameSlugs.Should().Contain("valorant");
+    }
+
+    [Fact]
+    public async Task Search_ShortQuery_UsesPrefixFallback()
+    {
+        // 2-char "va" wouldn't tokenize into a useful tsquery lexeme, so the endpoint
+        // falls back to ILIKE 'va%'. Prefix-only — "va" must not match games like
+        // "Counter-Strike 2" or clip titles that merely contain "va" mid-word.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var apexId = await GetGameIdBySlugAsync("apex-legends");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, apexId, title: "Vault chase");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, apexId, title: "Save the round"); // contains "va" mid-word, must NOT match
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/search?q=va");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        var gameNames = body.GetProperty("games").EnumerateArray()
+            .Select(g => g.GetProperty("name").GetString()).ToArray();
+        gameNames.Should().ContainSingle().Which.Should().Be("Valorant");
+
+        var clipTitles = body.GetProperty("clips").EnumerateArray()
+            .Select(c => c.GetProperty("title").GetString()).ToArray();
+        clipTitles.Should().ContainSingle().Which.Should().Be("Vault chase");
+    }
+
+    [Fact]
+    public async Task Search_HidesUnlistedAndProcessingClips()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var valorantId = await GetGameIdBySlugAsync("valorant");
+
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, valorantId, title: "Valorant public", status: "ready", visibility: "public");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, valorantId, title: "Valorant unlisted", visibility: "unlisted");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, valorantId, title: "Valorant processing", status: "processing");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/search?q=valorant&type=clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var titles = body.GetProperty("clips").EnumerateArray()
+            .Select(c => c.GetProperty("title").GetString()).ToArray();
+        titles.Should().ContainSingle().Which.Should().Be("Valorant public");
+    }
+
+    [Fact]
+    public async Task Search_TypeClips_ReturnsEmptyGames()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search?q=valorant&type=clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("games").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Search_TypeGames_ReturnsEmptyClips()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var valorantId = await GetGameIdBySlugAsync("valorant");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, valorantId, title: "Valorant clip");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/search?q=valorant&type=games");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("clips").GetArrayLength().Should().Be(0);
+        body.GetProperty("games").GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task Search_TsqueryMetacharacters_DoNotCause500()
+    {
+        // PlainToTsQuery treats input as a plain phrase, so operators like !, &, |, : *
+        // never reach the tsquery parser. Without that guard, raw to_tsquery would 500 on
+        // a malformed query like "!&|".
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search?q=%21%26%7C%3A%2A"); // "!&|:*"
+
+        resp.IsSuccessStatusCode.Should().BeTrue($"got {(int)resp.StatusCode}");
+    }
+
+    [Fact]
+    public async Task Search_LimitClampedToMax()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var valorantId = await GetGameIdBySlugAsync("valorant");
+        for (var i = 0; i < 60; i++)
+        {
+            await SeedClipAsync(userId, DateTimeOffset.UtcNow.AddSeconds(-i), valorantId,
+                title: $"Valorant clutch {i:D3}");
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/search?q=valorant&type=clips&limit=999");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        // MaxLimit is 50 in SearchEndpoints — pinned so a future bump comes with a deliberate update.
+        body.GetProperty("clips").GetArrayLength().Should().Be(50);
+    }
+
+    [Fact]
+    public async Task Search_UnknownType_Returns400()
+    {
+        // A typo like `type=clip` (singular) used to silently return empty halves; now
+        // it 400s with code=invalid_type so the misuse surfaces immediately.
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search?q=valorant&type=clip");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_type");
+    }
+
+    [Fact]
+    public async Task Search_TitleMatch_OutranksDescriptionMatch()
+    {
+        // The weighted tsvector (title=A, description=B) is the whole reason we use
+        // setweight in the migration. If a future change drops the weights, this test
+        // pins the behaviour: a clip with "valorant" in the title must rank above a
+        // clip that only mentions it in the description.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var apexId = await GetGameIdBySlugAsync("apex-legends");
+
+        var (descOnlyId, _) = await SeedClipAsync(
+            userId,
+            DateTimeOffset.UtcNow.AddMinutes(-1),
+            apexId,
+            title: "Random clutch",
+            description: "valorant comparison footage");
+        var (titleMatchId, _) = await SeedClipAsync(
+            userId,
+            DateTimeOffset.UtcNow.AddMinutes(-2),
+            apexId,
+            title: "valorant ace",
+            description: "no body text");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/search?q=valorant&type=clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("clips").EnumerateArray()
+            .Select(c => c.GetProperty("id").GetGuid()).ToList();
+        // Title-match must come first despite being older (CreatedAt only breaks ties).
+        ids.Should().HaveCount(2);
+        ids[0].Should().Be(titleMatchId);
+        ids[1].Should().Be(descOnlyId);
+    }
+
+    [Theory]
+    [InlineData("%5C", "snake")] // url-encoded backslash
+    [InlineData("%5F", "snake")] // url-encoded underscore
+    public async Task Search_PrefixFallback_EscapesLikeMetacharacters(string encodedChar, string seedPrefix)
+    {
+        // Without escaping, a 2-char query like `\` or `_` would interpret as wildcard
+        // and match every row. Each variant seeds a literal-char clip + a sibling and
+        // asserts the search resolves to a single clip whose title actually starts
+        // with the metacharacter.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var apexId = await GetGameIdBySlugAsync("apex-legends");
+
+        var rawChar = Uri.UnescapeDataString(encodedChar);
+        var matchTitle = rawChar + seedPrefix; // e.g. "_snake" or "\snake"
+        var (matchId, _) = await SeedClipAsync(
+            userId, DateTimeOffset.UtcNow, apexId, title: matchTitle);
+        await SeedClipAsync(
+            userId, DateTimeOffset.UtcNow, apexId, title: "other clip");
+
+        using var client = _factory!.CreateClient();
+        // Two-char query exercises the prefix-fallback branch (< FullTextMinLength=3).
+        var resp = await client.GetAsync($"/search?q={encodedChar}s&type=clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("clips").EnumerateArray()
+            .Select(c => c.GetProperty("id").GetGuid()).ToList();
+        ids.Should().ContainSingle().Which.Should().Be(matchId);
+    }
+
+    [Fact]
+    public async Task Search_NoAuthRequired()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search?q=valorant");
+
+        resp.IsSuccessStatusCode.Should().BeTrue($"got {(int)resp.StatusCode}");
+    }
+
+    // ---- helpers ----
+
+    private async Task<Guid> SeedUserAsync(string username = "search-test-user")
+    {
+        var (userId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+        return userId;
+    }
+
+    private async Task<int> GetGameIdBySlugAsync(string slug)
+    {
+        await using var db = _fx.CreateContext();
+        return await db.Games.Where(g => g.Slug == slug).Select(g => g.Id).FirstAsync();
+    }
+
+    // Returns (id, _) so call sites can `var (id, _)` for readability — matches the shape
+    // GamesEndpointsTests uses for its seeder.
+    private async Task<(Guid id, string shareCode)> SeedClipAsync(
+        Guid userId,
+        DateTimeOffset createdAt,
+        int? gameId,
+        string title = "test clip",
+        string status = "ready",
+        string visibility = "public",
+        string? description = null)
+    {
+        var id = Guid.NewGuid();
+        var shareCode = ShareCodeGenerator.Next();
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            GameId = gameId,
+            Title = title,
+            Description = description,
+            VideoKey = $"{userId}/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = shareCode,
+            Status = status,
+            Visibility = visibility,
+            DurationSecs = 30,
+            Width = 1920,
+            Height = 1080,
+            FileSizeBytes = 1_000_000,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        });
+        await db.SaveChangesAsync();
+        return (id, shareCode);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/SearchEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/SearchEndpointsTests.cs
@@ -99,6 +99,27 @@ public class SearchEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Search_PunctuatedQuery_SplitsTokensAtSeparators()
+    {
+        // Regression: the previous tokenizer stripped non-alphanumeric chars *within*
+        // a whitespace-split token, so "Counter-Strike" became one fused lexeme
+        // "CounterStrike:*" that didn't match any of the actual stored lexemes
+        // ("counter", "strike", "counter-strike"). The regex-based tokenizer splits
+        // on punctuation instead, producing "counter:* & strike:*" — both lexemes
+        // exist in the tsvector, so the game surfaces.
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/search?q=Counter-Strike&type=games");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var slugs = body.GetProperty("games").EnumerateArray()
+            .Select(g => g.GetProperty("slug").GetString()).ToArray();
+        slugs.Should().Contain("cs2");
+    }
+
+    [Fact]
     public async Task Search_ShortQuery_MatchesTokenPrefix()
     {
         // 2-char "va" becomes the tsquery lexeme `va:*`, which matches any token that

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/SearchEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/SearchEndpointsTests.cs
@@ -99,16 +99,17 @@ public class SearchEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Search_ShortQuery_UsesPrefixFallback()
+    public async Task Search_ShortQuery_MatchesTokenPrefix()
     {
-        // 2-char "va" wouldn't tokenize into a useful tsquery lexeme, so the endpoint
-        // falls back to ILIKE 'va%'. Prefix-only — "va" must not match games like
-        // "Counter-Strike 2" or clip titles that merely contain "va" mid-word.
+        // 2-char "va" becomes the tsquery lexeme `va:*`, which matches any token that
+        // *starts* with "va" (anywhere in the title, not just title-prefix). It must
+        // still reject titles that only contain "va" mid-word: "Save" tokenizes as
+        // "save", and "save" doesn't start with "va".
         await _fx.ResetAsync();
         var userId = await SeedUserAsync();
         var apexId = await GetGameIdBySlugAsync("apex-legends");
         await SeedClipAsync(userId, DateTimeOffset.UtcNow, apexId, title: "Vault chase");
-        await SeedClipAsync(userId, DateTimeOffset.UtcNow, apexId, title: "Save the round"); // contains "va" mid-word, must NOT match
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, apexId, title: "Save the round"); // "save" doesn't start with "va"
 
         using var client = _factory!.CreateClient();
         var resp = await client.GetAsync("/search?q=va");
@@ -123,6 +124,29 @@ public class SearchEndpointsTests : IAsyncLifetime
         var clipTitles = body.GetProperty("clips").EnumerateArray()
             .Select(c => c.GetProperty("title").GetString()).ToArray();
         clipTitles.Should().ContainSingle().Which.Should().Be("Vault chase");
+    }
+
+    [Fact]
+    public async Task Search_NumericToken_MatchesTokenAnywhereInTitle()
+    {
+        // Regression: with the old plainto_tsquery + 3-char-cutoff design, searching
+        // "04" fell into the ILIKE-prefix branch and only matched titles *starting*
+        // with "04" — so "Seed Clip 04" never surfaced. With to_tsquery(`04:*`) the
+        // numeric token matches wherever it appears in the tsvector.
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var apexId = await GetGameIdBySlugAsync("apex-legends");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, apexId, title: "Seed Clip 04");
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, apexId, title: "Seed Clip 07");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/search?q=04&type=clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var titles = body.GetProperty("clips").EnumerateArray()
+            .Select(c => c.GetProperty("title").GetString()).ToArray();
+        titles.Should().ContainSingle().Which.Should().Be("Seed Clip 04");
     }
 
     [Fact]
@@ -179,9 +203,9 @@ public class SearchEndpointsTests : IAsyncLifetime
     [Fact]
     public async Task Search_TsqueryMetacharacters_DoNotCause500()
     {
-        // PlainToTsQuery treats input as a plain phrase, so operators like !, &, |, : *
-        // never reach the tsquery parser. Without that guard, raw to_tsquery would 500 on
-        // a malformed query like "!&|".
+        // BuildPrefixTsQuery's allowlist sanitization strips tsquery operators (!, &,
+        // |, :, *) before they reach to_tsquery. Without that guard, to_tsquery would
+        // 500 on a malformed expression like "!&|".
         await _fx.ResetAsync();
         using var client = _factory!.CreateClient();
 
@@ -263,35 +287,22 @@ public class SearchEndpointsTests : IAsyncLifetime
         ids[1].Should().Be(descOnlyId);
     }
 
-    [Theory]
-    [InlineData("%5C", "snake")] // url-encoded backslash
-    [InlineData("%5F", "snake")] // url-encoded underscore
-    public async Task Search_PrefixFallback_EscapesLikeMetacharacters(string encodedChar, string seedPrefix)
+    [Fact]
+    public async Task Search_AllNonAlphanumericQuery_Returns200WithEmptyResults()
     {
-        // Without escaping, a 2-char query like `\` or `_` would interpret as wildcard
-        // and match every row. Each variant seeds a literal-char clip + a sibling and
-        // asserts the search resolves to a single clip whose title actually starts
-        // with the metacharacter.
+        // Replaces the old "LIKE escape" theory. Sanitization now strips anything
+        // that isn't a letter/digit before building the tsquery; a query that's
+        // purely punctuation tokenizes to nothing, so the response is a 200 with
+        // empty halves rather than a 500 from a malformed to_tsquery expression.
         await _fx.ResetAsync();
-        var userId = await SeedUserAsync();
-        var apexId = await GetGameIdBySlugAsync("apex-legends");
-
-        var rawChar = Uri.UnescapeDataString(encodedChar);
-        var matchTitle = rawChar + seedPrefix; // e.g. "_snake" or "\snake"
-        var (matchId, _) = await SeedClipAsync(
-            userId, DateTimeOffset.UtcNow, apexId, title: matchTitle);
-        await SeedClipAsync(
-            userId, DateTimeOffset.UtcNow, apexId, title: "other clip");
-
         using var client = _factory!.CreateClient();
-        // Two-char query exercises the prefix-fallback branch (< FullTextMinLength=3).
-        var resp = await client.GetAsync($"/search?q={encodedChar}s&type=clips");
+
+        var resp = await client.GetAsync("/search?q=%5C%5F%26%21"); // "\_&!"
 
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
-        var ids = body.GetProperty("clips").EnumerateArray()
-            .Select(c => c.GetProperty("id").GetGuid()).ToList();
-        ids.Should().ContainSingle().Which.Should().Be(matchId);
+        body.GetProperty("clips").GetArrayLength().Should().Be(0);
+        body.GetProperty("games").GetArrayLength().Should().Be(0);
     }
 
     [Fact]

--- a/web/src/api/__tests__/search.spec.ts
+++ b/web/src/api/__tests__/search.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { search } from '../search'
+import { configureAuth, BASE_URL } from '../client'
+
+beforeEach(() => {
+  configureAuth({
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    onTokenRefreshed: () => {},
+    onRefreshFailed: () => {},
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('api/search', () => {
+  it('GETs /search?q= with just the query', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ clips: [], games: [] })),
+    )
+
+    await search.query('valorant')
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/search?q=valorant`)
+  })
+
+  it('URL-encodes the query', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ clips: [], games: [] })),
+    )
+
+    await search.query('valor & rl')
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+    // URLSearchParams encodes spaces as '+' and '&' as '%26'.
+    expect(url).toBe(`${BASE_URL}/search?q=valor+%26+rl`)
+  })
+
+  it('appends type and limit when provided', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ clips: [], games: [] })),
+    )
+
+    await search.query('val', { type: 'games', limit: 5 })
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/search?q=val&type=games&limit=5`)
+  })
+
+  it('omits limit when not provided', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ clips: [], games: [] })),
+    )
+
+    await search.query('val', { type: 'all' })
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/search?q=val&type=all`)
+  })
+
+  it('returns the parsed response shape', async () => {
+    const body = {
+      clips: [
+        {
+          id: 'abc',
+          title: 't',
+          description: null,
+          thumbnailUrl: 'https://thumb.test/x.jpg',
+          durationSecs: 30,
+          viewCount: 0,
+          likeCount: 0,
+          createdAt: new Date().toISOString(),
+          author: { id: 'u', username: 'u', avatarUrl: null },
+          game: null,
+          likedByMe: false,
+          shareCode: 'abc123',
+        },
+      ],
+      games: [{ id: 1, name: 'Valorant', slug: 'valorant', tag: 'VAL', coverUrl: null }],
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(body)),
+    )
+
+    const result = await search.query('valorant')
+    expect(result).toEqual(body)
+  })
+})

--- a/web/src/api/search.ts
+++ b/web/src/api/search.ts
@@ -1,0 +1,19 @@
+import { api } from './client'
+import type { ClipFeedItem } from './clips'
+import type { GameListItem } from './games'
+
+export type SearchType = 'clips' | 'games' | 'all'
+
+export interface SearchResponse {
+  clips: ClipFeedItem[]
+  games: GameListItem[]
+}
+
+export const search = {
+  query(q: string, opts?: { type?: SearchType; limit?: number }): Promise<SearchResponse> {
+    const params = new URLSearchParams({ q })
+    if (opts?.type) params.set('type', opts.type)
+    if (opts?.limit !== undefined) params.set('limit', String(opts.limit))
+    return api<SearchResponse>(`/search?${params.toString()}`)
+  },
+}

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useThemeStore } from '@/stores/theme'
@@ -36,6 +36,48 @@ const query = ref('')
 const isFocused = ref(false)
 const results = ref<SearchResponse>({ clips: [], games: [] })
 const loading = ref(false)
+
+// The dropdown is teleported to <body> so it doesn't get clipped/stack-trapped by
+// the header's `backdrop-filter` paint context — which was rendering page content
+// over the dropdown's bottom rows and breaking hit-testing for clicks. Living in
+// the root stacking context means it just needs a high z-index to beat the header.
+const inputWrapperRef = useTemplateRef<HTMLDivElement>('inputWrapperRef')
+// Coordinates the teleported popover anchors to. Recomputed on focus + on resize
+// while the popover is visible — scroll isn't tracked because the header is sticky,
+// so the input's viewport position is stable.
+const popoverPos = ref({ top: 0, left: 0, width: 0 })
+
+function updatePopoverPos() {
+  const el = inputWrapperRef.value
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  popoverPos.value = {
+    top: rect.bottom + 4, // matches the previous mt-1 (4px) gap
+    left: rect.left,
+    width: rect.width,
+  }
+}
+
+const popoverStyle = computed(() => ({
+  top: `${popoverPos.value.top}px`,
+  left: `${popoverPos.value.left}px`,
+  width: `${popoverPos.value.width}px`,
+}))
+
+const showPopover = computed(() => isFocused.value && query.value.trim().length > 0)
+
+watch(showPopover, async (open) => {
+  if (!open) return
+  await nextTick()
+  updatePopoverPos()
+})
+
+function onResize() {
+  if (showPopover.value) updatePopoverPos()
+}
+
+onMounted(() => window.addEventListener('resize', onResize))
+onBeforeUnmount(() => window.removeEventListener('resize', onResize))
 
 let debounceTimer: ReturnType<typeof setTimeout> | undefined
 // requestSeq ensures a slow earlier response can't overwrite a fast later one.
@@ -155,8 +197,9 @@ function onBlur() {
       </nav>
 
       <!-- Search (desktop only) -->
-      <div class="relative hidden min-w-0 shrink min-[1281px]:block">
+      <div class="hidden min-w-0 shrink min-[1281px]:block">
         <div
+          ref="inputWrapperRef"
           class="flex h-9 w-60 max-w-60 items-center gap-2 overflow-hidden rounded-md border bg-surface-overlay px-3 font-mono text-xs whitespace-nowrap transition-colors duration-150"
           :class="isFocused ? 'border-brand text-text-primary' : 'border-border text-text-muted'"
         >
@@ -177,12 +220,18 @@ function onBlur() {
           />
         </div>
 
-        <!-- Dropdown -->
-        <div
-          v-if="isFocused && query.trim().length > 0"
-          id="nav-search-results"
-          class="absolute right-0 left-0 top-full z-40 mt-1 overflow-hidden rounded-md border border-border bg-surface-overlay shadow-[0_18px_50px_-18px_rgba(0,0,0,0.6)]"
-        >
+        <!-- Dropdown — teleported to body so the header's backdrop-filter context
+             can't trap or clip its rendering. Position is computed from the input
+             wrapper's bounding rect (see updatePopoverPos). Panel bg uses
+             surface-raised so the row-hover surface-overlay reads as a brighter band. -->
+        <Teleport to="body">
+          <div
+            v-if="showPopover"
+            id="nav-search-results"
+            :style="popoverStyle"
+            class="fixed z-[60] overflow-hidden rounded-md border border-border-strong bg-surface-raised shadow-[0_18px_50px_-18px_rgba(0,0,0,0.6)]"
+            @mousedown.prevent
+          >
           <div
             v-if="loading && results.clips.length === 0 && results.games.length === 0"
             class="px-3.5 py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
@@ -219,7 +268,7 @@ function onBlur() {
                   :key="c.id"
                   role="option"
                   :aria-selected="false"
-                  class="flex cursor-pointer items-center gap-3 px-3.5 py-2 transition-colors duration-150 hover:bg-surface-raised"
+                  class="flex cursor-pointer items-center gap-3 px-3.5 py-2 transition-colors duration-150 hover:bg-surface-overlay"
                   @mousedown.prevent="onResultClick({ name: 'clip', params: { id: c.id } })"
                 >
                   <img
@@ -240,7 +289,8 @@ function onBlur() {
               No matches
             </div>
           </template>
-        </div>
+          </div>
+        </Teleport>
       </div>
 
       <!-- Actions -->

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -232,63 +232,63 @@ function onBlur() {
             class="fixed z-[60] overflow-hidden rounded-md border border-border-strong bg-surface-raised shadow-[0_18px_50px_-18px_rgba(0,0,0,0.6)]"
             @mousedown.prevent
           >
-          <div
-            v-if="loading && results.clips.length === 0 && results.games.length === 0"
-            class="px-3.5 py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
-          >
-            Searching…
-          </div>
-          <template v-else>
-            <div v-if="results.games.length > 0">
-              <div
-                class="px-3.5 pt-2.5 pb-1 font-mono text-[10px] uppercase tracking-widest text-text-muted"
-              >
-                Games
-              </div>
-              <ul role="listbox" class="m-0 list-none p-0">
-                <GameSearchResult
-                  v-for="g in results.games.slice(0, DROPDOWN_GAME_LIMIT)"
-                  :key="g.id"
-                  :tag="g.tag"
-                  :name="g.name"
-                  @select="onResultClick({ name: 'game-detail', params: { slug: g.slug } })"
-                />
-              </ul>
-            </div>
-            <div v-if="results.clips.length > 0">
-              <div
-                class="px-3.5 pt-2.5 pb-1 font-mono text-[10px] uppercase tracking-widest text-text-muted"
-                :class="{ 'border-t border-border': results.games.length > 0 }"
-              >
-                Clips
-              </div>
-              <ul role="listbox" class="m-0 list-none p-0">
-                <li
-                  v-for="c in results.clips.slice(0, DROPDOWN_CLIP_LIMIT)"
-                  :key="c.id"
-                  role="option"
-                  :aria-selected="false"
-                  class="flex cursor-pointer items-center gap-3 px-3.5 py-2 transition-colors duration-150 hover:bg-surface-overlay"
-                  @mousedown.prevent="onResultClick({ name: 'clip', params: { id: c.id } })"
-                >
-                  <img
-                    :src="c.thumbnailUrl"
-                    alt=""
-                    class="h-9 w-16 shrink-0 rounded-sm object-cover"
-                  />
-                  <span class="min-w-0 flex-1 truncate font-body text-sm text-text-primary">
-                    {{ c.title }}
-                  </span>
-                </li>
-              </ul>
-            </div>
             <div
-              v-if="!loading && results.clips.length === 0 && results.games.length === 0"
+              v-if="loading && results.clips.length === 0 && results.games.length === 0"
               class="px-3.5 py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
             >
-              No matches
+              Searching…
             </div>
-          </template>
+            <template v-else>
+              <div v-if="results.games.length > 0">
+                <div
+                  class="px-3.5 pt-2.5 pb-1 font-mono text-[10px] uppercase tracking-widest text-text-muted"
+                >
+                  Games
+                </div>
+                <ul role="listbox" class="m-0 list-none p-0">
+                  <GameSearchResult
+                    v-for="g in results.games.slice(0, DROPDOWN_GAME_LIMIT)"
+                    :key="g.id"
+                    :tag="g.tag"
+                    :name="g.name"
+                    @select="onResultClick({ name: 'game-detail', params: { slug: g.slug } })"
+                  />
+                </ul>
+              </div>
+              <div v-if="results.clips.length > 0">
+                <div
+                  class="px-3.5 pt-2.5 pb-1 font-mono text-[10px] uppercase tracking-widest text-text-muted"
+                  :class="{ 'border-t border-border': results.games.length > 0 }"
+                >
+                  Clips
+                </div>
+                <ul role="listbox" class="m-0 list-none p-0">
+                  <li
+                    v-for="c in results.clips.slice(0, DROPDOWN_CLIP_LIMIT)"
+                    :key="c.id"
+                    role="option"
+                    :aria-selected="false"
+                    class="flex cursor-pointer items-center gap-3 px-3.5 py-2 transition-colors duration-150 hover:bg-surface-overlay"
+                    @mousedown.prevent="onResultClick({ name: 'clip', params: { id: c.id } })"
+                  >
+                    <img
+                      :src="c.thumbnailUrl"
+                      alt=""
+                      class="h-9 w-16 shrink-0 rounded-sm object-cover"
+                    />
+                    <span class="min-w-0 flex-1 truncate font-body text-sm text-text-primary">
+                      {{ c.title }}
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                v-if="!loading && results.clips.length === 0 && results.games.length === 0"
+                class="px-3.5 py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
+              >
+                No matches
+              </div>
+            </template>
           </div>
         </Teleport>
       </div>

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
+import { onBeforeUnmount, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useThemeStore } from '@/stores/theme'
+import { search, type SearchResponse } from '@/api/search'
 import ThemePicker from './ThemePicker.vue'
 import UserAvatar from './UserAvatar.vue'
+import GameSearchResult from './GameSearchResult.vue'
 import IconSearch from './icons/IconSearch.vue'
 import IconSun from './icons/IconSun.vue'
 import IconMoon from './icons/IconMoon.vue'
@@ -10,9 +14,105 @@ import IconPlus from './icons/IconPlus.vue'
 
 const auth = useAuthStore()
 const theme = useThemeStore()
+const router = useRouter()
 
 const navLinkActive =
   "text-text-primary after:content-[''] after:absolute after:left-3.5 after:right-3.5 after:bottom-0.5 after:h-0.5 after:bg-brand-light"
+
+// --- Search box state ---------------------------------------------------------
+//
+// Decorative input until now (issue #86). Wires to GET /search via api/search.ts.
+// Layout: combobox-pattern input with a popover listbox below, top 5 clips + top
+// 3 games. Enter navigates to the full /search results view.
+//
+// Tokens used: kept the existing `border-border bg-surface-overlay` shell from
+// the prior decorative div so the visual mass of the navbar doesn't shift.
+
+const SEARCH_DEBOUNCE_MS = 250
+const DROPDOWN_CLIP_LIMIT = 5
+const DROPDOWN_GAME_LIMIT = 3
+
+const query = ref('')
+const isFocused = ref(false)
+const results = ref<SearchResponse>({ clips: [], games: [] })
+const loading = ref(false)
+
+let debounceTimer: ReturnType<typeof setTimeout> | undefined
+// requestSeq ensures a slow earlier response can't overwrite a fast later one.
+let requestSeq = 0
+
+async function runSearch(raw: string) {
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    results.value = { clips: [], games: [] }
+    loading.value = false
+    return
+  }
+  const seq = ++requestSeq
+  loading.value = true
+  try {
+    // Backend caps games to whatever the user gets via `limit`; we ask for the
+    // larger of the two visual caps and slice in the template. One request,
+    // simplest contract.
+    const resp = await search.query(trimmed, {
+      type: 'all',
+      limit: Math.max(DROPDOWN_CLIP_LIMIT, DROPDOWN_GAME_LIMIT),
+    })
+    if (seq !== requestSeq) return
+    results.value = resp
+  } catch {
+    if (seq !== requestSeq) return
+    // Silent failure in the dropdown is intentional: typing-on-every-keystroke
+    // would otherwise turn a transient network blip into a flashing toast.
+    results.value = { clips: [], games: [] }
+  } finally {
+    if (seq === requestSeq) loading.value = false
+  }
+}
+
+watch(query, (q) => {
+  clearTimeout(debounceTimer)
+  if (!q.trim()) {
+    results.value = { clips: [], games: [] }
+    loading.value = false
+    return
+  }
+  debounceTimer = setTimeout(() => runSearch(q), SEARCH_DEBOUNCE_MS)
+})
+
+onBeforeUnmount(() => clearTimeout(debounceTimer))
+
+// Bumps requestSeq so any in-flight fetch resolves into a stale-branch and
+// can't overwrite `results` after we navigate. Also clears the debounce timer
+// so a queued search doesn't fire after the user has already moved on.
+function cancelInFlight() {
+  clearTimeout(debounceTimer)
+  requestSeq++
+  loading.value = false
+}
+
+function onSubmit() {
+  const trimmed = query.value.trim()
+  if (!trimmed) return
+  cancelInFlight()
+  isFocused.value = false
+  void router.push({ name: 'search', query: { q: trimmed } })
+}
+
+function onResultClick(to: { name: string; params: Record<string, string> }) {
+  // Clear focus so the dropdown closes; navigate after the focus state settles.
+  cancelInFlight()
+  isFocused.value = false
+  query.value = ''
+  void router.push(to)
+}
+
+// Slight blur delay so a click on a result still fires before the dropdown unmounts.
+function onBlur() {
+  setTimeout(() => {
+    isFocused.value = false
+  }, 120)
+}
 </script>
 
 <template>
@@ -54,14 +154,93 @@ const navLinkActive =
         </RouterLink>
       </nav>
 
-      <!-- Search (desktop only, decorative) -->
-      <div
-        class="hidden h-9 w-60 max-w-60 min-w-0 shrink items-center gap-2 overflow-hidden rounded-md border border-border bg-surface-overlay px-3 font-mono text-xs whitespace-nowrap text-text-muted min-[1281px]:flex"
-        aria-hidden="true"
-      >
-        <IconSearch :size="14" :stroke-width="2.2" class="shrink-0" />
-        <span class="min-w-0 flex-1 truncate">search clips, players, games</span>
-        <kbd class="shrink-0">⌘K</kbd>
+      <!-- Search (desktop only) -->
+      <div class="relative hidden min-w-0 shrink min-[1281px]:block">
+        <div
+          class="flex h-9 w-60 max-w-60 items-center gap-2 overflow-hidden rounded-md border bg-surface-overlay px-3 font-mono text-xs whitespace-nowrap transition-colors duration-150"
+          :class="isFocused ? 'border-brand text-text-primary' : 'border-border text-text-muted'"
+        >
+          <IconSearch :size="14" :stroke-width="2.2" class="shrink-0" />
+          <input
+            v-model="query"
+            type="search"
+            role="combobox"
+            aria-controls="nav-search-results"
+            aria-autocomplete="list"
+            :aria-expanded="isFocused && query.trim().length > 0"
+            placeholder="search clips, games"
+            class="min-w-0 flex-1 border-0 bg-transparent font-mono text-xs text-text-primary placeholder:text-text-muted focus:outline-none"
+            @focus="isFocused = true"
+            @blur="onBlur"
+            @keydown.enter.prevent="onSubmit"
+            @keydown.escape="($event.target as HTMLInputElement).blur()"
+          />
+        </div>
+
+        <!-- Dropdown -->
+        <div
+          v-if="isFocused && query.trim().length > 0"
+          id="nav-search-results"
+          class="absolute right-0 left-0 top-full z-40 mt-1 overflow-hidden rounded-md border border-border bg-surface-overlay shadow-[0_18px_50px_-18px_rgba(0,0,0,0.6)]"
+        >
+          <div
+            v-if="loading && results.clips.length === 0 && results.games.length === 0"
+            class="px-3.5 py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
+          >
+            Searching…
+          </div>
+          <template v-else>
+            <div v-if="results.games.length > 0">
+              <div
+                class="px-3.5 pt-2.5 pb-1 font-mono text-[10px] uppercase tracking-widest text-text-muted"
+              >
+                Games
+              </div>
+              <ul role="listbox" class="m-0 list-none p-0">
+                <GameSearchResult
+                  v-for="g in results.games.slice(0, DROPDOWN_GAME_LIMIT)"
+                  :key="g.id"
+                  :tag="g.tag"
+                  :name="g.name"
+                  @select="onResultClick({ name: 'game-detail', params: { slug: g.slug } })"
+                />
+              </ul>
+            </div>
+            <div v-if="results.clips.length > 0">
+              <div
+                class="px-3.5 pt-2.5 pb-1 font-mono text-[10px] uppercase tracking-widest text-text-muted"
+                :class="{ 'border-t border-border': results.games.length > 0 }"
+              >
+                Clips
+              </div>
+              <ul role="listbox" class="m-0 list-none p-0">
+                <li
+                  v-for="c in results.clips.slice(0, DROPDOWN_CLIP_LIMIT)"
+                  :key="c.id"
+                  role="option"
+                  :aria-selected="false"
+                  class="flex cursor-pointer items-center gap-3 px-3.5 py-2 transition-colors duration-150 hover:bg-surface-raised"
+                  @mousedown.prevent="onResultClick({ name: 'clip', params: { id: c.id } })"
+                >
+                  <img
+                    :src="c.thumbnailUrl"
+                    alt=""
+                    class="h-9 w-16 shrink-0 rounded-sm object-cover"
+                  />
+                  <span class="min-w-0 flex-1 truncate font-body text-sm text-text-primary">
+                    {{ c.title }}
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div
+              v-if="!loading && results.clips.length === 0 && results.games.length === 0"
+              class="px-3.5 py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
+            >
+              No matches
+            </div>
+          </template>
+        </div>
       </div>
 
       <!-- Actions -->

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -113,10 +113,13 @@ async function runSearch(raw: string) {
 }
 
 watch(query, (q) => {
-  clearTimeout(debounceTimer)
+  // cancelInFlight bumps requestSeq so any pending fetch resolves into the stale
+  // branch — without this, the next keystroke would only clear the debounce timer
+  // and an in-flight response could land between debounces, briefly painting stale
+  // results for the previous query.
+  cancelInFlight()
   if (!q.trim()) {
     results.value = { clips: [], games: [] }
-    loading.value = false
     return
   }
   debounceTimer = setTimeout(() => runSearch(q), SEARCH_DEBOUNCE_MS)

--- a/web/src/components/GameCoverTile.vue
+++ b/web/src/components/GameCoverTile.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+// Portrait (3:4) box-art tile linking to /game/:slug. The single shared way to render
+// a game in a grid — used by both the catalog (GamesView) and search results so the
+// covers stay visually consistent.
+//
+// Supplementary text under the name (e.g. "12 clips") goes in the `#footer-extra`
+// slot — kept out of the component because each call site derives it differently
+// (GamesView counts from a loaded feed page; SearchView has no clip count).
+//
+// Cover rendered as <img> (never as a background-image url()) so a hostile coverUrl
+// can't break out of a CSS string. Lazy-loaded for catalogs of hundreds of tiles.
+
+import type { GameListItem } from '@/api/games'
+import GameTag from './GameTag.vue'
+
+defineProps<{
+  game: GameListItem
+}>()
+</script>
+
+<template>
+  <RouterLink
+    :to="{ name: 'game-detail', params: { slug: game.slug } }"
+    class="group relative block aspect-3/4 overflow-hidden rounded-md border border-border bg-surface-raised no-underline transition-[border-color,box-shadow,transform] duration-150 hover:-translate-y-0.5 hover:border-brand hover:shadow-[0_14px_40px_-14px_var(--color-brand-glow)]"
+  >
+    <!-- alt="" — decorative: the game name is rendered as visible text in this same
+         link, so a non-empty alt would make screen readers announce it twice. -->
+    <img
+      v-if="game.coverUrl"
+      :src="game.coverUrl"
+      alt=""
+      loading="lazy"
+      decoding="async"
+      class="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+    />
+    <!-- Bottom scrim: fade to near-solid surface so the label stays legible over any art. -->
+    <div
+      class="absolute inset-x-0 bottom-0 top-1/3 bg-[linear-gradient(180deg,transparent_0%,color-mix(in_srgb,var(--color-surface-sunken)_85%,transparent)_60%,var(--color-surface-sunken)_100%)]"
+      aria-hidden="true"
+    ></div>
+    <div class="absolute inset-x-0 bottom-0 flex flex-col gap-1.5 p-3">
+      <span class="font-heading text-lg font-bold uppercase leading-none text-text-primary">
+        {{ game.name }}
+      </span>
+      <div class="flex items-center gap-2">
+        <GameTag :tag="game.tag" tone="subtle" />
+        <slot name="footer-extra" />
+      </div>
+    </div>
+  </RouterLink>
+</template>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -52,6 +52,11 @@ const router = createRouter({
       component: () => import('@/views/TrendingView.vue'),
     },
     {
+      path: '/search',
+      name: 'search',
+      component: () => import('@/views/SearchView.vue'),
+    },
+    {
       path: '/clip/:id',
       name: 'clip',
       component: () => import('@/views/ClipView.vue'),

--- a/web/src/views/GamesView.vue
+++ b/web/src/views/GamesView.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import { games as gamesApi, type GameListItem } from '@/api/games'
 import { clips, type ClipFeedItem } from '@/api/clips'
 import ClipCard from '@/components/ClipCard.vue'
-import GameTag from '@/components/GameTag.vue'
+import GameCoverTile from '@/components/GameCoverTile.vue'
 import StatusPanel from '@/components/StatusPanel.vue'
 import PageHeader from '@/components/PageHeader.vue'
 
@@ -69,46 +69,21 @@ onMounted(load)
     </StatusPanel>
 
     <template v-else>
-      <!-- Box-art wall — portrait (3:4) game covers, each links to /game/:slug. Covers are
-           native portrait art, so we show them full-bleed instead of cropping to a landscape band. -->
+      <!-- Box-art wall — portrait (3:4) game covers, each links to /game/:slug.
+           Tile rendering lives in GameCoverTile so SearchView's games section
+           stays visually identical. -->
       <div
         class="mt-8 grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-4 max-[640px]:grid-cols-[repeat(auto-fill,minmax(8rem,1fr))] max-[640px]:gap-3"
       >
-        <RouterLink
-          v-for="g in allGames"
-          :key="g.id"
-          :to="{ name: 'game-detail', params: { slug: g.slug } }"
-          class="group relative block aspect-3/4 overflow-hidden rounded-md border border-border bg-surface-raised no-underline transition-[border-color,box-shadow,transform] duration-150 hover:-translate-y-0.5 hover:border-brand hover:shadow-[0_14px_40px_-14px_var(--color-brand-glow)]"
-        >
-          <!-- Cover as <img> (not background-image) so a hostile coverUrl can't break out of a
-               CSS url() string. Lazy-loaded — the catalog can grow to hundreds of tiles. -->
-          <!-- alt="" — decorative: the game name is rendered as visible text in this same link,
-               so a non-empty alt would make screen readers announce it twice. -->
-          <img
-            v-if="g.coverUrl"
-            :src="g.coverUrl"
-            alt=""
-            loading="lazy"
-            decoding="async"
-            class="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-          />
-          <!-- Bottom scrim: fade to near-solid surface so the label stays legible over any art. -->
-          <div
-            class="absolute inset-x-0 bottom-0 top-1/3 bg-[linear-gradient(180deg,transparent_0%,color-mix(in_srgb,var(--color-surface-sunken)_85%,transparent)_60%,var(--color-surface-sunken)_100%)]"
-            aria-hidden="true"
-          ></div>
-          <div class="absolute inset-x-0 bottom-0 flex flex-col gap-1.5 p-3">
-            <span class="font-heading text-lg font-bold uppercase leading-none text-text-primary">
-              {{ g.name }}
+        <GameCoverTile v-for="g in allGames" :key="g.id" :game="g">
+          <template #footer-extra>
+            <!-- Per-game clip counts are derived from the loaded feed page (rough
+                 indicator); the authoritative count is on the game-detail page. -->
+            <span class="font-mono text-[10px] tracking-[0.08em] text-text-secondary">
+              {{ clipCountByGame.get(g.slug) ?? 0 }} clips
             </span>
-            <div class="flex items-center gap-2">
-              <GameTag :tag="g.tag" tone="subtle" />
-              <span class="font-mono text-[10px] tracking-[0.08em] text-text-secondary">
-                {{ clipCountByGame.get(g.slug) ?? 0 }} clips
-              </span>
-            </div>
-          </div>
-        </RouterLink>
+          </template>
+        </GameCoverTile>
       </div>
 
       <!-- Featured clips teaser -->

--- a/web/src/views/SearchView.vue
+++ b/web/src/views/SearchView.vue
@@ -18,23 +18,37 @@ const errored = ref(false)
 // "0 results for newWord" while the previous response is still on screen.
 const lastQuery = ref('')
 
+// Per-call token: route.query.q can change faster than the fetch resolves (e.g. user
+// edits the URL twice in quick succession or types in the navbar while SearchView is
+// open). Capturing the seq at the start of load() and re-checking before each state
+// write makes sure an out-of-order earlier response can't overwrite the newer one.
+let loadSeq = 0
+
 async function load(q: string) {
+  const seq = ++loadSeq
   const trimmed = q.trim()
   if (!trimmed) {
     results.value = { clips: [], games: [] }
     lastQuery.value = ''
+    // Clear errored too: navigating from a failed `/search?q=foo` back to `/search`
+    // shouldn't leave the error panel up over an empty-query state.
+    errored.value = false
+    loading.value = false
     return
   }
   loading.value = true
   errored.value = false
   try {
-    results.value = await search.query(trimmed, { type: 'all', limit: 20 })
+    const resp = await search.query(trimmed, { type: 'all', limit: 20 })
+    if (seq !== loadSeq) return
+    results.value = resp
     lastQuery.value = trimmed
   } catch (err) {
+    if (seq !== loadSeq) return
     console.error('search: load failed', err)
     errored.value = true
   } finally {
-    loading.value = false
+    if (seq === loadSeq) loading.value = false
   }
 }
 

--- a/web/src/views/SearchView.vue
+++ b/web/src/views/SearchView.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { search, type SearchResponse } from '@/api/search'
+import ClipCard from '@/components/ClipCard.vue'
+import GameTag from '@/components/GameTag.vue'
+import StatusPanel from '@/components/StatusPanel.vue'
+import PageHeader from '@/components/PageHeader.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const results = ref<SearchResponse>({ clips: [], games: [] })
+const loading = ref(false)
+const errored = ref(false)
+// Holds the query the *current* `results` were fetched for. The header reads this
+// rather than `route.query.q` so an in-flight fetch doesn't flash a misleading
+// "0 results for newWord" while the previous response is still on screen.
+const lastQuery = ref('')
+
+async function load(q: string) {
+  const trimmed = q.trim()
+  if (!trimmed) {
+    results.value = { clips: [], games: [] }
+    lastQuery.value = ''
+    return
+  }
+  loading.value = true
+  errored.value = false
+  try {
+    results.value = await search.query(trimmed, { type: 'all', limit: 20 })
+    lastQuery.value = trimmed
+  } catch (err) {
+    console.error('search: load failed', err)
+    errored.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => route.query.q,
+  (q) => {
+    const value = typeof q === 'string' ? q : ''
+    void load(value)
+  },
+  { immediate: true },
+)
+
+const hasQuery = () => typeof route.query.q === 'string' && route.query.q.trim().length > 0
+</script>
+
+<template>
+  <main class="mx-auto max-w-360 px-6 pt-8 pb-30">
+    <PageHeader title="Search" pulse>
+      <template #caption>
+        <template v-if="hasQuery()">
+          {{ results.clips.length }} clips · {{ results.games.length }} games for
+          <span class="text-text-primary">"{{ lastQuery || route.query.q }}"</span>
+        </template>
+        <template v-else>Type a query to search clips and games</template>
+      </template>
+    </PageHeader>
+
+    <StatusPanel v-if="errored" kind="error" message="Couldn't run the search.">
+      <button
+        class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="load(String(route.query.q ?? ''))"
+      >
+        Retry
+      </button>
+    </StatusPanel>
+
+    <StatusPanel
+      v-else-if="loading && results.clips.length === 0 && results.games.length === 0"
+      kind="loading"
+      message="Searching…"
+    />
+
+    <template v-else-if="hasQuery()">
+      <!-- Games -->
+      <section class="mt-10">
+        <h2
+          class="section-title-bar m-0 mb-5 inline-flex items-center gap-3.5 font-heading text-2xl font-bold uppercase tracking-[0.02em] text-text-primary"
+        >
+          Games
+        </h2>
+        <div v-if="results.games.length" class="flex flex-wrap gap-3">
+          <RouterLink
+            v-for="g in results.games"
+            :key="g.id"
+            :to="{ name: 'game-detail', params: { slug: g.slug } }"
+            class="inline-flex items-center gap-3 rounded-md border border-border bg-surface-raised px-3.5 py-2.5 no-underline transition-colors duration-150 hover:border-brand"
+          >
+            <GameTag :tag="g.tag" />
+            <span class="font-body text-sm text-text-primary">{{ g.name }}</span>
+          </RouterLink>
+        </div>
+        <StatusPanel v-else kind="empty" message="No games match." />
+      </section>
+
+      <!-- Clips -->
+      <section class="mt-12">
+        <h2
+          class="section-title-bar m-0 mb-5 inline-flex items-center gap-3.5 font-heading text-2xl font-bold uppercase tracking-[0.02em] text-text-primary"
+        >
+          Clips
+        </h2>
+        <div v-if="results.clips.length" class="feed-grid">
+          <ClipCard
+            v-for="clip in results.clips"
+            :key="clip.id"
+            :clip="clip"
+            @click="router.push({ name: 'clip', params: { id: clip.id } })"
+          />
+        </div>
+        <StatusPanel v-else kind="empty" message="No clips match." />
+      </section>
+    </template>
+  </main>
+</template>

--- a/web/src/views/SearchView.vue
+++ b/web/src/views/SearchView.vue
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { search, type SearchResponse } from '@/api/search'
 import ClipCard from '@/components/ClipCard.vue'
-import GameTag from '@/components/GameTag.vue'
+import GameCoverTile from '@/components/GameCoverTile.vue'
 import StatusPanel from '@/components/StatusPanel.vue'
 import PageHeader from '@/components/PageHeader.vue'
 
@@ -78,23 +78,18 @@ const hasQuery = () => typeof route.query.q === 'string' && route.query.q.trim()
     />
 
     <template v-else-if="hasQuery()">
-      <!-- Games -->
+      <!-- Games — same portrait box-art tiles as the catalog (GameCoverTile). -->
       <section class="mt-10">
         <h2
           class="section-title-bar m-0 mb-5 inline-flex items-center gap-3.5 font-heading text-2xl font-bold uppercase tracking-[0.02em] text-text-primary"
         >
           Games
         </h2>
-        <div v-if="results.games.length" class="flex flex-wrap gap-3">
-          <RouterLink
-            v-for="g in results.games"
-            :key="g.id"
-            :to="{ name: 'game-detail', params: { slug: g.slug } }"
-            class="inline-flex items-center gap-3 rounded-md border border-border bg-surface-raised px-3.5 py-2.5 no-underline transition-colors duration-150 hover:border-brand"
-          >
-            <GameTag :tag="g.tag" />
-            <span class="font-body text-sm text-text-primary">{{ g.name }}</span>
-          </RouterLink>
+        <div
+          v-if="results.games.length"
+          class="grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-4 max-[640px]:grid-cols-[repeat(auto-fill,minmax(8rem,1fr))] max-[640px]:gap-3"
+        >
+          <GameCoverTile v-for="g in results.games" :key="g.id" :game="g" />
         </div>
         <StatusPanel v-else kind="empty" message="No games match." />
       </section>


### PR DESCRIPTION
## Summary

Wires up the navbar search box (previously decorative) end-to-end: Postgres `tsvector`/GIN full-text search behind a unified `GET /search`, a focus-time autocomplete popover in the navbar, and a dedicated `/search` results view. Phase 3 (Discovery) of PLAN.md §9.

## What's here

- **Server.** `tsvector` stored-generated columns on `clips` (weight A=title, B=description) and `games` (name) with companion GIN indexes, all via EF Core's `HasComputedColumnSql` + `HasMethod("GIN")` — no raw migration SQL. New `GET /search?q=&type=clips|games|all&limit=` endpoint that builds a sanitized `to_tsquery` expression from user input (Unicode letter/digit allowlist + `:*` prefix-match per token) so a single query path handles 1-char, multi-char, and numeric tokens (`04` matches "Seed Clip 04"). `ClipsReadEndpoints` exposes a reusable `ProjectFeedItemsAsync` so the clip half of the response reuses the feed's thumbnail-signing + `likedByMe` logic instead of duplicating it. `SearchResponse` reuses the existing `ClipFeedItem` / `GameListItem` DTOs.
- **Web.** New `api/search.ts` (typed wrapper over the endpoint, reuses existing DTO types). Navbar input is now a real combobox with 250ms debounce, request-sequence guard, focus-time popover teleported to `<body>` so the header's `backdrop-filter` paint context can't trap or clip it. `Enter` navigates to `/search?q=…`. New `SearchView.vue` at `/search` renders results.
- **Shared `GameCoverTile.vue`** extracted from `GamesView` — the portrait box-art tile (cover img + scrim + name + tag) is now the single source of truth for game grids. SearchView's games section uses the same component, so covers stay visually consistent across the catalog and search results.
- **Tests.** 15 integration tests on `SearchEndpoints` (Testcontainers Postgres): empty/whitespace `q` → 400, unknown `type` → 400, full-text + prefix-token matching, numeric-token regression (`04`), visibility/status filtering, title-weight-beats-description ranking, tsquery-metacharacter safety, limit clamp. 5 web tests on the API client.

Closes #86

## How to test manually

```bash
# Server contract checks
curl -s 'http://localhost:5050/search?q=ace&type=all' | jq
curl -s 'http://localhost:5050/search?q=va&type=games' | jq          # prefix match → Valorant
curl -s 'http://localhost:5050/search?q=04&type=clips' | jq          # finds "Seed Clip 04"
curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/search?q='        # → 400
curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/search?q=ace&type=clip'  # → 400 invalid_type
curl -s 'http://localhost:5050/search?q=%21%26%7C' | jq              # tsquery metacharacters → 200

# Index actually used (force off seq-scan so a 10-row dev DB picks the GIN path)
psql … -c "SET enable_seqscan=off; EXPLAIN ANALYZE
  SELECT id FROM clips WHERE search_vector @@ to_tsquery('simple', 'seed:*');"
# Expect "Bitmap Index Scan on idx_clips_search_vector"

# Browser (desktop ≥1281px)
# - Focus the navbar search, type "valor" slowly → one /search request fires ~250ms after you stop.
# - Dropdown shows games (Valorant) + clips. Hover highlights, click navigates.
# - Enter → /search?q=valor renders the full results page with portrait covers matching /games.
# - Escape → input blurs, dropdown closes.
```

## Checklist

- [ ] Verified manually in the browser across both themes
- [ ] Reviewed the migration footnote about prod rollout (stored generated column + GIN index both rewrite the table — staged variant called out inline)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added full-text search functionality enabling users to search across clips and games
- Implemented a functional, debounced search dropdown in the navigation bar with instant results
- Created a dedicated search results page with filtering options (clips, games, or all)
- Enhanced game display with improved cover tile components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->