### PR TITLE
[server] [web] tags implementation

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
@@ -1,4 +1,5 @@
 using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Contracts.Tags;
 
 namespace GankedTV.Api.Contracts.Clips;
 
@@ -21,5 +22,6 @@ public sealed record ClipDetailResponse(
     DateTimeOffset CreatedAt,
     AuthorSummary Author,
     GameSummary? Game,
+    IReadOnlyList<TagSummary> Tags,
     bool LikedByMe,
     string Visibility);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipFeedItem.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipFeedItem.cs
@@ -1,4 +1,5 @@
 using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Contracts.Tags;
 
 namespace GankedTV.Api.Contracts.Clips;
 
@@ -17,4 +18,5 @@ public sealed record ClipFeedItem(
     DateTimeOffset CreatedAt,
     AuthorSummary Author,
     GameSummary? Game,
+    IReadOnlyList<TagSummary> Tags,
     bool LikedByMe);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
@@ -1,4 +1,5 @@
 using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Contracts.Tags;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.Clips;
 
@@ -31,6 +32,7 @@ public static class ClipMappings
             clip.CreatedAt,
             clip.User.ToAuthorSummary(),
             clip.Game?.ToGameSummary(),
+            clip.ToTagSummaries(),
             likedByMe);
 
     public static ClipDetailResponse ToDetail(
@@ -55,6 +57,18 @@ public static class ClipMappings
             clip.CreatedAt,
             clip.User.ToAuthorSummary(),
             clip.Game?.ToGameSummary(),
+            clip.ToTagSummaries(),
             likedByMe,
             clip.Visibility);
+
+    // Tag projection used by both ToFeedItem and ToDetail. Sorted by slug so cards
+    // render deterministically regardless of clip_tags insertion order. Callers must
+    // Include(c => c.ClipTags).ThenInclude(ct => ct.Tag) on the entity load — an
+    // un-included collection silently maps to an empty list, hiding bugs.
+    private static IReadOnlyList<TagSummary> ToTagSummaries(this Clip clip) =>
+        clip.ClipTags
+            .Where(ct => ct.Tag is not null)
+            .OrderBy(ct => ct.Tag.Slug, StringComparer.Ordinal)
+            .Select(ct => ct.Tag.ToSummary())
+            .ToList();
 }

--- a/server/src/GankedTV.Api/Contracts/Clips/CreateClipRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/CreateClipRequest.cs
@@ -10,4 +10,8 @@ public sealed record CreateClipRequest(
     [property: StringLength(ClipValidationLimits.MaxDescriptionLength)]
     string? Description,
     int? GameId,
-    string? Visibility);
+    string? Visibility,
+    // Optional. Omitted = no tags; otherwise each entry is normalized + get-or-created
+    // server-side. Validation (max 5, char/length rules) lives in TagsResolver so POST
+    // and PATCH share one code path. Null is treated identically to an empty list.
+    List<string>? Tags);

--- a/server/src/GankedTV.Api/Contracts/Clips/UpdateClipRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/UpdateClipRequest.cs
@@ -9,4 +9,8 @@ public sealed record UpdateClipRequest(
     [property: StringLength(ClipValidationLimits.MaxDescriptionLength)]
     string? Description,
     int? GameId,
-    string? Visibility);
+    string? Visibility,
+    // PATCH semantics: <c>null</c> = "tags field omitted, leave the existing set alone".
+    // A non-null list (including empty) = "replace the current set with this exact list".
+    // Caller distinguishes the two states; the JSON binder maps a missing key to null.
+    List<string>? Tags);

--- a/server/src/GankedTV.Api/Contracts/Tags/TagDetail.cs
+++ b/server/src/GankedTV.Api/Contracts/Tags/TagDetail.cs
@@ -1,0 +1,7 @@
+namespace GankedTV.Api.Contracts.Tags;
+
+/// <summary>
+/// Header payload for the <c>/tag/:slug</c> page — the tag itself plus a live count
+/// of public/ready clips, matching the count the paginated feed would walk through.
+/// </summary>
+public sealed record TagDetail(int Id, string Slug, string Name, int ClipCount);

--- a/server/src/GankedTV.Api/Contracts/Tags/TagSummary.cs
+++ b/server/src/GankedTV.Api/Contracts/Tags/TagSummary.cs
@@ -1,0 +1,8 @@
+namespace GankedTV.Api.Contracts.Tags;
+
+/// <summary>
+/// Compact tag projection embedded in clip DTOs and returned by the autocomplete endpoint.
+/// <see cref="ClipCount"/> is populated only by <c>GET /tags?prefix=</c>; when nested under
+/// a clip the count is <c>0</c> (clients only need it for the autocomplete dropdown).
+/// </summary>
+public sealed record TagSummary(int Id, string Slug, string Name, int ClipCount);

--- a/server/src/GankedTV.Api/Contracts/Tags/TagsMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Tags/TagsMappings.cs
@@ -1,0 +1,12 @@
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Contracts.Tags;
+
+public static class TagsMappings
+{
+    public static TagSummary ToSummary(this Tag tag, int clipCount = 0) =>
+        new(tag.Id, tag.Slug, tag.Name, clipCount);
+
+    public static TagDetail ToDetail(this Tag tag, int clipCount) =>
+        new(tag.Id, tag.Slug, tag.Name, clipCount);
+}

--- a/server/src/GankedTV.Api/Data/ClipQueryExtensions.cs
+++ b/server/src/GankedTV.Api/Data/ClipQueryExtensions.cs
@@ -1,0 +1,20 @@
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Data;
+
+public static class ClipQueryExtensions
+{
+    /// <summary>
+    /// Eager-load every relation a <see cref="Clip"/> projection (feed item or detail)
+    /// touches: author, game, and the tag join. Centralised so additions stay in one
+    /// place — <see cref="Contracts.Clips.ClipMappings.ToFeedItem"/> and
+    /// <see cref="Contracts.Clips.ClipMappings.ToDetail"/> both silently fall back to
+    /// an empty collection if these Includes are missing, hiding the bug.
+    /// </summary>
+    public static IQueryable<Clip> IncludeFeedRelations(this IQueryable<Clip> query) =>
+        query
+            .Include(c => c.User)
+            .Include(c => c.Game)
+            .Include(c => c.ClipTags).ThenInclude(ct => ct.Tag);
+}

--- a/server/src/GankedTV.Api/Data/Entities/Clip.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Clip.cs
@@ -30,4 +30,5 @@ public class Clip
     public User User { get; set; } = null!;
     public Game? Game { get; set; }
     public ICollection<Like> Likes { get; set; } = [];
+    public ICollection<ClipTag> ClipTags { get; set; } = [];
 }

--- a/server/src/GankedTV.Api/Data/Entities/ClipTag.cs
+++ b/server/src/GankedTV.Api/Data/Entities/ClipTag.cs
@@ -1,0 +1,10 @@
+namespace GankedTV.Api.Data.Entities;
+
+public class ClipTag
+{
+    public Guid ClipId { get; set; }
+    public int TagId { get; set; }
+
+    public Clip Clip { get; set; } = null!;
+    public Tag Tag { get; set; } = null!;
+}

--- a/server/src/GankedTV.Api/Data/Entities/Tag.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Tag.cs
@@ -1,0 +1,11 @@
+namespace GankedTV.Api.Data.Entities;
+
+public class Tag
+{
+    public int Id { get; set; }
+    public required string Slug { get; set; }
+    public required string Name { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public ICollection<ClipTag> ClipTags { get; set; } = [];
+}

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -10,6 +10,8 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
     public DbSet<Clip> Clips => Set<Clip>();
     public DbSet<Like> Likes => Set<Like>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+    public DbSet<Tag> Tags => Set<Tag>();
+    public DbSet<ClipTag> ClipTags => Set<ClipTag>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -120,6 +122,34 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
                 .WithMany(c => c.Likes)
                 .HasForeignKey(l => l.ClipId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Tag>(e =>
+        {
+            e.HasKey(t => t.Id);
+            e.Property(t => t.Slug).HasMaxLength(24);
+            e.Property(t => t.Name).HasMaxLength(24);
+            e.Property(t => t.CreatedAt).HasDefaultValueSql("now()");
+            e.HasIndex(t => t.Slug).IsUnique().HasDatabaseName("idx_tags_slug");
+        });
+
+        modelBuilder.Entity<ClipTag>(e =>
+        {
+            e.HasKey(ct => new { ct.ClipId, ct.TagId });
+
+            e.HasOne(ct => ct.Clip)
+                .WithMany(c => c.ClipTags)
+                .HasForeignKey(ct => ct.ClipId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(ct => ct.Tag)
+                .WithMany(t => t.ClipTags)
+                .HasForeignKey(ct => ct.TagId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Supports both the autocomplete (counting clips per tag) and the
+            // GET /tags/{slug}/clips query (filtering by tag id then joining clips).
+            e.HasIndex(ct => new { ct.TagId, ct.ClipId }).HasDatabaseName("idx_clip_tags_tag");
         });
 
         modelBuilder.Entity<RefreshToken>(e =>

--- a/server/src/GankedTV.Api/Data/Migrations/20260522175228_AddTagsAndClipTags.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522175228_AddTagsAndClipTags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522175228_AddTagsAndClipTags")]
+    partial class AddTagsAndClipTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/GankedTV.Api/Data/Migrations/20260522175228_AddTagsAndClipTags.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260522175228_AddTagsAndClipTags.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTagsAndClipTags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tags",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    slug = table.Column<string>(type: "character varying(24)", maxLength: 24, nullable: false),
+                    name = table.Column<string>(type: "character varying(24)", maxLength: 24, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_tags", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "clip_tags",
+                columns: table => new
+                {
+                    clip_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tag_id = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_clip_tags", x => new { x.clip_id, x.tag_id });
+                    table.ForeignKey(
+                        name: "fk_clip_tags_clips_clip_id",
+                        column: x => x.clip_id,
+                        principalTable: "clips",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_clip_tags_tags_tag_id",
+                        column: x => x.tag_id,
+                        principalTable: "tags",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_clip_tags_tag",
+                table: "clip_tags",
+                columns: new[] { "tag_id", "clip_id" });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_tags_slug",
+                table: "tags",
+                column: "slug",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "clip_tags");
+
+            migrationBuilder.DropTable(
+                name: "tags");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -7,6 +7,7 @@ using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.Maintenance;
 using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Services.Tags;
 using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -40,6 +41,7 @@ public static class ClipsMutateEndpoints
         ClaimsPrincipal principal,
         GankedTvDbContext db,
         IObjectStorageService storage,
+        ITagsResolver tagsResolver,
         IOptions<S3Options> s3,
         IOptions<ClipValidationOptions> validation,
         CancellationToken ct)
@@ -58,7 +60,7 @@ public static class ClipsMutateEndpoints
         }
 
         var clip = await db.Clips
-            .Include(c => c.User)
+            .IncludeFeedRelations()
             .FirstOrDefaultAsync(c => c.Id == id, ct);
 
         if (clip is null)
@@ -121,6 +123,20 @@ public static class ClipsMutateEndpoints
                 return ProblemResults.BadRequest("invalid_game");
             }
             clip.GameId = req.GameId;
+        }
+
+        // PATCH semantics: null Tags = "field omitted, leave alone"; any non-null list
+        // (including empty) = "replace with this set". The resolver handles normalize +
+        // dedupe + max-5 + get-or-create; SetClipTags applies the diff against the loaded
+        // ClipTags collection (already Include'd above).
+        if (req.Tags is not null)
+        {
+            var tagsResult = await tagsResolver.ResolveAsync(req.Tags, ct);
+            if (!tagsResult.IsSuccess)
+            {
+                return ProblemResults.BadRequest(TagsResolveProblemCodes.ToCode(tagsResult.Error!.Value));
+            }
+            tagsResolver.SetClipTags(clip, tagsResult.Tags);
         }
 
         clip.UpdatedAt = DateTimeOffset.UtcNow;

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -87,8 +87,7 @@ public static class ClipsReadEndpoints
         var rows = await query
             .OrderByDescending(c => c.CreatedAt)
             .ThenByDescending(c => c.Id)
-            .Include(c => c.User)
-            .Include(c => c.Game)
+            .IncludeFeedRelations()
             .Take(clampedLimit + 1)
             .ToListAsync(ct);
 
@@ -226,8 +225,7 @@ public static class ClipsReadEndpoints
         CancellationToken ct)
     {
         var clip = await db.Clips.AsNoTracking()
-            .Include(c => c.User)
-            .Include(c => c.Game)
+            .IncludeFeedRelations()
             .FirstOrDefaultAsync(predicate, ct);
 
         if (clip is null)

--- a/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsUploadEndpoints.cs
@@ -4,6 +4,7 @@ using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Services.Tags;
 using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -50,7 +51,7 @@ public static class ClipsUploadEndpoints
 
         var result = await clips.CreateAsync(
             userId,
-            new CreateClipInput(req.Title, req.Description, req.GameId, req.Visibility),
+            new CreateClipInput(req.Title, req.Description, req.GameId, req.Visibility, req.Tags),
             ct);
 
         return result.IsSuccess
@@ -105,6 +106,8 @@ public static class ClipsUploadEndpoints
         ClipUploadError.ObjectNotUploaded => ProblemResults.BadRequest("object_not_uploaded"),
         ClipUploadError.FileTooLarge => ProblemResults.BadRequest("file_too_large"),
         ClipUploadError.UnsupportedContentType => ProblemResults.BadRequest("unsupported_content_type"),
+        ClipUploadError.TooManyTags => ProblemResults.BadRequest(TagsResolveProblemCodes.TooManyTags),
+        ClipUploadError.InvalidTag => ProblemResults.BadRequest(TagsResolveProblemCodes.InvalidTag),
         _ => UnmappedError(error, loggerFactory),
     };
 

--- a/server/src/GankedTV.Api/Endpoints/TagsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/TagsEndpoints.cs
@@ -1,0 +1,132 @@
+using System.Security.Claims;
+using GankedTV.Api.Contracts.Tags;
+using GankedTV.Api.Data;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Services.Tags;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class TagsEndpoints
+{
+    private const int AutocompleteDefaultLimit = 10;
+    private const int AutocompleteMaxLimit = 25;
+
+    public static IEndpointRouteBuilder MapTagsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/tags");
+        group.MapGet("/", GetTags);
+        group.MapGet("/{slug}", GetBySlug);
+        group.MapGet("/{slug}/clips", GetClipsForTag);
+        return app;
+    }
+
+    private static async Task<IResult> GetTags(
+        string? prefix,
+        int? limit,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var clampedLimit = Math.Clamp(limit ?? AutocompleteDefaultLimit, 1, AutocompleteMaxLimit);
+
+        // Normalize the prefix through the same canonicalization that ResolveAsync uses
+        // so "Clu" and "clu" find the same rows. NormalizePrefix is lenient on length
+        // (1+) so a single-character prefix still works for autocomplete.
+        var normalized = TagNormalization.NormalizePrefix(prefix);
+
+        var query = db.Tags.AsNoTracking().AsQueryable();
+        if (normalized is not null)
+        {
+            // Escape LIKE metacharacters before appending '%'. Identical pattern to GamesEndpoints.
+            var trimmed = normalized
+                .Replace(@"\", @"\\")
+                .Replace("%", @"\%")
+                .Replace("_", @"\_");
+            var pattern = $"{trimmed}%";
+            // Case-sensitive Like (not ILike): slug rows are normalized to lowercase at
+            // insert time (TagsResolver) and the prefix is lowercased above (NormalizePrefix),
+            // so both sides of the match are already canonical — ILike would be wasted work.
+            query = query.Where(t => EF.Functions.Like(t.Slug, pattern, @"\"));
+        }
+
+        // Project clipCount in the same SELECT — single round trip, ordered by popularity
+        // then alphabetical for stable cross-page ordering. The Where on Visibility/Status
+        // matches the per-tag feed's filter so the count reflects what the user can actually
+        // scroll through.
+        var rows = await query
+            .Select(t => new
+            {
+                t.Id,
+                t.Slug,
+                t.Name,
+                ClipCount = db.Clips.Count(c =>
+                    c.ClipTags.Any(ct => ct.TagId == t.Id)
+                    && c.Visibility == "public"
+                    && c.Status == "ready"),
+            })
+            .OrderByDescending(r => r.ClipCount)
+            .ThenBy(r => r.Slug)
+            .Take(clampedLimit)
+            .ToListAsync(ct);
+
+        var items = rows
+            .Select(r => new TagSummary(r.Id, r.Slug, r.Name, r.ClipCount))
+            .ToList();
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetBySlug(
+        string slug,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var row = await db.Tags.AsNoTracking()
+            .Where(t => t.Slug == slug)
+            .Select(t => new
+            {
+                Tag = t,
+                ClipCount = db.Clips.Count(c =>
+                    c.ClipTags.Any(ct => ct.TagId == t.Id)
+                    && c.Visibility == "public"
+                    && c.Status == "ready"),
+            })
+            .FirstOrDefaultAsync(ct);
+
+        return row is null
+            ? ProblemResults.NotFound("not_found")
+            : Results.Ok(row.Tag.ToDetail(row.ClipCount));
+    }
+
+    private static async Task<IResult> GetClipsForTag(
+        string slug,
+        string? cursor,
+        int? limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        // Distinguish "no such tag" (404) from "tag exists but has no clips" (200, empty page)
+        // so the client picks the right empty state. Mirrors GamesEndpoints.GetClipsForGame.
+        var tagId = await db.Tags.AsNoTracking()
+            .Where(t => t.Slug == slug)
+            .Select(t => (int?)t.Id)
+            .FirstOrDefaultAsync(ct);
+
+        if (tagId is null)
+            return ProblemResults.NotFound("not_found");
+
+        var resolvedTagId = tagId.Value;
+        var baseQuery = db.Clips.AsNoTracking()
+            .Where(c => c.ClipTags.Any(ct => ct.TagId == resolvedTagId)
+                && c.Visibility == "public"
+                && c.Status == "ready");
+
+        var response = await ClipsReadEndpoints.BuildFeedPageAsync(
+            baseQuery, cursor, limit, principal, db, storage, s3, ct);
+        return Results.Ok(response);
+    }
+}

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -15,6 +15,7 @@ using GankedTV.Api.Services.Igdb;
 using GankedTV.Api.Services.Maintenance;
 using GankedTV.Api.Services.Media;
 using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Services.Tags;
 using GankedTV.Api.Tools;
 using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -154,6 +155,7 @@ builder.Services.AddOptions<ClipValidationOptions>()
     .ValidateOnStart();
 
 builder.Services.AddScoped<IClipUploadService, ClipUploadService>();
+builder.Services.AddScoped<ITagsResolver, TagsResolver>();
 
 // ---- Auth configuration ----
 
@@ -360,6 +362,7 @@ app.MapClipsMutateEndpoints();
 app.MapLikesEndpoints();
 app.MapUsersEndpoints();
 app.MapGamesEndpoints();
+app.MapTagsEndpoints();
 
 if (app.Environment.IsDevelopment())
 {

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Services.Tags;
 using GankedTV.Api.Validation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -14,6 +16,7 @@ public sealed class ClipUploadService : IClipUploadService
 
     private readonly GankedTvDbContext _db;
     private readonly IObjectStorageService _storage;
+    private readonly ITagsResolver _tagsResolver;
     private readonly ClipValidationOptions _validation;
     private readonly S3Options _s3;
     private readonly TimeProvider _clock;
@@ -21,12 +24,14 @@ public sealed class ClipUploadService : IClipUploadService
     public ClipUploadService(
         GankedTvDbContext db,
         IObjectStorageService storage,
+        ITagsResolver tagsResolver,
         IOptions<ClipValidationOptions> validation,
         IOptions<S3Options> s3,
         TimeProvider clock)
     {
         _db = db;
         _storage = storage;
+        _tagsResolver = tagsResolver;
         _validation = validation.Value;
         _s3 = s3.Value;
         _clock = clock;
@@ -73,6 +78,18 @@ public sealed class ClipUploadService : IClipUploadService
             }
         }
 
+        // Resolve tags BEFORE the clip is staged so a tag validation failure doesn't
+        // require rolling back a partial Clip insert. ResolveAsync flushes any newly
+        // created tag rows; rolling back the clip insert via SaveChangesAsync below
+        // leaves those Tag rows intact but unreferenced — harmless and reachable for
+        // the next clip that uses the same slug (the whole point of get-or-create).
+        var requestedTags = input.Tags ?? [];
+        var tagsResult = await _tagsResolver.ResolveAsync(requestedTags, ct);
+        if (!tagsResult.IsSuccess)
+        {
+            return ClipResult<CreateClipResult>.Fail(MapTagsError(tagsResult.Error!.Value));
+        }
+
         var id = Guid.NewGuid();
         var now = _clock.GetUtcNow();
         var shareCode = await ShareCodeGenerator.GenerateUniqueAsync(_db.Clips, ct);
@@ -93,12 +110,26 @@ public sealed class ClipUploadService : IClipUploadService
             CreatedAt = now,
             UpdatedAt = now,
         };
+        // Same diff-and-attach as PATCH — the clip starts with an empty ClipTags
+        // collection, so SetClipTags reduces to "add all resolved tags".
+        _tagsResolver.SetClipTags(clip, tagsResult.Tags);
 
         _db.Clips.Add(clip);
         await _db.SaveChangesAsync(ct);
 
         return ClipResult<CreateClipResult>.Ok(new CreateClipResult(id));
     }
+
+    // Exhaustive over the defined TagsResolveError cases. The throwing default arm
+    // satisfies CS8524 (which can't prove an int-backed enum has no unnamed values)
+    // while still failing loudly if a future enum case is added without updating this
+    // map — preferable to a silent wrong mapping.
+    internal static ClipUploadError MapTagsError(TagsResolveError error) => error switch
+    {
+        TagsResolveError.TooManyTags => ClipUploadError.TooManyTags,
+        TagsResolveError.InvalidTag => ClipUploadError.InvalidTag,
+        _ => throw new UnreachableException($"Unmapped TagsResolveError: {error}"),
+    };
 
     public async Task<ClipResult<UploadUrlResult>> GetUploadUrlAsync(
         Guid userId,

--- a/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
@@ -11,7 +11,8 @@ public sealed record CreateClipInput(
     string? Title,
     string? Description,
     int? GameId,
-    string? Visibility);
+    string? Visibility,
+    IReadOnlyList<string>? Tags);
 
 public sealed record CreateClipResult(Guid ClipId);
 public sealed record UploadUrlResult(string Url, DateTimeOffset ExpiresAt, string ContentType);
@@ -28,6 +29,8 @@ public enum ClipUploadError
     ObjectNotUploaded,
     FileTooLarge,
     UnsupportedContentType,
+    TooManyTags,
+    InvalidTag,
 }
 
 public readonly record struct ClipResult<T>(T? Value, ClipUploadError? Error)

--- a/server/src/GankedTV.Api/Services/Tags/ITagsResolver.cs
+++ b/server/src/GankedTV.Api/Services/Tags/ITagsResolver.cs
@@ -1,0 +1,55 @@
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Services.Tags;
+
+public interface ITagsResolver
+{
+    /// <summary>
+    /// Normalize, dedupe, validate (max count + char/length rules), and get-or-create
+    /// the given raw tag strings. The returned <see cref="TagsResolution.Tags"/> is in the
+    /// same order as the (deduped) request and contains both freshly inserted and
+    /// pre-existing rows. The caller is responsible for attaching them to a clip.
+    /// </summary>
+    Task<TagsResolution> ResolveAsync(IReadOnlyList<string> requested, CancellationToken ct);
+
+    /// <summary>
+    /// Replace a clip's tag set with the supplied (already-resolved) tags. Adds new
+    /// associations and removes ones that are no longer present. Caller must have loaded
+    /// <c>clip.ClipTags</c> on the change-tracker (e.g. via <c>Include</c>) so the diff
+    /// runs against the actual current state.
+    /// </summary>
+    void SetClipTags(Clip clip, IReadOnlyList<Tag> resolved);
+}
+
+public sealed record TagsResolution(IReadOnlyList<Tag> Tags, TagsResolveError? Error)
+{
+    public bool IsSuccess => Error is null;
+
+    public static TagsResolution Ok(IReadOnlyList<Tag> tags) => new(tags, null);
+    public static TagsResolution Fail(TagsResolveError error) => new([], error);
+}
+
+public enum TagsResolveError
+{
+    TooManyTags,
+    InvalidTag,
+}
+
+/// <summary>
+/// Single source of truth for the machine-readable problem-detail codes any caller
+/// surfaces when a <see cref="TagsResolveError"/> propagates out as an HTTP 400. Used
+/// directly by <c>PATCH /clips</c> and via the <see cref="ClipUploadError"/> mapper
+/// in <c>ClipUploadService.MapTagsError</c> → <c>ClipsUploadEndpoints.MapError</c>.
+/// </summary>
+public static class TagsResolveProblemCodes
+{
+    public const string TooManyTags = "too_many_tags";
+    public const string InvalidTag = "invalid_tag";
+
+    public static string ToCode(TagsResolveError error) => error switch
+    {
+        TagsResolveError.TooManyTags => TooManyTags,
+        TagsResolveError.InvalidTag => InvalidTag,
+        _ => throw new System.Diagnostics.UnreachableException($"Unmapped TagsResolveError: {error}"),
+    };
+}

--- a/server/src/GankedTV.Api/Services/Tags/TagNormalization.cs
+++ b/server/src/GankedTV.Api/Services/Tags/TagNormalization.cs
@@ -56,25 +56,42 @@ public static class TagNormalization
     }
 
     /// <summary>
-    /// Normalize a prefix for autocomplete LIKE queries. Lowercases and strips disallowed
-    /// characters but does NOT enforce min length (so a one-character prefix like "c" is
-    /// still queryable). Returns <c>null</c> if the prefix is empty or only invalid chars.
+    /// Normalize a prefix for autocomplete LIKE queries. Mirrors <see cref="TryNormalize"/>'s
+    /// slug transformation (lowercase, whitespace/underscore → hyphen, repeated hyphens
+    /// collapsed, edge hyphens trimmed) but does NOT enforce min length — a one-character
+    /// prefix like <c>c</c> is still queryable. Returns <c>null</c> if the prefix is empty
+    /// or contains only invalid characters.
     /// </summary>
+    /// <remarks>
+    /// Must apply the same whitespace-to-hyphen mapping as <see cref="TryNormalize"/>, or a
+    /// user typing <c>"league of"</c> in autocomplete would search for <c>"leagueof"</c>
+    /// and never match the stored slug <c>"league-of"</c>.
+    /// </remarks>
     public static string? NormalizePrefix(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return null;
         var sb = new StringBuilder(raw.Length);
+        var lastWasHyphen = false;
         foreach (var ch in raw)
         {
-            if (ch is (>= 'a' and <= 'z') or (>= '0' and <= '9') or '-')
+            if (ch is (>= 'a' and <= 'z') or (>= '0' and <= '9'))
             {
                 sb.Append(ch);
+                lastWasHyphen = false;
             }
             else if (ch is >= 'A' and <= 'Z')
             {
                 sb.Append((char)(ch + ('a' - 'A')));
+                lastWasHyphen = false;
+            }
+            else if (ch == '-' || ch == '_' || char.IsWhiteSpace(ch))
+            {
+                if (sb.Length == 0 || lastWasHyphen) continue;
+                sb.Append('-');
+                lastWasHyphen = true;
             }
         }
+        if (sb.Length > 0 && sb[^1] == '-') sb.Length--;
         return sb.Length == 0 ? null : sb.ToString();
     }
 }

--- a/server/src/GankedTV.Api/Services/Tags/TagNormalization.cs
+++ b/server/src/GankedTV.Api/Services/Tags/TagNormalization.cs
@@ -1,0 +1,80 @@
+using System.Text;
+
+namespace GankedTV.Api.Services.Tags;
+
+/// <summary>
+/// Slug normalization for user-submitted tag input. Used both by the resolver
+/// (to canonicalize before get-or-create) and by the autocomplete endpoint
+/// (to canonicalize the <c>prefix</c> query before ILIKE).
+/// </summary>
+public static class TagNormalization
+{
+    public const int MinLength = 2;
+    public const int MaxLength = 24;
+    public const int MaxTagsPerClip = 5;
+
+    /// <summary>
+    /// Normalize a single raw input to a slug: lowercased, internal whitespace + non-alnum
+    /// → <c>-</c>, repeated hyphens collapsed, edge hyphens trimmed. Returns <c>false</c>
+    /// if the result is empty or outside <see cref="MinLength"/>..<see cref="MaxLength"/>.
+    /// </summary>
+    public static bool TryNormalize(string? raw, out string slug)
+    {
+        slug = string.Empty;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+
+        var sb = new StringBuilder(raw.Length);
+        var lastWasHyphen = false;
+        foreach (var ch in raw)
+        {
+            if (ch is (>= 'a' and <= 'z') or (>= '0' and <= '9'))
+            {
+                sb.Append(ch);
+                lastWasHyphen = false;
+            }
+            else if (ch is >= 'A' and <= 'Z')
+            {
+                sb.Append((char)(ch + ('a' - 'A')));
+                lastWasHyphen = false;
+            }
+            else if (ch == '-' || ch == '_' || char.IsWhiteSpace(ch))
+            {
+                if (sb.Length == 0 || lastWasHyphen) continue;
+                sb.Append('-');
+                lastWasHyphen = true;
+            }
+            // Any other character is silently dropped — emoji, punctuation, accents etc.
+        }
+
+        // Trim trailing hyphen if any.
+        if (sb.Length > 0 && sb[^1] == '-') sb.Length--;
+
+        if (sb.Length < MinLength || sb.Length > MaxLength) return false;
+
+        slug = sb.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Normalize a prefix for autocomplete LIKE queries. Lowercases and strips disallowed
+    /// characters but does NOT enforce min length (so a one-character prefix like "c" is
+    /// still queryable). Returns <c>null</c> if the prefix is empty or only invalid chars.
+    /// </summary>
+    public static string? NormalizePrefix(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var sb = new StringBuilder(raw.Length);
+        foreach (var ch in raw)
+        {
+            if (ch is (>= 'a' and <= 'z') or (>= '0' and <= '9') or '-')
+            {
+                sb.Append(ch);
+            }
+            else if (ch is >= 'A' and <= 'Z')
+            {
+                sb.Append((char)(ch + ('a' - 'A')));
+            }
+        }
+        return sb.Length == 0 ? null : sb.ToString();
+    }
+}

--- a/server/src/GankedTV.Api/Services/Tags/TagsResolver.cs
+++ b/server/src/GankedTV.Api/Services/Tags/TagsResolver.cs
@@ -1,0 +1,144 @@
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace GankedTV.Api.Services.Tags;
+
+public sealed class TagsResolver : ITagsResolver
+{
+    // Retry budget for the SELECT-then-INSERT race on a brand-new slug. One retry is
+    // enough: after a concurrent transaction loses the race and a unique violation
+    // surfaces, the next SELECT is guaranteed to see the winning row.
+    private const int MaxInsertAttempts = 2;
+
+    private readonly GankedTvDbContext _db;
+    private readonly TimeProvider _clock;
+
+    public TagsResolver(GankedTvDbContext db, TimeProvider clock)
+    {
+        _db = db;
+        _clock = clock;
+    }
+
+    // Resolver intentionally uses its own auto-commit semantics rather than running
+    // inside the caller's transaction. Two trade-offs are baked into that choice:
+    //   1. The race-retry below requires a live (non-aborted) connection to re-query
+    //      after a unique violation. Inside a broken outer transaction Postgres rejects
+    //      every subsequent statement until ROLLBACK, which would defeat the retry.
+    //   2. If the caller's subsequent SaveChangesAsync fails, any tag rows this method
+    //      just inserted remain. That's harmless — they're indistinguishable from rows
+    //      a previous upload created and will be reused on the next get-or-create.
+    public async Task<TagsResolution> ResolveAsync(IReadOnlyList<string> requested, CancellationToken ct)
+    {
+        if (requested.Count == 0)
+        {
+            return TagsResolution.Ok([]);
+        }
+
+        // Normalize first so the max-5 cap is applied AFTER dedupe — submitting
+        // ["clutch", "Clutch", "CLUTCH"] should not 400 with too_many_tags.
+        var slugToDisplay = new Dictionary<string, string>(StringComparer.Ordinal);
+        var orderedSlugs = new List<string>(requested.Count);
+        foreach (var raw in requested)
+        {
+            if (!TagNormalization.TryNormalize(raw, out var slug))
+            {
+                return TagsResolution.Fail(TagsResolveError.InvalidTag);
+            }
+            if (slugToDisplay.ContainsKey(slug)) continue;
+
+            // Display name preserves the user's casing for first-seen tags. We strip
+            // leading/trailing whitespace but otherwise keep the raw input within
+            // the same length cap as the slug, so casing like "Clutch" survives.
+            var display = (raw ?? string.Empty).Trim();
+            if (display.Length > TagNormalization.MaxLength)
+            {
+                display = display[..TagNormalization.MaxLength];
+            }
+            slugToDisplay[slug] = display.Length == 0 ? slug : display;
+            orderedSlugs.Add(slug);
+        }
+
+        if (orderedSlugs.Count > TagNormalization.MaxTagsPerClip)
+        {
+            return TagsResolution.Fail(TagsResolveError.TooManyTags);
+        }
+
+        var now = _clock.GetUtcNow();
+
+        for (var attempt = 1; attempt <= MaxInsertAttempts; attempt++)
+        {
+            var existing = await _db.Tags
+                .Where(t => orderedSlugs.Contains(t.Slug))
+                .ToListAsync(ct);
+            var bySlug = existing.ToDictionary(t => t.Slug, StringComparer.Ordinal);
+
+            var newRows = new List<Tag>();
+            foreach (var slug in orderedSlugs)
+            {
+                if (bySlug.ContainsKey(slug)) continue;
+                var tag = new Tag
+                {
+                    Slug = slug,
+                    Name = slugToDisplay[slug],
+                    CreatedAt = now,
+                };
+                _db.Tags.Add(tag);
+                newRows.Add(tag);
+                bySlug[slug] = tag;
+            }
+
+            if (newRows.Count == 0)
+            {
+                return TagsResolution.Ok(orderedSlugs.Select(s => bySlug[s]).ToList());
+            }
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+                return TagsResolution.Ok(orderedSlugs.Select(s => bySlug[s]).ToList());
+            }
+            catch (DbUpdateException ex) when (IsSlugUniqueViolation(ex) && attempt < MaxInsertAttempts)
+            {
+                // Another transaction inserted one of our slugs between our SELECT and our INSERT.
+                // Detach the pending Added entries so the next attempt's SaveChanges doesn't
+                // re-issue them; the next SELECT will return the winning rows.
+                foreach (var row in newRows)
+                {
+                    _db.Entry(row).State = EntityState.Detached;
+                }
+            }
+        }
+
+        // Unreachable: the loop either returns on success or rethrows on the final attempt.
+        throw new InvalidOperationException(
+            $"TagsResolver.ResolveAsync exhausted {MaxInsertAttempts} attempts without resolving.");
+    }
+
+    private static bool IsSlugUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg
+        && pg.SqlState == PostgresErrorCodes.UniqueViolation
+        && string.Equals(pg.ConstraintName, "idx_tags_slug", StringComparison.Ordinal);
+
+    public void SetClipTags(Clip clip, IReadOnlyList<Tag> resolved)
+    {
+        var targetIds = resolved.Select(t => t.Id).ToHashSet();
+        var currentIds = clip.ClipTags.Select(ct => ct.TagId).ToHashSet();
+
+        // Remove links that are no longer in the target set.
+        var stale = clip.ClipTags.Where(ct => !targetIds.Contains(ct.TagId)).ToList();
+        foreach (var ct in stale)
+        {
+            clip.ClipTags.Remove(ct);
+            _db.ClipTags.Remove(ct);
+        }
+
+        // Add brand-new links.
+        foreach (var tag in resolved)
+        {
+            if (currentIds.Contains(tag.Id)) continue;
+            clip.ClipTags.Add(new ClipTag { ClipId = clip.Id, TagId = tag.Id, Tag = tag });
+        }
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsTagsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsTagsTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+// Covers the tag-related behaviour of POST /clips and PATCH /clips/{id}. Kept
+// separate from ClipsUploadEndpointsTests / ClipsMutateEndpointsTests so the tag
+// feature lives in one file and is easy to delete or move later.
+[Collection("Postgres")]
+public class ClipsTagsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public ClipsTagsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://minio.local/presigned");
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "owner") =>
+        AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+
+    private HttpClient ClientWithBearer(string token) =>
+        AuthTestHelpers.CreateBearerClient(_factory!, token);
+
+    private async Task<Guid> SeedReadyClipAsync(Guid userId, params string[] tagSlugs)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = "seed",
+            VideoKey = $"{userId}/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = ShareCodeGenerator.Next(),
+            Status = "ready",
+            Visibility = "public",
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        foreach (var slug in tagSlugs)
+        {
+            var tag = new Tag { Slug = slug, Name = slug, CreatedAt = now };
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            db.ClipTags.Add(new ClipTag { ClipId = id, TagId = tag.Id });
+        }
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    // ---- POST /clips with tags ----
+
+    [Fact]
+    public async Task Create_WithTags_PersistsClipTagsRows()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new
+        {
+            title = "clutch ace",
+            tags = new[] { "clutch", "ace" },
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var clipId = body.GetProperty("id").GetGuid();
+
+        await using var db = _fx.CreateContext();
+        var slugs = await db.ClipTags
+            .Where(ct => ct.ClipId == clipId)
+            .Select(ct => ct.Tag.Slug)
+            .ToListAsync();
+        slugs.Should().BeEquivalentTo(new[] { "clutch", "ace" });
+    }
+
+    [Fact]
+    public async Task Create_TagsNormalizeAndDedupeWithinRequest()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new
+        {
+            title = "x",
+            tags = new[] { "Clutch", "clutch", "CLUTCH" },
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var clipId = (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetGuid();
+
+        await using var db = _fx.CreateContext();
+        var tags = await db.ClipTags.Where(ct => ct.ClipId == clipId)
+            .Select(ct => ct.Tag.Slug).ToListAsync();
+        tags.Should().ContainSingle().Which.Should().Be("clutch");
+
+        var totalTagRows = await db.Tags.CountAsync(t => t.Slug == "clutch");
+        totalTagRows.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Create_SixDistinctTags_Returns400TooManyTags()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new
+        {
+            title = "x",
+            tags = new[] { "a1", "a2", "a3", "a4", "a5", "a6" },
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("too_many_tags");
+    }
+
+    [Fact]
+    public async Task Create_InvalidTag_Returns400InvalidTag()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips", new
+        {
+            title = "x",
+            tags = new[] { "a" },
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_tag");
+    }
+
+    [Fact]
+    public async Task Create_ReusesExistingTagRow()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var first = await client.PostAsJsonAsync("/clips", new { title = "x", tags = new[] { "clutch" } });
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var second = await client.PostAsJsonAsync("/clips", new { title = "y", tags = new[] { "Clutch" } });
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = _fx.CreateContext();
+        var rows = await db.Tags.Where(t => t.Slug == "clutch").ToListAsync();
+        rows.Should().HaveCount(1);
+    }
+
+    // ---- PATCH /clips/{id} with tags ----
+
+    [Fact]
+    public async Task Patch_TagsOmitted_LeavesExistingSetUnchanged()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedReadyClipAsync(userId, "clutch", "ace");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "renamed" });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = _fx.CreateContext();
+        var slugs = await db.ClipTags.Where(ct => ct.ClipId == clipId)
+            .Select(ct => ct.Tag.Slug).ToListAsync();
+        slugs.Should().BeEquivalentTo(new[] { "clutch", "ace" });
+    }
+
+    [Fact]
+    public async Task Patch_EmptyTagsArray_ClearsAll()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedReadyClipAsync(userId, "clutch", "ace");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { tags = Array.Empty<string>() });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = _fx.CreateContext();
+        var count = await db.ClipTags.CountAsync(ct => ct.ClipId == clipId);
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Patch_ReplaceTags_DiffsAddAndRemove()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedReadyClipAsync(userId, "clutch", "ace");
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new
+        {
+            tags = new[] { "clutch", "fail" },
+        });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var responseSlugs = body.GetProperty("tags").EnumerateArray()
+            .Select(t => t.GetProperty("slug").GetString()).ToList();
+        responseSlugs.Should().Equal("clutch", "fail");
+
+        await using var db = _fx.CreateContext();
+        var slugs = await db.ClipTags.Where(ct => ct.ClipId == clipId)
+            .Select(ct => ct.Tag.Slug).ToListAsync();
+        slugs.Should().BeEquivalentTo(new[] { "clutch", "fail" });
+    }
+
+    [Fact]
+    public async Task Patch_TooManyTags_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedReadyClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new
+        {
+            tags = new[] { "a1", "a2", "a3", "a4", "a5", "a6" },
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("too_many_tags");
+    }
+
+    [Fact]
+    public async Task Patch_ResubmitSameTagSet_IsIdempotent_NoChurn()
+    {
+        // Guards against a future change to SetClipTags that would naively delete-then-reinsert
+        // the same rows on every PATCH. We pin behaviour by capturing the existing rows' identities
+        // (composite PK (ClipId, TagId)) before + after and asserting they're unchanged.
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedReadyClipAsync(userId, "clutch", "ace");
+        using var client = ClientWithBearer(token);
+
+        int[] tagIdsBefore;
+        await using (var db = _fx.CreateContext())
+        {
+            tagIdsBefore = await db.ClipTags.Where(ct => ct.ClipId == clipId)
+                .OrderBy(ct => ct.TagId).Select(ct => ct.TagId).ToArrayAsync();
+        }
+
+        // Submit the same set in a different order — server normalizes anyway.
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new
+        {
+            tags = new[] { "ace", "Clutch" },
+        });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var verify = _fx.CreateContext();
+        var tagIdsAfter = await verify.ClipTags.Where(ct => ct.ClipId == clipId)
+            .OrderBy(ct => ct.TagId).Select(ct => ct.TagId).ToArrayAsync();
+        tagIdsAfter.Should().Equal(tagIdsBefore);
+    }
+
+    [Fact]
+    public async Task Patch_TagsOmitted_DoesNotTouchClipTagsRows()
+    {
+        // Tighter version of Patch_TagsOmitted_LeavesExistingSetUnchanged: also asserts the
+        // resolver wasn't invoked on the tags collection (no delete-then-reinsert churn) by
+        // pinning the row identities — a regression that always called the resolver with
+        // (req.Tags ?? []) would clear the set and this would fail.
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedReadyClipAsync(userId, "clutch", "ace");
+        using var client = ClientWithBearer(token);
+
+        int[] tagIdsBefore;
+        await using (var db = _fx.CreateContext())
+        {
+            tagIdsBefore = await db.ClipTags.Where(ct => ct.ClipId == clipId)
+                .OrderBy(ct => ct.TagId).Select(ct => ct.TagId).ToArrayAsync();
+        }
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "renamed" });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var verify = _fx.CreateContext();
+        var tagIdsAfter = await verify.ClipTags.Where(ct => ct.ClipId == clipId)
+            .OrderBy(ct => ct.TagId).Select(ct => ct.TagId).ToArrayAsync();
+        tagIdsAfter.Should().Equal(tagIdsBefore);
+    }
+
+    [Fact]
+    public async Task Patch_InvalidTag_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedReadyClipAsync(userId);
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new
+        {
+            tags = new[] { "!!!" },
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_tag");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/TagsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/TagsEndpointsTests.cs
@@ -1,0 +1,227 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class TagsEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public TagsEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://minio.local/presigned");
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private async Task<Guid> SeedUserAsync(string username = "tags-test-user")
+    {
+        var (userId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+        return userId;
+    }
+
+    private async Task<(Guid id, string shareCode)> SeedClipAsync(
+        Guid userId,
+        DateTimeOffset createdAt,
+        string status = "ready",
+        string visibility = "public",
+        params string[] tagSlugs)
+    {
+        var id = Guid.NewGuid();
+        var shareCode = ShareCodeGenerator.Next();
+        await using var db = _fx.CreateContext();
+        var clip = new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = $"clip-{id:N}".Substring(0, 20),
+            VideoKey = $"{userId}/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = shareCode,
+            Status = status,
+            Visibility = visibility,
+            DurationSecs = 30,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        };
+        db.Clips.Add(clip);
+        foreach (var slug in tagSlugs)
+        {
+            var tag = await db.Tags.FirstOrDefaultAsync(t => t.Slug == slug)
+                ?? new Tag { Slug = slug, Name = slug, CreatedAt = createdAt };
+            if (tag.Id == 0)
+            {
+                db.Tags.Add(tag);
+                await db.SaveChangesAsync();
+            }
+            db.ClipTags.Add(new ClipTag { ClipId = id, TagId = tag.Id });
+        }
+        await db.SaveChangesAsync();
+        return (id, shareCode);
+    }
+
+    // ---- GET /tags ----
+
+    [Fact]
+    public async Task GetTags_OrdersByClipCountDescThenSlug()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var now = DateTimeOffset.UtcNow;
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "clutch", "ace" });
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "clutch" });
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "clutch" });
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "fail" });
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/tags");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var arr = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var rows = arr.EnumerateArray().Select(e => new
+        {
+            Slug = e.GetProperty("slug").GetString(),
+            Count = e.GetProperty("clipCount").GetInt32(),
+        }).ToList();
+        rows.Select(r => r.Slug).Should().Equal("clutch", "ace", "fail");
+        rows[0].Count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetTags_PrefixIsNormalized()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var now = DateTimeOffset.UtcNow;
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "clutch" });
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "cs2" });
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/tags?prefix=CLU");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var arr = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        arr.EnumerateArray().Select(e => e.GetProperty("slug").GetString())
+            .Should().ContainSingle().Which.Should().Be("clutch");
+    }
+
+    [Fact]
+    public async Task GetTags_NoAuthRequired()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/tags?prefix=clu");
+
+        resp.IsSuccessStatusCode.Should().BeTrue($"got {(int)resp.StatusCode}");
+    }
+
+    // ---- GET /tags/{slug} ----
+
+    [Fact]
+    public async Task GetBySlug_Returns200WithCount()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var now = DateTimeOffset.UtcNow;
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "clutch" });
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "clutch" });
+        await SeedClipAsync(userId, now, status: "processing", tagSlugs: new[] { "clutch" });
+        await SeedClipAsync(userId, now, visibility: "unlisted", tagSlugs: new[] { "clutch" });
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/tags/clutch");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("slug").GetString().Should().Be("clutch");
+        body.GetProperty("clipCount").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetBySlug_Unknown_Returns404()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/tags/does-not-exist");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ---- GET /tags/{slug}/clips ----
+
+    [Fact]
+    public async Task GetClipsForTag_FiltersByTagAndVisibility()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        var now = DateTimeOffset.UtcNow;
+        var (target1, _) = await SeedClipAsync(userId, now.AddMinutes(-1), tagSlugs: new[] { "clutch" });
+        var (target2, _) = await SeedClipAsync(userId, now.AddMinutes(-2), tagSlugs: new[] { "clutch", "ace" });
+        await SeedClipAsync(userId, now, tagSlugs: new[] { "fail" }); // different tag
+        await SeedClipAsync(userId, now, status: "processing", tagSlugs: new[] { "clutch" });
+        await SeedClipAsync(userId, now, visibility: "unlisted", tagSlugs: new[] { "clutch" });
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/tags/clutch/clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(target1, target2);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GetClipsForTag_ItemsIncludeTagsArray()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync();
+        await SeedClipAsync(userId, DateTimeOffset.UtcNow, tagSlugs: new[] { "clutch", "ace" });
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/tags/clutch/clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var first = body.GetProperty("items").EnumerateArray().First();
+        var tags = first.GetProperty("tags").EnumerateArray()
+            .Select(t => t.GetProperty("slug").GetString())
+            .ToList();
+        // Mapper sorts by slug.
+        tags.Should().Equal("ace", "clutch");
+    }
+
+    [Fact]
+    public async Task GetClipsForTag_UnknownSlug_Returns404()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/tags/does-not-exist/clips");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Tags/TagNormalizationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Tags/TagNormalizationTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using GankedTV.Api.Services.Tags;
+
+namespace GankedTV.Api.Tests.Services.Tags;
+
+public class TagNormalizationTests
+{
+    [Theory]
+    [InlineData("clutch", "clutch")]
+    [InlineData("Clutch", "clutch")]
+    [InlineData("CLUTCH", "clutch")]
+    [InlineData("  clutch  ", "clutch")]
+    [InlineData("clutch-play", "clutch-play")]
+    [InlineData("clutch play", "clutch-play")]
+    [InlineData("clutch_play", "clutch-play")]
+    [InlineData("clutch   play", "clutch-play")]
+    [InlineData("clutch--play", "clutch-play")]
+    [InlineData("--clutch--", "clutch")]
+    [InlineData("c2", "c2")]
+    [InlineData("éclair", "clair")] // accented chars stripped
+    [InlineData("ace 🎯", "ace")]
+    public void TryNormalize_ValidInputs_ProducesCanonicalSlug(string raw, string expected)
+    {
+        TagNormalization.TryNormalize(raw, out var slug).Should().BeTrue();
+        slug.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("   ")]
+    [InlineData("a")]
+    [InlineData("-")]
+    [InlineData("--")]
+    [InlineData("!!!")]
+    public void TryNormalize_RejectsEmptyOrTooShort(string? raw)
+    {
+        TagNormalization.TryNormalize(raw, out var slug).Should().BeFalse();
+        slug.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryNormalize_RejectsTooLong()
+    {
+        var raw = new string('a', TagNormalization.MaxLength + 1);
+        TagNormalization.TryNormalize(raw, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryNormalize_AtMaxLength_Accepts()
+    {
+        var raw = new string('a', TagNormalization.MaxLength);
+        TagNormalization.TryNormalize(raw, out var slug).Should().BeTrue();
+        slug.Should().HaveLength(TagNormalization.MaxLength);
+    }
+
+    [Theory]
+    [InlineData("c", "c")]
+    [InlineData("Clu", "clu")]
+    [InlineData("clutch-pl", "clutch-pl")]
+    [InlineData("  ", null)]
+    [InlineData(null, null)]
+    [InlineData("!!!", null)]
+    [InlineData("ABCdef-09", "abcdef-09")]
+    public void NormalizePrefix_LowercasesAndStripsInvalid(string? raw, string? expected)
+    {
+        TagNormalization.NormalizePrefix(raw).Should().Be(expected);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Tags/TagNormalizationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Tags/TagNormalizationTests.cs
@@ -62,6 +62,15 @@ public class TagNormalizationTests
     [InlineData(null, null)]
     [InlineData("!!!", null)]
     [InlineData("ABCdef-09", "abcdef-09")]
+    // Whitespace and underscores map to '-' so the prefix matches the stored slug
+    // shape — "league of" finds rows with slug "league-of" instead of looking for
+    // the impossible "leagueof".
+    [InlineData("league of", "league-of")]
+    [InlineData("league_of", "league-of")]
+    [InlineData("League Of", "league-of")]
+    [InlineData("  spaced  ", "spaced")]
+    [InlineData("a--b", "a-b")]
+    [InlineData("-clutch-", "clutch")]
     public void NormalizePrefix_LowercasesAndStripsInvalid(string? raw, string? expected)
     {
         TagNormalization.NormalizePrefix(raw).Should().Be(expected);

--- a/server/tests/GankedTV.Api.Tests/Services/Tags/TagsResolverTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Tags/TagsResolverTests.cs
@@ -1,0 +1,198 @@
+using FluentAssertions;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Tags;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Tests.Services.Tags;
+
+[Collection("Postgres")]
+public class TagsResolverTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+
+    public TagsResolverTests(PostgresFixture fx) => _fx = fx;
+
+    public async Task InitializeAsync() => await _fx.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private TagsResolver CreateResolver(out GankedTvDbContext db)
+    {
+        db = _fx.CreateContext();
+        return new TagsResolver(db, TimeProvider.System);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_EmptyList_ReturnsEmpty()
+    {
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        var result = await resolver.ResolveAsync([], default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CreatesNewTagsAndReturnsThem()
+    {
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        var result = await resolver.ResolveAsync(["clutch", "ace"], default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Tags.Should().HaveCount(2);
+        result.Tags.Select(t => t.Slug).Should().Equal("clutch", "ace");
+
+        var stored = await db.Tags.ToListAsync();
+        stored.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ReusesExistingTagsBySlug()
+    {
+        // Pre-seed "clutch" via one resolver instance.
+        {
+            var resolver = CreateResolver(out var db);
+            await using (db)
+            {
+                await resolver.ResolveAsync(["clutch"], default);
+            }
+        }
+
+        var resolver2 = CreateResolver(out var db2);
+        await using (db2)
+        {
+            var result = await resolver2.ResolveAsync(["Clutch", "ace"], default);
+            result.IsSuccess.Should().BeTrue();
+            result.Tags.Select(t => t.Slug).Should().Equal("clutch", "ace");
+        }
+
+        // No duplicate clutch row.
+        await using var verify = _fx.CreateContext();
+        var stored = await verify.Tags.Where(t => t.Slug == "clutch").ToListAsync();
+        stored.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NormalizesAndDedupesWithinRequest()
+    {
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        var result = await resolver.ResolveAsync(["Clutch", "clutch", "CLUTCH", "ace"], default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Tags.Select(t => t.Slug).Should().Equal("clutch", "ace");
+
+        var stored = await db.Tags.ToListAsync();
+        stored.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SixDistinctTags_ReturnsTooManyTags()
+    {
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        var result = await resolver.ResolveAsync(["a1", "a2", "a3", "a4", "a5", "a6"], default);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(TagsResolveError.TooManyTags);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SixDuplicates_IsAcceptedAfterDedupe()
+    {
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        // After dedupe this is one tag, not six.
+        var result = await resolver.ResolveAsync(["clutch", "clutch", "clutch", "clutch", "clutch", "clutch"], default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Tags.Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("!!!")]
+    public async Task ResolveAsync_InvalidTag_ReturnsInvalidTag(string raw)
+    {
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        var result = await resolver.ResolveAsync([raw], default);
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(TagsResolveError.InvalidTag);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WhitespaceInRaw_NormalizesToHyphenSlug()
+    {
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        var result = await resolver.ResolveAsync(["With Space"], default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Tags.Single().Slug.Should().Be("with-space");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ConcurrentInsertVisibleToFreshResolver_NoRowChurn()
+    {
+        // Adjacent-test for the unique-violation retry path: if a sibling context inserted
+        // "clutch" before our resolver runs its SELECT, the resolver should pick up the
+        // existing row (no INSERT attempted, no conflict). Pins the happy concurrent case.
+        // The true SELECT-then-conflict-then-retry path can't be driven deterministically
+        // from a single xUnit test thread (DbContext isn't thread-safe and we can't pause
+        // SaveChanges mid-flight), but the retry code is small and self-contained.
+        await using (var sibling = _fx.CreateContext())
+        {
+            sibling.Tags.Add(new Tag { Slug = "clutch", Name = "clutch", CreatedAt = DateTimeOffset.UtcNow });
+            await sibling.SaveChangesAsync();
+        }
+
+        var resolver = CreateResolver(out var db);
+        await using var _ = db;
+
+        var result = await resolver.ResolveAsync(["Clutch"], default);
+        result.IsSuccess.Should().BeTrue();
+        result.Tags.Single().Slug.Should().Be("clutch");
+
+        await using var verify = _fx.CreateContext();
+        (await verify.Tags.CountAsync(t => t.Slug == "clutch")).Should().Be(1);
+    }
+
+    [Fact]
+    public void SetClipTags_DiffsAddsAndRemoves()
+    {
+        var resolver = CreateResolver(out var db);
+        using var _ = db;
+
+        var clip = new Clip
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Title = "x",
+            VideoKey = "k",
+            ShareCode = "abcabc",
+        };
+        var existingA = new Tag { Id = 100, Slug = "a", Name = "a" };
+        var existingB = new Tag { Id = 200, Slug = "b", Name = "b" };
+        clip.ClipTags.Add(new ClipTag { ClipId = clip.Id, TagId = existingA.Id, Tag = existingA });
+        clip.ClipTags.Add(new ClipTag { ClipId = clip.Id, TagId = existingB.Id, Tag = existingB });
+
+        var newC = new Tag { Id = 300, Slug = "c", Name = "c" };
+        resolver.SetClipTags(clip, [existingA, newC]);
+
+        // existingB is removed, newC added, existingA kept.
+        clip.ClipTags.Select(ct => ct.TagId).Should().BeEquivalentTo(new[] { 100, 300 });
+    }
+}

--- a/web/src/api/__tests__/tags.spec.ts
+++ b/web/src/api/__tests__/tags.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { tags } from '../tags'
+import { configureAuth, BASE_URL } from '../client'
+
+beforeEach(() => {
+  configureAuth({
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    onTokenRefreshed: () => {},
+    onRefreshFailed: () => {},
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('api/tags', () => {
+  describe('autocomplete()', () => {
+    it('GETs /tags?prefix=… and returns the parsed list', async () => {
+      const payload = [{ id: 1, slug: 'clutch', name: 'clutch', clipCount: 12 }]
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(payload)),
+      )
+
+      const result = await tags.autocomplete('clu')
+
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/tags?prefix=clu`)
+    })
+
+    it('URL-encodes the prefix', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse([])),
+      )
+
+      await tags.autocomplete('clu tch')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      // URLSearchParams encodes space as '+'.
+      expect(url).toContain('prefix=clu+tch')
+    })
+
+    it('passes through a limit', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse([])),
+      )
+
+      await tags.autocomplete('c', 5)
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('limit=5')
+    })
+
+    it('omits prefix from the query string when empty', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse([])),
+      )
+
+      await tags.autocomplete('')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      // Either '/tags' (no qs) or '/tags?' is acceptable — both ignore an empty prefix.
+      expect(url.startsWith(`${BASE_URL}/tags`)).toBe(true)
+      expect(url).not.toContain('prefix=')
+    })
+  })
+
+  describe('getBySlug()', () => {
+    it('GETs /tags/{slug} with the encoded slug', async () => {
+      const payload = { id: 1, slug: 'clutch', name: 'clutch', clipCount: 5 }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(payload)),
+      )
+
+      const result = await tags.getBySlug('clutch')
+
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/tags/clutch`)
+    })
+
+    it('throws ApiError on 404', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ code: 'not_found' }, 404)),
+      )
+
+      await expect(tags.getBySlug('does-not-exist')).rejects.toMatchObject({ status: 404 })
+    })
+  })
+
+  describe('clips()', () => {
+    it('GETs /tags/{slug}/clips and parses the page', async () => {
+      const payload = { items: [], nextCursor: null }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(payload)),
+      )
+
+      const result = await tags.clips('clutch')
+
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/tags/clutch/clips`)
+    })
+
+    it('passes cursor and limit through', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await tags.clips('clutch', { cursor: 'abc=', limit: 5 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('cursor=abc%3D')
+      expect(url).toContain('limit=5')
+    })
+  })
+})

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -1,4 +1,5 @@
 import { api } from './client'
+import type { TagSummary } from './tags'
 
 export interface AuthorSummary {
   id: string
@@ -26,6 +27,7 @@ export interface ClipFeedItem {
   createdAt: string
   author: AuthorSummary
   game: GameSummary | null
+  tags: TagSummary[]
   likedByMe: boolean
   shareCode: string
 }
@@ -45,6 +47,7 @@ export interface ClipDetail {
   createdAt: string
   author: AuthorSummary
   game: GameSummary | null
+  tags: TagSummary[]
   likedByMe: boolean
   visibility: 'public' | 'unlisted'
   shareCode: string
@@ -55,6 +58,9 @@ export interface UpdateClipBody {
   description?: string
   gameId?: number | null
   visibility?: 'public' | 'unlisted'
+  // null/omitted = "leave tags alone". Empty array = "clear all tags".
+  // Otherwise = "replace the tag set with this exact list (post-normalization server-side)".
+  tags?: string[]
 }
 
 export interface ClipFeedPage {
@@ -81,6 +87,9 @@ export interface CreateClipBody {
   description: string | null
   gameId: number | null
   visibility: 'public' | 'unlisted'
+  // Optional. When omitted, the clip has no tags. Server normalizes (lowercase,
+  // hyphenate, max 5) and get-or-creates rows by slug.
+  tags?: string[]
 }
 
 export interface CompleteClipResult {

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -58,8 +58,8 @@ export interface UpdateClipBody {
   description?: string
   gameId?: number | null
   visibility?: 'public' | 'unlisted'
-  // null/omitted = "leave tags alone". Empty array = "clear all tags".
-  // Otherwise = "replace the tag set with this exact list (post-normalization server-side)".
+  // Omitted = leave tags unchanged. Empty array = clear all tags. Otherwise =
+  // replace the tag set with this exact list (post-normalization server-side).
   tags?: string[]
 }
 

--- a/web/src/api/tags.ts
+++ b/web/src/api/tags.ts
@@ -1,0 +1,42 @@
+import { api } from './client'
+import type { ClipFeedPage, ClipFeedQuery } from './clips'
+
+export interface TagSummary {
+  id: number
+  slug: string
+  name: string
+  // 0 when nested under a clip; populated by GET /tags (autocomplete).
+  clipCount: number
+}
+
+export interface TagDetail {
+  id: number
+  slug: string
+  name: string
+  clipCount: number
+}
+
+export const tags = {
+  // Autocomplete dropdown source. Prefix is sent as-is — the server normalizes
+  // (lowercases, strips invalid chars) before LIKE-matching, so the client can pass
+  // the user's literal keystrokes without local preprocessing.
+  autocomplete(prefix: string, limit?: number): Promise<TagSummary[]> {
+    const params = new URLSearchParams()
+    if (prefix) params.set('prefix', prefix)
+    if (limit !== undefined) params.set('limit', String(limit))
+    const qs = params.toString()
+    return api<TagSummary[]>(`/tags${qs ? `?${qs}` : ''}`)
+  },
+
+  getBySlug(slug: string): Promise<TagDetail> {
+    return api<TagDetail>(`/tags/${encodeURIComponent(slug)}`)
+  },
+
+  clips(slug: string, query: ClipFeedQuery = {}): Promise<ClipFeedPage> {
+    const params = new URLSearchParams()
+    if (query.cursor) params.set('cursor', query.cursor)
+    if (query.limit !== undefined) params.set('limit', String(query.limit))
+    const qs = params.toString()
+    return api<ClipFeedPage>(`/tags/${encodeURIComponent(slug)}/clips${qs ? `?${qs}` : ''}`)
+  },
+}

--- a/web/src/components/ClipCard.vue
+++ b/web/src/components/ClipCard.vue
@@ -75,12 +75,16 @@ function onKeydown(e: KeyboardEvent) {
       <!-- Tag row: up to 3 chips + "+N" overflow indicator. Hidden when the
            clip has no tags so cards without tags don't grow a blank row. The
            overflow chip is a plain span — it isn't a link to any tag in
-           particular, just a visual cue that more exist on the detail page. -->
+           particular, just a visual cue that more exist on the detail page.
+           Both elements .stop the click so the chip area doesn't double as a
+           card-click target (TagChip's internal RouterLink also .stops, but
+           the redundancy makes the contract obvious from this template). -->
       <div v-if="clip.tags.length" class="flex flex-wrap gap-1.5">
-        <TagChip v-for="t in visibleTags" :key="t.id" :slug="t.slug" :name="t.name" />
+        <TagChip v-for="t in visibleTags" :key="t.id" :slug="t.slug" :name="t.name" @click.stop />
         <span
           v-if="overflowCount > 0"
           class="rounded-[3px] border border-border-strong bg-surface-base px-1.5 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.06em] text-text-muted"
+          @click.stop
         >
           +{{ overflowCount }}
         </span>

--- a/web/src/components/ClipCard.vue
+++ b/web/src/components/ClipCard.vue
@@ -1,17 +1,24 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { ClipFeedItem } from '@/api/clips'
 import { formatNum, formatRelativeTime } from '@/lib/format'
 import UserAvatar from './UserAvatar.vue'
 import GameTag from './GameTag.vue'
 import DurationBadge from './DurationBadge.vue'
 import AuthorHandle from './AuthorHandle.vue'
+import TagChip from './TagChip.vue'
 import IconHeart from './icons/IconHeart.vue'
 import IconEye from './icons/IconEye.vue'
+
+const MAX_VISIBLE_TAGS = 3
 
 const props = withDefaults(defineProps<{ clip: ClipFeedItem; showAuthor?: boolean }>(), {
   showAuthor: true,
 })
 const emit = defineEmits<{ click: [] }>()
+
+const visibleTags = computed(() => props.clip.tags.slice(0, MAX_VISIBLE_TAGS))
+const overflowCount = computed(() => Math.max(0, props.clip.tags.length - MAX_VISIBLE_TAGS))
 
 function onKeydown(e: KeyboardEvent) {
   if (e.key === 'Enter' || e.key === ' ') {
@@ -64,6 +71,20 @@ function onKeydown(e: KeyboardEvent) {
       >
         {{ clip.title }}
       </h3>
+
+      <!-- Tag row: up to 3 chips + "+N" overflow indicator. Hidden when the
+           clip has no tags so cards without tags don't grow a blank row. The
+           overflow chip is a plain span — it isn't a link to any tag in
+           particular, just a visual cue that more exist on the detail page. -->
+      <div v-if="clip.tags.length" class="flex flex-wrap gap-1.5">
+        <TagChip v-for="t in visibleTags" :key="t.id" :slug="t.slug" :name="t.name" />
+        <span
+          v-if="overflowCount > 0"
+          class="rounded-[3px] border border-border-strong bg-surface-base px-1.5 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.06em] text-text-muted"
+        >
+          +{{ overflowCount }}
+        </span>
+      </div>
 
       <div
         v-if="showAuthor"

--- a/web/src/components/ClipEditDialog.vue
+++ b/web/src/components/ClipEditDialog.vue
@@ -3,6 +3,7 @@ import { ref, watch, computed, onMounted, onUnmounted } from 'vue'
 import { ApiError } from '@/api/client'
 import { clips, type ClipDetail, type UpdateClipBody, type GameSummary } from '@/api/clips'
 import GameSelector from '@/components/GameSelector.vue'
+import TagInput from '@/components/TagInput.vue'
 import IconGlobe from '@/components/icons/IconGlobe.vue'
 import IconLink from '@/components/icons/IconLink.vue'
 
@@ -17,6 +18,7 @@ const localTitle = ref(props.clip.title)
 const localDesc = ref(props.clip.description ?? '')
 const localGame = ref<GameSummary | null>(props.clip.game)
 const localVisibility = ref<'public' | 'unlisted'>(props.clip.visibility)
+const localTags = ref<string[]>(props.clip.tags.map((t) => t.slug))
 const submitting = ref(false)
 
 watch(
@@ -27,10 +29,19 @@ watch(
       localDesc.value = props.clip.description ?? ''
       localGame.value = props.clip.game
       localVisibility.value = props.clip.visibility
+      localTags.value = props.clip.tags.map((t) => t.slug)
       submitting.value = false
     }
   },
 )
+
+function arraysEqualSorted(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = [...a].sort()
+  const sb = [...b].sort()
+  for (let i = 0; i < sa.length; i++) if (sa[i] !== sb[i]) return false
+  return true
+}
 
 function onKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape' && props.open) emit('close')
@@ -52,6 +63,10 @@ const diff = computed((): UpdateClipBody => {
   if ((localGame.value?.id ?? null) !== (props.clip.game?.id ?? null))
     body.gameId = localGame.value?.id ?? null
   if (localVisibility.value !== props.clip.visibility) body.visibility = localVisibility.value
+  const originalTagSlugs = props.clip.tags.map((t) => t.slug)
+  if (!arraysEqualSorted(localTags.value, originalTagSlugs)) {
+    body.tags = [...localTags.value]
+  }
   return body
 })
 
@@ -67,6 +82,8 @@ const ERROR_CODES: Record<string, string> = {
   forbidden: "You don't have permission to edit this clip",
   not_found: 'Clip not found',
   invalid_state: 'Only published clips can be edited',
+  too_many_tags: 'You can use up to 5 tags',
+  invalid_tag: 'One of your tags is invalid (use 2-24 letters, digits or hyphens)',
 }
 
 async function save() {
@@ -175,6 +192,14 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
                 Game <span class="text-[9px] text-text-muted">(optional)</span>
               </label>
               <GameSelector v-model="localGame" />
+            </div>
+
+            <!-- Tags -->
+            <div>
+              <label :class="labelClass">
+                Tags <span class="text-[9px] text-text-muted">(optional, max 5)</span>
+              </label>
+              <TagInput v-model="localTags" :input-class="inputClass" />
             </div>
 
             <!-- Visibility -->

--- a/web/src/components/TagChip.vue
+++ b/web/src/components/TagChip.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+// Display-only tag chip — clicking navigates to /tag/:slug. Modeled on GameTag.vue
+// pill variant but renders as a RouterLink so card clicks don't trigger clip
+// navigation (we stopPropagation the link click in the parent template).
+//
+// Use `interactive=false` for non-linking variants (e.g. the "+N" overflow chip
+// or read-only previews) to render a plain <span> with identical typography.
+
+withDefaults(
+  defineProps<{
+    slug: string
+    name: string
+    size?: 'sm' | 'md'
+    interactive?: boolean
+  }>(),
+  { interactive: true },
+)
+</script>
+
+<template>
+  <RouterLink
+    v-if="interactive"
+    :to="{ name: 'tag-detail', params: { slug } }"
+    :aria-label="`Browse #${slug}`"
+    class="rounded-[3px] border border-border-strong bg-surface-base font-mono font-medium uppercase tracking-[0.06em] text-text-primary outline-none transition-colors duration-150 hover:border-brand-light hover:text-text-primary focus-visible:ring-2 focus-visible:ring-brand"
+    :class="
+      size === 'md' ? 'px-2.5 py-1 text-[10px] tracking-[0.08em]' : 'px-1.5 py-0.5 text-[10px]'
+    "
+    @click.stop
+    @keydown.enter.stop
+    @keydown.space.prevent.stop
+  >
+    #{{ name }}
+  </RouterLink>
+  <span
+    v-else
+    class="rounded-[3px] border border-border-strong bg-surface-base font-mono font-medium uppercase tracking-[0.06em] text-text-muted"
+    :class="
+      size === 'md' ? 'px-2.5 py-1 text-[10px] tracking-[0.08em]' : 'px-1.5 py-0.5 text-[10px]'
+    "
+  >
+    {{ name }}
+  </span>
+</template>

--- a/web/src/components/TagInput.vue
+++ b/web/src/components/TagInput.vue
@@ -1,0 +1,271 @@
+<script setup lang="ts">
+// Chip-style tag input. v-model:tags is an array of normalized slug strings.
+//
+// Commit: comma, space, or Enter commit the current draft. Backspace at an
+// empty draft pops the last chip (matches every chat/email composer).
+//
+// Normalization mirrors TagNormalization on the server: lowercase, replace
+// whitespace/underscores with '-', strip anything outside [a-z0-9-], collapse
+// repeated hyphens, length in [2, 24]. The server re-normalizes too — this is
+// purely for instant feedback.
+//
+// Autocomplete: typing fires a debounced GET /tags?prefix=… with the *raw*
+// (non-normalized) draft, and the dropdown ranks results by clipCount. Picking
+// a result commits the canonical slug. ArrowUp/Down navigate, Enter selects
+// the highlighted row (or commits the draft if none is highlighted).
+import { ref, computed, onUnmounted, nextTick, useId, watch } from 'vue'
+import { tags as tagsApi, type TagSummary } from '@/api/tags'
+
+const props = defineProps<{
+  modelValue: string[]
+  max?: number
+  inputClass?: string
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [value: string[]] }>()
+
+const MAX_TAGS_DEFAULT = 5
+const MIN_LEN = 2
+const MAX_LEN = 24
+
+const max = computed(() => props.max ?? MAX_TAGS_DEFAULT)
+const isFull = computed(() => props.modelValue.length >= max.value)
+
+const draft = ref('')
+const results = ref<TagSummary[]>([])
+const showDropdown = ref(false)
+const highlightedIndex = ref(-1)
+const inputEl = ref<HTMLInputElement | null>(null)
+
+// IDs for the listbox + active option wiring. useId() guarantees uniqueness across
+// multiple TagInputs on the same page (e.g. upload form + a future filter sidebar).
+const listboxId = useId()
+const optionId = (i: number) => `${listboxId}-opt-${i}`
+const activeDescendantId = computed(() =>
+  showDropdown.value && highlightedIndex.value >= 0 ? optionId(highlightedIndex.value) : undefined,
+)
+
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+let blurTimer: ReturnType<typeof setTimeout> | null = null
+let lastQuery = ''
+
+// Same algorithm as the server's TagNormalization.TryNormalize. Returns null for
+// inputs that don't yield a valid slug.
+function normalize(raw: string): string | null {
+  if (!raw) return null
+  const out: string[] = []
+  let lastWasHyphen = false
+  for (const ch of raw) {
+    const code = ch.charCodeAt(0)
+    const isLower = code >= 97 && code <= 122
+    const isUpper = code >= 65 && code <= 90
+    const isDigit = code >= 48 && code <= 57
+    if (isLower || isDigit) {
+      out.push(ch)
+      lastWasHyphen = false
+    } else if (isUpper) {
+      out.push(String.fromCharCode(code + 32))
+      lastWasHyphen = false
+    } else if (ch === '-' || ch === '_' || /\s/.test(ch)) {
+      if (out.length === 0 || lastWasHyphen) continue
+      out.push('-')
+      lastWasHyphen = true
+    }
+  }
+  if (out.length > 0 && out[out.length - 1] === '-') out.pop()
+  const slug = out.join('')
+  if (slug.length < MIN_LEN || slug.length > MAX_LEN) return null
+  return slug
+}
+
+function commit(rawOrSlug: string) {
+  const slug = normalize(rawOrSlug)
+  if (!slug) return false
+  if (props.modelValue.includes(slug)) {
+    draft.value = ''
+    return false
+  }
+  if (isFull.value) return false
+  emit('update:modelValue', [...props.modelValue, slug])
+  draft.value = ''
+  results.value = []
+  showDropdown.value = false
+  highlightedIndex.value = -1
+  return true
+}
+
+function removeAt(index: number) {
+  const next = props.modelValue.slice()
+  next.splice(index, 1)
+  emit('update:modelValue', next)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'ArrowDown' && results.value.length > 0) {
+    e.preventDefault()
+    showDropdown.value = true
+    highlightedIndex.value = Math.min(highlightedIndex.value + 1, results.value.length - 1)
+    return
+  }
+  if (e.key === 'ArrowUp' && results.value.length > 0) {
+    e.preventDefault()
+    highlightedIndex.value = Math.max(highlightedIndex.value - 1, -1)
+    return
+  }
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    if (highlightedIndex.value >= 0 && results.value[highlightedIndex.value]) {
+      commit(results.value[highlightedIndex.value].slug)
+    } else if (draft.value) {
+      commit(draft.value)
+    }
+    return
+  }
+  if (e.key === ',' || e.key === ' ') {
+    if (draft.value.trim()) {
+      e.preventDefault()
+      commit(draft.value)
+    }
+    return
+  }
+  if (e.key === 'Backspace' && draft.value === '' && props.modelValue.length > 0) {
+    removeAt(props.modelValue.length - 1)
+    return
+  }
+  if (e.key === 'Escape') {
+    showDropdown.value = false
+    highlightedIndex.value = -1
+  }
+}
+
+watch(draft, (q) => {
+  if (searchTimer) clearTimeout(searchTimer)
+  const trimmed = q.trim()
+  if (!trimmed) {
+    results.value = []
+    showDropdown.value = false
+    highlightedIndex.value = -1
+    return
+  }
+  searchTimer = setTimeout(async () => {
+    const queryAtCall = trimmed
+    lastQuery = queryAtCall
+    try {
+      const rows = await tagsApi.autocomplete(queryAtCall, 8)
+      if (lastQuery !== queryAtCall) return
+      // Hide already-chosen tags so the user can't pick them twice from the dropdown.
+      results.value = rows.filter((r) => !props.modelValue.includes(r.slug))
+      showDropdown.value = results.value.length > 0
+      highlightedIndex.value = -1
+    } catch {
+      if (lastQuery !== queryAtCall) return
+      results.value = []
+      showDropdown.value = false
+    }
+  }, 150)
+})
+
+function onInputBlur() {
+  // Delay so a mousedown on a dropdown row registers before we hide it.
+  if (blurTimer) clearTimeout(blurTimer)
+  blurTimer = setTimeout(() => {
+    showDropdown.value = false
+    blurTimer = null
+  }, 150)
+}
+
+function focusInput() {
+  nextTick(() => inputEl.value?.focus())
+}
+
+onUnmounted(() => {
+  if (searchTimer) clearTimeout(searchTimer)
+  if (blurTimer) clearTimeout(blurTimer)
+})
+
+const resolvedInputClass = computed(
+  () =>
+    props.inputClass ??
+    'w-full rounded-md border border-border bg-surface-raised px-3.5 py-3 font-body text-sm text-text-primary outline-none',
+)
+</script>
+
+<template>
+  <div>
+    <div class="flex flex-wrap items-center gap-2">
+      <span
+        v-for="(slug, i) in props.modelValue"
+        :key="slug"
+        class="inline-flex items-center gap-1.5 rounded-[3px] border border-border-strong bg-surface-base px-2 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.06em] text-text-primary"
+      >
+        #{{ slug }}
+        <button
+          type="button"
+          :aria-label="`Remove tag ${slug}`"
+          class="cursor-pointer leading-none text-text-muted transition-colors duration-150 hover:text-text-primary"
+          @click="
+            () => {
+              removeAt(i)
+              focusInput()
+            }
+          "
+        >
+          ×
+        </button>
+      </span>
+      <div class="relative min-w-40 flex-1">
+        <input
+          ref="inputEl"
+          v-model="draft"
+          type="text"
+          autocomplete="off"
+          spellcheck="false"
+          :maxlength="MAX_LEN"
+          :disabled="isFull"
+          :placeholder="
+            isFull
+              ? `Max ${max} tags`
+              : props.modelValue.length === 0
+                ? 'add a tag…'
+                : 'add another…'
+          "
+          :class="resolvedInputClass"
+          role="combobox"
+          :aria-expanded="showDropdown && results.length > 0"
+          :aria-controls="listboxId"
+          :aria-activedescendant="activeDescendantId"
+          aria-autocomplete="list"
+          @keydown="onKeydown"
+          @focus="showDropdown = results.length > 0"
+          @blur="onInputBlur"
+        />
+        <ul
+          v-if="showDropdown && results.length"
+          :id="listboxId"
+          role="listbox"
+          class="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-md border border-border-strong bg-surface-raised"
+        >
+          <li
+            v-for="(r, i) in results"
+            :id="optionId(i)"
+            :key="r.id"
+            role="option"
+            :aria-selected="i === highlightedIndex"
+            class="flex cursor-pointer items-center justify-between gap-3 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.06em] text-text-primary transition-colors duration-150 hover:bg-surface-overlay"
+            :class="i === highlightedIndex ? 'bg-surface-overlay' : ''"
+            @mousedown.prevent="commit(r.slug)"
+          >
+            <span>#{{ r.name }}</span>
+            <span class="text-[10px] text-text-muted">{{ r.clipCount }}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <p
+      v-if="props.modelValue.length > 0 || draft.length > 0"
+      class="mt-1.5 font-mono text-[10px] uppercase tracking-widest text-text-muted"
+    >
+      {{ props.modelValue.length }} / {{ max }} — comma, space or enter to add
+    </p>
+  </div>
+</template>

--- a/web/src/components/TagInput.vue
+++ b/web/src/components/TagInput.vue
@@ -142,6 +142,10 @@ watch(draft, (q) => {
   if (searchTimer) clearTimeout(searchTimer)
   const trimmed = q.trim()
   if (!trimmed) {
+    // Invalidate lastQuery so any in-flight autocomplete response that started
+    // before this clear can't pass the `lastQuery !== queryAtCall` guard below
+    // and re-open the dropdown after the user has emptied the draft.
+    lastQuery = ''
     results.value = []
     showDropdown.value = false
     highlightedIndex.value = -1

--- a/web/src/components/__tests__/ClipCard.spec.ts
+++ b/web/src/components/__tests__/ClipCard.spec.ts
@@ -15,6 +15,11 @@ function makeRouter() {
         name: 'game-detail',
         component: defineComponent({ render: () => h('div') }),
       },
+      {
+        path: '/tag/:slug',
+        name: 'tag-detail',
+        component: defineComponent({ render: () => h('div') }),
+      },
     ],
   })
 }
@@ -31,6 +36,7 @@ function makeClip(overrides: Partial<ClipFeedItem> = {}): ClipFeedItem {
     createdAt: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
     author: { id: 'u1', username: 'phantomveil', avatarUrl: null },
     game: { id: 1, name: 'Valorant', slug: 'valorant', tag: 'VALORANT' },
+    tags: [],
     likedByMe: false,
     shareCode: 'testcode',
     ...overrides,
@@ -118,5 +124,48 @@ describe('ClipCard', () => {
     })
     await wrapper.find('a').trigger('click')
     expect(wrapper.emitted('click')).toBeFalsy()
+  })
+
+  it('renders tag chips for the first 3 tags as /tag/:slug links', () => {
+    const tags = [
+      { id: 1, slug: 'clutch', name: 'clutch', clipCount: 0 },
+      { id: 2, slug: 'ace', name: 'ace', clipCount: 0 },
+      { id: 3, slug: 'fail', name: 'fail', clipCount: 0 },
+    ]
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip({ tags }) },
+      global: { plugins: [makeRouter()] },
+    })
+    const hrefs = wrapper.findAll('a').map((a) => a.attributes('href'))
+    expect(hrefs).toContain('/tag/clutch')
+    expect(hrefs).toContain('/tag/ace')
+    expect(hrefs).toContain('/tag/fail')
+  })
+
+  it('renders +N overflow indicator when there are more than 3 tags', () => {
+    const tags = [
+      { id: 1, slug: 'a', name: 'a', clipCount: 0 },
+      { id: 2, slug: 'b', name: 'b', clipCount: 0 },
+      { id: 3, slug: 'c', name: 'c', clipCount: 0 },
+      { id: 4, slug: 'd', name: 'd', clipCount: 0 },
+      { id: 5, slug: 'e', name: 'e', clipCount: 0 },
+    ]
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip({ tags }) },
+      global: { plugins: [makeRouter()] },
+    })
+    expect(wrapper.text()).toContain('+2')
+    // The +N chip is a non-link span — only 4 anchors total (game + 3 tags).
+    const tagLinks = wrapper.findAll('a').filter((a) => a.attributes('href')?.startsWith('/tag/'))
+    expect(tagLinks.length).toBe(3)
+  })
+
+  it('omits the tag row when the clip has no tags', () => {
+    const wrapper = mount(ClipCard, {
+      props: { clip: makeClip({ tags: [] }) },
+      global: { plugins: [makeRouter()] },
+    })
+    const tagLinks = wrapper.findAll('a').filter((a) => a.attributes('href')?.startsWith('/tag/'))
+    expect(tagLinks.length).toBe(0)
   })
 })

--- a/web/src/components/__tests__/TagChip.spec.ts
+++ b/web/src/components/__tests__/TagChip.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { defineComponent, h } from 'vue'
+import TagChip from '../TagChip.vue'
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: defineComponent({ render: () => h('div') }) },
+      {
+        path: '/tag/:slug',
+        name: 'tag-detail',
+        component: defineComponent({ render: () => h('div') }),
+      },
+    ],
+  })
+}
+
+describe('TagChip', () => {
+  it('renders as a RouterLink to /tag/:slug by default', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+    const wrapper = mount(TagChip, {
+      props: { slug: 'clutch', name: 'clutch' },
+      global: { plugins: [router] },
+    })
+    const link = wrapper.find('a')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBe('/tag/clutch')
+    expect(link.text()).toContain('clutch')
+  })
+
+  it('renders a non-link span when interactive=false', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+    const wrapper = mount(TagChip, {
+      props: { slug: 'clutch', name: '+2', interactive: false },
+      global: { plugins: [router] },
+    })
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.find('span').text()).toBe('+2')
+  })
+
+  it('encodes the slug into the route', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+    const wrapper = mount(TagChip, {
+      props: { slug: 'with-hyphen', name: 'with-hyphen' },
+      global: { plugins: [router] },
+    })
+    expect(wrapper.find('a').attributes('href')).toBe('/tag/with-hyphen')
+  })
+})

--- a/web/src/components/__tests__/TagInput.spec.ts
+++ b/web/src/components/__tests__/TagInput.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import TagInput from '../TagInput.vue'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function mountInput(initial: string[] = []) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => jsonResponse([])),
+  )
+  return mount(TagInput, { props: { modelValue: initial, 'onUpdate:modelValue': () => {} } })
+}
+
+async function setDraft(wrapper: ReturnType<typeof mountInput>, value: string) {
+  const input = wrapper.find('input')
+  await input.setValue(value)
+}
+
+describe('TagInput', () => {
+  it('commits a draft when Enter is pressed', async () => {
+    const wrapper = mountInput()
+    await setDraft(wrapper, 'clutch')
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+    const events = wrapper.emitted('update:modelValue')!
+    expect(events[events.length - 1][0]).toEqual(['clutch'])
+  })
+
+  it('commits on comma and clears the draft', async () => {
+    const wrapper = mountInput()
+    await setDraft(wrapper, 'clutch')
+    await wrapper.find('input').trigger('keydown', { key: ',' })
+    const events = wrapper.emitted('update:modelValue')!
+    expect(events[events.length - 1][0]).toEqual(['clutch'])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('commits on space when the draft is non-empty', async () => {
+    const wrapper = mountInput()
+    await setDraft(wrapper, 'clutch')
+    await wrapper.find('input').trigger('keydown', { key: ' ' })
+    const events = wrapper.emitted('update:modelValue')!
+    expect(events[events.length - 1][0]).toEqual(['clutch'])
+  })
+
+  it('normalizes casing and whitespace before emitting', async () => {
+    const wrapper = mountInput()
+    await setDraft(wrapper, 'Clutch Play')
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+    const events = wrapper.emitted('update:modelValue')!
+    expect(events[events.length - 1][0]).toEqual(['clutch-play'])
+  })
+
+  it('rejects too-short input (no emit)', async () => {
+    const wrapper = mountInput()
+    await setDraft(wrapper, 'a')
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('rejects fully-invalid input (no emit)', async () => {
+    const wrapper = mountInput()
+    await setDraft(wrapper, '!!!')
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('does not re-emit when the slug is already present', async () => {
+    const wrapper = mountInput(['clutch'])
+    await setDraft(wrapper, 'Clutch')
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('disables the input when at max tags', () => {
+    const wrapper = mountInput(['a1', 'a2', 'a3', 'a4', 'a5'])
+    expect((wrapper.find('input').element as HTMLInputElement).disabled).toBe(true)
+  })
+
+  it('removes the last chip on Backspace when draft is empty', async () => {
+    const wrapper = mountInput(['clutch', 'ace'])
+    await wrapper.find('input').trigger('keydown', { key: 'Backspace' })
+    const events = wrapper.emitted('update:modelValue')!
+    expect(events[events.length - 1][0]).toEqual(['clutch'])
+  })
+
+  it('debounces the autocomplete fetch', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse([]))
+    vi.stubGlobal('fetch', fetchStub)
+    const wrapper = mount(TagInput, {
+      props: { modelValue: [], 'onUpdate:modelValue': () => {} },
+    })
+    const input = wrapper.find('input')
+    await input.setValue('c')
+    await input.setValue('cl')
+    await input.setValue('clu')
+
+    // No fetch yet — still inside the debounce window.
+    expect(fetchStub).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(200)
+    await nextTick()
+    expect(fetchStub).toHaveBeenCalledTimes(1)
+    const calls = fetchStub.mock.calls as unknown as Array<[string]>
+    expect(calls[0][0]).toContain('prefix=clu')
+  })
+})

--- a/web/src/components/__tests__/TagInput.spec.ts
+++ b/web/src/components/__tests__/TagInput.spec.ts
@@ -99,6 +99,44 @@ describe('TagInput', () => {
     expect(events[events.length - 1][0]).toEqual(['clutch'])
   })
 
+  it('does not repopulate the dropdown after the draft is cleared mid-fetch', async () => {
+    // Regression: lastQuery must be invalidated when the user clears the input
+    // while an autocomplete is in flight, otherwise the stale response can pass
+    // the `lastQuery !== queryAtCall` guard and reopen the dropdown.
+    let resolveFetch: (resp: Response) => void = () => {}
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve
+    })
+    const fetchStub = vi.fn(() => fetchPromise)
+    vi.stubGlobal('fetch', fetchStub)
+
+    const wrapper = mount(TagInput, {
+      props: { modelValue: [], 'onUpdate:modelValue': () => {} },
+    })
+    const input = wrapper.find('input')
+    await input.setValue('clu')
+    // Let the debounce timer fire so the fetch starts (but stays unresolved).
+    await vi.advanceTimersByTimeAsync(200)
+    expect(fetchStub).toHaveBeenCalledTimes(1)
+
+    // User clears the input before the response arrives.
+    await input.setValue('')
+    await nextTick()
+
+    // Stale response arrives now — must be discarded.
+    resolveFetch(
+      new Response(JSON.stringify([{ id: 1, slug: 'clutch', name: 'clutch', clipCount: 7 }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    await fetchPromise
+    await nextTick()
+
+    expect(wrapper.find('ul[role="listbox"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('clutch')
+  })
+
   it('debounces the autocomplete fetch', async () => {
     const fetchStub = vi.fn(async () => jsonResponse([]))
     vi.stubGlobal('fetch', fetchStub)

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -42,6 +42,11 @@ const router = createRouter({
       component: () => import('@/views/GameView.vue'),
     },
     {
+      path: '/tag/:slug',
+      name: 'tag-detail',
+      component: () => import('@/views/TagView.vue'),
+    },
+    {
       path: '/trending',
       name: 'trending',
       component: () => import('@/views/TrendingView.vue'),

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -307,13 +307,7 @@ async function onConfirmDelete() {
         </h1>
 
         <div v-if="clip.tags.length" class="mt-3 flex flex-wrap gap-2">
-          <TagChip
-            v-for="t in clip.tags"
-            :key="t.id"
-            :slug="t.slug"
-            :name="t.name"
-            size="md"
-          />
+          <TagChip v-for="t in clip.tags" :key="t.id" :slug="t.slug" :name="t.name" size="md" />
         </div>
 
         <div class="mt-4 flex flex-wrap items-center gap-3">

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -9,6 +9,7 @@ import { formatNum, formatRelativeTime } from '@/lib/format'
 import { useAuthStore } from '@/stores/auth'
 import { safeImageUrl } from '@/lib/url'
 import GameTag from '@/components/GameTag.vue'
+import TagChip from '@/components/TagChip.vue'
 import AuthorHandle from '@/components/AuthorHandle.vue'
 import StatusPanel from '@/components/StatusPanel.vue'
 import ClipEditDialog from '@/components/ClipEditDialog.vue'
@@ -304,6 +305,16 @@ async function onConfirmDelete() {
         >
           {{ clip.title }}
         </h1>
+
+        <div v-if="clip.tags.length" class="mt-3 flex flex-wrap gap-2">
+          <TagChip
+            v-for="t in clip.tags"
+            :key="t.id"
+            :slug="t.slug"
+            :name="t.name"
+            size="md"
+          />
+        </div>
 
         <div class="mt-4 flex flex-wrap items-center gap-3">
           <!-- Author info -->

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -6,6 +6,7 @@ import { formatNum, formatDuration, formatRelativeTime } from '@/lib/format'
 import ClipCard from '@/components/ClipCard.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import GameTag from '@/components/GameTag.vue'
+import TagChip from '@/components/TagChip.vue'
 import DurationBadge from '@/components/DurationBadge.vue'
 import AuthorHandle from '@/components/AuthorHandle.vue'
 import StatusPanel from '@/components/StatusPanel.vue'
@@ -145,6 +146,15 @@ onMounted(loadMore)
                 {{ formatRelativeTime(hero.createdAt) }} ago by
                 <AuthorHandle :username="hero.author.username" class="text-text-primary" />
               </p>
+              <div v-if="hero.tags.length" class="flex flex-wrap gap-2">
+                <TagChip
+                  v-for="t in hero.tags"
+                  :key="t.id"
+                  :slug="t.slug"
+                  :name="t.name"
+                  size="md"
+                />
+              </div>
             </div>
 
             <div class="my-5 flex gap-7 border-y border-border py-4 font-mono">

--- a/web/src/views/TagView.vue
+++ b/web/src/views/TagView.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { tags, type TagDetail } from '@/api/tags'
+import type { ClipFeedItem } from '@/api/clips'
+import { ApiError } from '@/api/client'
+import { useAuthStore } from '@/stores/auth'
+import ClipCard from '@/components/ClipCard.vue'
+import PageHeader from '@/components/PageHeader.vue'
+import StatusPanel from '@/components/StatusPanel.vue'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const slug = computed(() => {
+  const raw = route.params.slug
+  return Array.isArray(raw) ? raw[0] : raw
+})
+
+const tag = ref<TagDetail | null>(null)
+const items = ref<ClipFeedItem[]>([])
+const cursor = ref<string | null>(null)
+const reachedEnd = ref(false)
+const loading = ref(false)
+const initialLoading = ref(true)
+const errored = ref(false)
+const notFound = ref(false)
+const paginationErrored = ref(false)
+
+const sentinel = ref<HTMLElement | null>(null)
+let observer: IntersectionObserver | null = null
+
+// Same monotonic-token pattern as GameView so a fast slug nav can't let a
+// stale response stomp state for the new slug.
+let requestId = 0
+
+async function loadTag() {
+  const s = slug.value
+  if (!s) return
+  const token = requestId
+  try {
+    const result = await tags.getBySlug(s)
+    if (token !== requestId) return
+    tag.value = result
+  } catch (err) {
+    if (token !== requestId) return
+    if (err instanceof ApiError && err.status === 404) {
+      notFound.value = true
+    } else {
+      errored.value = true
+    }
+    throw err
+  }
+}
+
+async function loadMore() {
+  const s = slug.value
+  if (!s || loading.value || reachedEnd.value || notFound.value) return
+  const token = requestId
+  loading.value = true
+  paginationErrored.value = false
+  try {
+    const page = await tags.clips(s, { cursor: cursor.value })
+    if (token !== requestId) return
+    items.value.push(...page.items)
+    cursor.value = page.nextCursor
+    if (page.nextCursor === null) reachedEnd.value = true
+  } catch (err) {
+    if (token !== requestId) return
+    if (items.value.length === 0) {
+      if (err instanceof ApiError && err.status === 404) {
+        notFound.value = true
+      } else {
+        errored.value = true
+      }
+    } else {
+      paginationErrored.value = true
+      detachObserver()
+    }
+    console.error('tag-detail: load failed', err)
+  } finally {
+    if (token === requestId) loading.value = false
+  }
+}
+
+async function retryLoadMore() {
+  await loadMore()
+  if (!paginationErrored.value && !reachedEnd.value) {
+    attachObserver()
+  }
+}
+
+function attachObserver() {
+  if (observer || !sentinel.value || reachedEnd.value) return
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((e) => e.isIntersecting)) loadMore()
+    },
+    { rootMargin: '400px' },
+  )
+  observer.observe(sentinel.value)
+}
+
+function detachObserver() {
+  observer?.disconnect()
+  observer = null
+}
+
+async function loadAll() {
+  const token = ++requestId
+  errored.value = false
+  notFound.value = false
+  paginationErrored.value = false
+  reachedEnd.value = false
+  initialLoading.value = true
+  tag.value = null
+  items.value = []
+  cursor.value = null
+  loading.value = false
+  detachObserver()
+
+  try {
+    await loadTag()
+    if (token !== requestId) return
+    if (notFound.value || errored.value) return
+    await loadMore()
+  } catch {
+    // handlers set the right flag
+  } finally {
+    if (token === requestId) {
+      initialLoading.value = false
+      if (!notFound.value && !errored.value && !reachedEnd.value) {
+        requestAnimationFrame(attachObserver)
+      }
+    }
+  }
+}
+
+function retry() {
+  loadAll()
+}
+
+onMounted(loadAll)
+onBeforeUnmount(detachObserver)
+
+watch(slug, () => {
+  loadAll()
+})
+</script>
+
+<template>
+  <main
+    class="mx-auto max-w-360 px-6 pt-8 pb-30 max-[899px]:px-3.5 max-[899px]:pt-4 max-[899px]:pb-20"
+  >
+    <StatusPanel v-if="notFound" kind="empty" message="No tag with that slug.">
+      <RouterLink
+        to="/"
+        class="rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+      >
+        Back to feed
+      </RouterLink>
+    </StatusPanel>
+
+    <StatusPanel v-else-if="errored" kind="error" message="Couldn't load this tag.">
+      <button
+        class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="retry"
+      >
+        Retry
+      </button>
+    </StatusPanel>
+
+    <StatusPanel v-else-if="initialLoading && !tag" kind="loading" message="Loading…" />
+
+    <template v-else-if="tag">
+      <section
+        class="relative mb-10 overflow-hidden rounded-lg border border-border bg-surface-raised"
+      >
+        <div class="relative px-8 py-8 max-[899px]:px-5 max-[899px]:py-7">
+          <PageHeader :title="`#${tag.slug}`" pulse>
+            <template #caption>
+              Tag · {{ tag.clipCount }} clip{{ tag.clipCount === 1 ? '' : 's' }}
+            </template>
+            <div class="mt-3 flex items-center gap-3">
+              <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-text-muted">
+                {{ tag.name }}
+              </span>
+            </div>
+          </PageHeader>
+        </div>
+      </section>
+
+      <div v-if="items.length" class="feed-grid">
+        <ClipCard
+          v-for="clip in items"
+          :key="clip.id"
+          :clip="clip"
+          @click="router.push({ name: 'clip', params: { id: clip.id } })"
+        />
+      </div>
+
+      <StatusPanel v-else-if="reachedEnd" kind="empty" message="No clips with this tag yet.">
+        <RouterLink
+          v-if="auth.isAuthenticated"
+          to="/upload"
+          class="rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        >
+          Upload a clip
+        </RouterLink>
+      </StatusPanel>
+
+      <div v-if="!reachedEnd" ref="sentinel" class="mt-8 py-6" aria-hidden="true"></div>
+      <div
+        v-if="loading && !reachedEnd"
+        role="status"
+        aria-live="polite"
+        class="-mt-6 flex items-center justify-center py-3 font-mono text-[11px] uppercase tracking-widest text-text-muted"
+      >
+        Loading more…
+      </div>
+
+      <div v-if="paginationErrored" class="mt-2 flex flex-col items-center gap-2">
+        <span class="font-mono text-[11px] uppercase tracking-widest text-text-muted">
+          Couldn't load more — try again.
+        </span>
+        <button
+          :disabled="loading"
+          @click="retryLoadMore"
+          class="cursor-pointer rounded-sm border border-border bg-surface-raised px-6 py-2.5 font-mono text-[11px] uppercase tracking-[0.08em] text-text-primary transition-colors duration-150 hover:border-brand-light disabled:opacity-50"
+        >
+          Retry
+        </button>
+      </div>
+    </template>
+  </main>
+</template>

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -5,6 +5,7 @@ import { ApiError } from '@/api/client'
 import { clips } from '@/api/clips'
 import type { GameSummary } from '@/api/clips'
 import GameSelector from '@/components/GameSelector.vue'
+import TagInput from '@/components/TagInput.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import IconUploadCloud from '@/components/icons/IconUploadCloud.vue'
 import IconFile from '@/components/icons/IconFile.vue'
@@ -33,6 +34,7 @@ const visibility = ref<'public' | 'unlisted'>('public')
 const dragging = ref(false)
 
 const selectedGame = ref<GameSummary | null>(null)
+const selectedTags = ref<string[]>([])
 
 // Upload state — granular so the checklist can light up step-by-step.
 type UploadStage = 'idle' | 'creating' | 'uploading' | 'completing' | 'done' | 'error'
@@ -130,6 +132,9 @@ async function startUpload() {
       description: desc.value.trim() || null,
       gameId: selectedGame.value?.id ?? null,
       visibility: visibility.value,
+      // Omit the field entirely when empty so the server treats it as "no tags"
+      // instead of an empty array. Same wire shape as the old POST.
+      ...(selectedTags.value.length ? { tags: selectedTags.value } : {}),
     })
     createdClipId.value = created.id
 
@@ -318,6 +323,14 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
               >Game <span class="text-[9px] text-text-muted">(optional)</span></label
             >
             <GameSelector v-model="selectedGame" />
+          </div>
+
+          <!-- Tags -->
+          <div>
+            <label :class="labelClass"
+              >Tags <span class="text-[9px] text-text-muted">(optional, max 5)</span></label
+            >
+            <TagInput v-model="selectedTags" :input-class="inputClass" />
           </div>
 
           <div>

--- a/web/src/views/__tests__/UserView.spec.ts
+++ b/web/src/views/__tests__/UserView.spec.ts
@@ -68,6 +68,7 @@ describe('UserView (issue #92 regression)', () => {
           createdAt: new Date().toISOString(),
           author: { id: 'u1', username: 'seeduser', avatarUrl: null },
           game: null,
+          tags: [],
           likedByMe: false,
           shareCode: 'seed01',
         },


### PR DESCRIPTION
## Summary

Phase 3 (Discovery) — user-defined tags on clips (`#clutch`, `#funny`, `#fail`, …). Today clips can only be filed under a game; tags give creators finer-grained labels and viewers a vibe-based browse axis. Adds the schema + API + UI end-to-end.

## What's here

**Server**
- New `tags` + `clip_tags` tables (migration `20260522175228_AddTagsAndClipTags`); composite-PK join, unique index on `tags.slug`, supporting `(tag_id, clip_id)` lookup index.
- `TagsResolver` service is the DRY core for normalize → dedupe → max-5 → get-or-create, shared by `POST /clips` and `PATCH /clips/{id}`. Race-safe via a single retry on the unique-slug index (`PostgresErrorCodes.UniqueViolation`).
- `POST /clips` and `PATCH /clips/{id}` accept `tags: string[]`. PATCH semantics: omitted = leave alone, `[]` = clear all, non-empty = replace the set.
- New `GET /tags?prefix=` (autocomplete, ordered by `clipCount DESC`), `GET /tags/{slug}` (header detail w/ live count), `GET /tags/{slug}/clips` (cursor-paginated feed — reuses the existing `BuildFeedPageAsync`).
- Every clip DTO (`ClipFeedItem`, `ClipDetailResponse`) gains `tags: TagSummary[]`.
- `IncludeFeedRelations()` extension centralises the `User + Game + ClipTags→Tag` eager-load chain.

**Web**
- New `api/tags.ts` plus `tags: TagSummary[]` on `ClipFeedItem`/`ClipDetail` in `api/clips.ts`.
- One `TagInput.vue` (chip-style w/ debounced autocomplete, comma/space/enter to commit, ARIA combobox) consumed by both the upload form and the edit dialog.
- One `TagChip.vue` consumed by `ClipCard` (max-3 visible + `+N` overflow), `TagView`, hero card on `HomeView`, and clip detail page.
- New `/tag/:slug` route + `TagView.vue` (header + clip grid + infinite scroll, mirrors `GameView`).
- Existing `ClipEditDialog` learns to diff the tag set into the sparse PATCH payload.

Closes #88

## How to test manually

```bash
# 1. Start infra + apply the new migration (or run from a fresh worktree via /worktree 88).
make up
cd server && dotnet ef database update --project src/GankedTV.Api

# 2. Boot the API + web.
make server   # in one terminal
make web      # in another

# 3. Mint a JWT for curl runs.
TOKEN=$(curl -sS -X POST http://localhost:5050/dev/token \
  -H 'Content-Type: application/json' -d '{"username":"tester"}' | jq -r .token)

# 4. Smoke the contract.
curl -sS -X POST http://localhost:5050/clips \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"title":"clutch ace","tags":["Clutch","Ace","CS2"]}' | jq          # normalizes + persists
curl -sS -X POST http://localhost:5050/clips \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"title":"x","tags":["a1","a2","a3","a4","a5","a6"]}' -i            # 400 too_many_tags
curl -sS -X POST http://localhost:5050/clips \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"title":"x","tags":["!!!"]}' -i                                    # 400 invalid_tag
curl -sS 'http://localhost:5050/tags?prefix=clu' | jq                     # autocomplete
curl -sS http://localhost:5050/tags/clutch/clips | jq                     # tag feed
curl -sS -i http://localhost:5050/tags/does-not-exist/clips                # 404
```

In the browser at `http://localhost:5173`:
- Upload a clip; type `clutch, ace, fail` into the tag input — chips render, `×` removes, max-5 enforced.
- Feed → `ClipCard` shows up to 3 `#tag` chips + `+N` overflow; click a chip → `/tag/clutch`.
- Hero (featured) card on the homepage and the clip-detail page both show full tag chip rows.
- Open an existing clip's edit dialog → tag input is pre-populated; remove/add tags + save → diff PATCHes correctly.
- Visit `/tag/does-not-exist` → not-found empty state with "Back to feed" CTA.

## Checklist
- [x] Max 5 tags enforced (`POST` with 6 → 400 `too_many_tags`)
- [x] Tag normalization: `Clutch`/`clutch`/`CLUTCH` resolve to the same row
- [x] Duplicate tags within one request are deduped, not double-inserted
- [x] `PATCH` replaces the tag set (omitted = leave alone; `[]` = clear)
- [x] `/tag/:slug` 404s for an unknown slug
- [x] Coverage gates pass (server 95.30% L / 86.83% B; web 93.87% L / 95.57% B)
- [x] Smoke-tested end-to-end against the worktree's dev stack


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tagging system for clips. Users can assign up to 5 tags when creating and editing clips.
  * Added tag search with autocomplete and normalization.
  * Added dedicated tag pages displaying all clips associated with each tag.
  * Tags now display on clip cards, detail pages, and featured sections across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->