### PR TITLE
[server] [web] trending feed + view counting (#87)

### DIFF
--- a/docs/trending-and-views.md
+++ b/docs/trending-and-views.md
@@ -1,0 +1,302 @@
+# Trending feed & view counting
+
+How `POST /clips/{id}/view`, the `clip_views` event table, and the trending feed
+(`GET /clips/feed?sort=trending&window=…`) fit together. Implemented in [#87].
+
+[#87]: https://github.com/gankedtv/gankedtv/issues/87
+
+## Pipeline at a glance
+
+```
+  ┌─────────────────┐   ≥3s playback   ┌──────────────────────┐
+  │  ClipView.vue   │ ───────────────► │ POST /clips/{id}/view │
+  └─────────────────┘                  └──────────┬───────────┘
+                                                  │ pass dedup?
+                                                  ▼
+                                          ┌──────────────────┐
+                                          │  IMemoryCache    │  30-min sliding window
+                                          │  view:{clip}:{v} │  keyed by user or IP
+                                          └────────┬─────────┘
+                                                   │ miss
+                                                   ▼
+                              ┌──────────────────────────────────────┐
+                              │ TX: clips.view_count++               │
+                              │     INSERT INTO clip_views(clip, ts) │
+                              └──────────────────────────────────────┘
+                                                   │
+                                                   ▼
+                              ┌──────────────────────────────────────┐
+                              │ GET /clips/feed?sort=trending&window │
+                              │   score = (likes×3 + views) /        │
+                              │           (hours+2)^1.5              │
+                              │   filtered to clips with engagement  │
+                              │   in the window, top 50              │
+                              └──────────────────────────────────────┘
+```
+
+## View counting
+
+### Endpoint
+
+`POST /clips/{id}/view`
+
+- Anonymous-friendly — no `Authorization` header required
+- Returns **`204 No Content`** on every outcome: success, dedup hit, missing clip,
+  non-public clip. The client fires-and-forgets; the response carries no
+  information it acts on
+- Rate-limited per-IP (see below)
+
+Files:
+- Endpoint: [server/src/GankedTV.Api/Endpoints/ClipsViewEndpoints.cs](../server/src/GankedTV.Api/Endpoints/ClipsViewEndpoints.cs)
+- Client call site: [web/src/views/ClipView.vue](../web/src/views/ClipView.vue) — `attachViewTracking`
+- API client method: `clips.recordView(id)` in [web/src/api/clips.ts](../web/src/api/clips.ts)
+
+### Dedup (the 30-min window)
+
+Each view is keyed and looked up in `IMemoryCache`:
+
+```
+key = "view:{clipId}:{viewerKey}"
+viewerKey = "u:{jwt_sub}"   // authenticated
+          | "ip:{remoteIp}" // anonymous
+ttl       = 30 min, sliding (resets on every cache hit)
+```
+
+A cache hit → silent `204`, no counter change, no event row.
+A cache miss → counter is bumped atomically, event row is inserted, **then** the
+cache entry is written. Writing the cache after the transaction commits means a
+transient DB failure doesn't poison the cache and silently swallow the next
+30 minutes of legitimate views.
+
+Behavioural consequences:
+
+- A 45-minute watch session counts as **one** view (sustained viewing keeps the
+  TTL sliding).
+- Stepping away for 30+ minutes and coming back counts as a **new** view.
+- Two different logged-out users behind the same NAT collapse to one viewer
+  until they sign in.
+- Two different signed-in users on the same IP each count once — auth wins over
+  IP for dedup, so shared networks don't penalise distinct viewers.
+- Cache is **in-process**. An API restart resets all dedup state; the next view
+  from any (clip, viewer) pair counts again. Acceptable for a single-instance
+  deployment; the Phase-4 follow-up (per [PLAN.md §4](../PLAN.md)) swaps for
+  Redis for cluster-wide + restart-stable dedup.
+
+> **This is not "unique viewers" forever.** It's time-windowed dedup. If you
+> ever need lifetime-unique-per-account semantics (à la YouTube unique viewers),
+> that's a different metric requiring a persisted `(clip_id, user_id)` table
+> with a unique constraint.
+
+### Rate limiting
+
+Policy `clips-view` — 20 requests per IP per minute, fixed window. Wired in
+[server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs](../server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs).
+
+Partition key is **IP-only** even for authenticated callers — the endpoint is
+anonymous-friendly so a per-user bucket wouldn't bound abuse from the dominant
+(logged-out) case. The 21st request from the same IP inside a 60-second window
+returns `429 Too Many Requests` with a `Retry-After` header.
+
+The dedup window (30 min) and the rate-limit window (60 s) are independent: the
+limiter counts every request (including dedup hits), the dedup decides whether
+the request mutates state.
+
+### Two pieces of state
+
+Each non-deduped view writes to two places in a single transaction:
+
+| Table / column | Purpose |
+| --- | --- |
+| `clips.view_count` (int) | Denormalised counter shown in feed/detail DTOs. Cheap reads. |
+| `clip_views(id, clip_id, created_at)` | Append-only event log. Drives time-window queries (trending). |
+
+Both updates are wrapped in `BeginTransactionAsync` → `ExecuteUpdateAsync` →
+`Add()` → `SaveChangesAsync` → `CommitAsync`. If the counter update affects
+zero rows (clip is missing, draft, processing, or unlisted) the transaction
+short-circuits and no event row is written.
+
+The `ExecuteUpdateAsync` predicate `Visibility = 'public' AND Status = 'ready'`
+is what makes a `POST /clips/{id}/view` against an unlisted or processing clip a
+silent no-op rather than a 404 — clients can't distinguish "missing" from
+"not viewable" by status code, which discourages enumeration attacks.
+
+### Indexes
+
+Migration: [20260523154709_AddClipViewsAndLikesCreatedAtIndex](../server/src/GankedTV.Api/Data/Migrations/20260523154709_AddClipViewsAndLikesCreatedAtIndex.cs).
+
+- `idx_clip_views_created_at` (created_at DESC) — global window scan
+- `idx_clip_views_clip_id_created_at` (clip_id, created_at DESC) — per-clip aggregation
+- `idx_likes_created_at_clip_id` (created_at DESC, clip_id) — likes time-window
+  aggregation (the `likes` table previously had only a composite PK on
+  `user_id, clip_id` — no `created_at` index — so the trending query would
+  have table-scanned likes without this)
+
+## Trending feed
+
+### Endpoint
+
+`GET /clips/feed?sort=trending&window=24h|7d&limit=…`
+
+- `sort=trending` switches the handler into the time-weighted ranking branch.
+- `window` is **required** when `sort=trending` — an unknown or missing value
+  returns `400 Bad Request` with `code: invalid_window`. Unlike `source`
+  (which falls back silently), trending without a window is meaningless and
+  the client sends the value verbatim, so a 400 surfaces UI bugs instead of
+  guessing.
+- `limit` clamps to `[1, 50]` (lower than the default feed's 100). The Trending
+  UI shows the top 10; 50 gives headroom for future top-N views.
+- `cursor` is ignored — trending is a single ranked page, `nextCursor: null`.
+- `sort=latest` and an omitted `sort` are identical to the pre-issue feed
+  (regression-guarded by `Feed_DefaultSortLatest_UnchangedFromPreTrendingBehavior`).
+
+Handler: `GetFeed` → `BuildTrendingFeedAsync` in
+[server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs](../server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs).
+
+### Score formula
+
+```
+score = (likes_in_window × 3 + views_in_window) / (max(0, hours_since_post) + 2) ^ 1.5
+```
+
+**Numerator — engagement signal:**
+
+- `likes_in_window` — `COUNT(*)` from `likes` where `created_at > now − window`
+- `views_in_window` — `COUNT(*)` from `clip_views` where `created_at > now − window`
+- Likes are weighted **3×** views — a deliberate emotional-investment vs.
+  passive-play ratio. Pinned by `Trending_LikesCountedTriple_VsViews`.
+
+**Denominator — age decay (Reddit-style):**
+
+- `hours_since_post = (now − clip.created_at).TotalHours`, clamped at 0
+- `+2` softens the t≈0 spike (a clip 0 minutes old would otherwise be
+  divided by 1 and dominate; the offset is 1.5× the steepness's natural unit)
+- `^1.5` is the decay exponent — half-life of relevance is approximately
+  `2 × (2^(2/3) − 1) ≈ 1.17` engagement-doublings per hour-doubling
+
+### Worked example
+
+24-hour window. `T` = right now.
+
+| Clip | Posted | Likes (24h) | Views (24h) | Numerator | Denom (hours+2)^1.5 | Score |
+| --- | --- | --: | --: | --: | --: | --: |
+| A | 1 h ago | 5 | 30 | 45 | 5.20 | **8.66** |
+| B | 12 h ago | 20 | 200 | 260 | 52.38 | **4.96** |
+| C | 30 min ago | 1 | 2 | 5 | 3.95 | **1.27** |
+| D | 1 h ago | 0 | 0 | 0 | — | excluded (no engagement) |
+
+Order: **A > B > C**. Clip A's recency lets fewer signals outweigh Clip B's
+higher absolute count. Clip D is pre-filtered SQL-side before scoring.
+
+### Query path
+
+1. Apply the base feed filter (`visibility = 'public' AND status = 'ready'`, plus
+   the optional `source=following` filter — trending honours it).
+2. **Pre-filter SQL-side** to clips with at least one like OR one view in the
+   window:
+   ```csharp
+   .Where(c => db.Likes.Any(l => l.ClipId == c.Id && l.CreatedAt > since)
+            || db.ClipViews.Any(v => v.ClipId == c.Id && v.CreatedAt > since))
+   ```
+   This is the load-shedding step. Without it, scoring would touch every public
+   clip even if nothing has happened to it in the window.
+3. Fetch `(Clip, likes_in_window, views_in_window)` tuples to memory.
+4. **Score in C#**, not SQL. Postgres has no clean `pow(double, double)` over
+   interval-derived hours via EF translation; scoring in memory over a
+   bounded candidate set is acceptable. The plan notes "revisit if active
+   clips per window climbs past ~10k" — we're well under that.
+5. Order by score desc, then `created_at` desc as tiebreaker.
+6. Take top N (clamped limit), re-fetch with `IncludeFeedRelations()` (author,
+   game, tags, like-state) preserving rank order.
+7. Project through the shared `ProjectFeedItemsAsync` so the response DTO is
+   byte-identical to the latest feed.
+
+### Excluded clips
+
+Trending omits:
+
+- `visibility != 'public'` — unlisted clips never reach Trending. Direct-link
+  access still works via `/clips/{id}` and `/c/{code}`.
+- `status != 'ready'` — processing or failed clips don't appear.
+- Clips with zero likes AND zero views in the window — even if they're brand
+  new. Trending answers "what are people engaging with right now," not
+  "what's new."
+
+## Web wiring
+
+[TrendingView.vue](../web/src/views/TrendingView.vue):
+
+- Calls `clips.feed({ sort: 'trending', window: timeWindow.value, limit: 50 })`,
+  then takes the first 10 for the leaderboard.
+- `watch(timeWindow, load)` re-fetches when the user toggles `24h` ↔ `7d`.
+- Only `24h` and `7d` tabs are enabled — `1h`, `30d`, `all` render dimmed/
+  non-clickable until server windows expand (deliberate roadmap surface).
+- Drops the pre-issue hardcoded trend-arrow indicator (▲/▼/—). The leaderboard
+  rank is the v1 signal; a real `previousRank` field is a follow-up.
+
+[ClipView.vue](../web/src/views/ClipView.vue) — view tracking:
+
+- Attaches a `timeupdate` listener to the underlying `<video>` element after
+  Plyr mounts. Plyr re-fires the same DOM event but the element listener is
+  resilient to Plyr-lifecycle quirks.
+- Accumulates playback time with a **per-tick delta clamped to [0, 1000 ms]**.
+  This is what stops a scrub-forward from instantly crediting the gap, and a
+  scrub-backward from subtracting.
+- At `playedMs >= 3000`, calls `clips.recordView(clipId)` exactly once per
+  mount and stores the clipId in a module-scope flag. Errors are silently
+  swallowed — fire-and-forget; retrying would defeat the server's dedup +
+  rate-limit.
+- Detached cleanly on clip teardown (`teardownPlayer`) and on
+  `onBeforeUnmount`. Switching to a different clip mid-watch resets the
+  accumulator.
+
+## Operational notes & follow-ups
+
+What's intentionally **not** in v1, noted here so we don't relitigate it in PR
+review:
+
+- **No caching of trending results.** Each request recomputes. The candidate
+  set is pre-filtered to engaged clips, and at current volume the cost is
+  bounded. Add caching (per-window TTL ~60 s) when DB load justifies it.
+- **No score-keyset cursor.** Trending returns a single top-N page. Deep
+  pagination of a time-decaying ranked list is a UX trap (entries shift
+  underneath the cursor); we deliberately ship "what's hot now" as a snapshot.
+- **No `previousRank` / trend arrows.** Re-introduce when there's product
+  signal for it; needs a periodic snapshot table or a delta computed from a
+  prior cached run.
+- **No Redis dedup.** `IMemoryCache` works for a single API instance. Two API
+  pods would each maintain their own dedup state — at worst, a viewer
+  alternating between pods would count twice instead of once. Phase 4.
+- **No `1h` / `30d` / `all` windows.** The UI shows these tabs as disabled so
+  the product intent is visible; the server returns 400 for them by design.
+  Adding a window is a one-line change in `TryParseTrendingWindow`.
+- **No follower/reach normalisation.** Raw engagement only. A high-follower
+  author's clips will rank higher because they get more likes and views, not
+  through any explicit boost.
+
+## Tests
+
+The numbers below are the new/changed cases — there's also the existing suite.
+
+| Test | Locks |
+| --- | --- |
+| `ClipsViewEndpointsTests.RecordView_Anonymous_Returns204AndIncrementsCounter` | Happy path |
+| `RecordView_RepeatedFromSameIp_IsDedupedToOne` | 30-min cache dedup |
+| `RecordView_NonExistentClip_Returns204Silently` | Silent no-op spec |
+| `RecordView_NonPublicClip_Returns204AndNoIncrement` | Unlisted/processing don't increment |
+| `RecordView_AuthenticatedDedupsByUserNotIp` | Auth wins over IP in dedup key |
+| `RecordView_ExceedingRateLimit_Returns429` | 20/min IP limit |
+| `ClipsReadEndpointsTests.Trending_24h_OrdersByScore` | Score-based ordering |
+| `Trending_LikesCountedTriple_VsViews` | The `×3` coefficient |
+| `Trending_24hExcludesOlderEngagement_7dIncludes` | Time-window boundary |
+| `Trending_ExcludesNonPublicAndNonReady` | Visibility/status filter |
+| `Trending_OmitsClipsWithoutEngagementInWindow` | The engagement pre-filter |
+| `Trending_InvalidWindow_Returns400` / `Trending_MissingWindow_Returns400` | 400 surface for bad windows |
+| `Trending_EmptyResult_Returns200WithNoItems` | Empty-page shape |
+| `Trending_LimitClampedToTrendingMax` | `[1, 50]` clamp |
+| `Feed_DefaultSortLatest_UnchangedFromPreTrendingBehavior` | Regression guard for `sort=latest` and omitted sort |
+| `ClipsRateLimitingTests.ResolveIpPartitionKey_*` | IP-only partition for view policy |
+| `clips.spec.ts › feed › encodes sort and window for trending queries` | Web → server param wire format |
+| `clips.spec.ts › recordView()` | `POST /clips/{id}/view` shape |
+
+Server: 686 tests, coverage 94.65 line / 86.67 branch (gate 85/85).
+Web: 173 tests, coverage 94.96 branch / 93.42 line on the gated paths.

--- a/docs/trending-and-views.md
+++ b/docs/trending-and-views.md
@@ -7,7 +7,7 @@ How `POST /clips/{id}/view`, the `clip_views` event table, and the trending feed
 
 ## Pipeline at a glance
 
-```
+```text
   ┌─────────────────┐   ≥3s playback   ┌──────────────────────┐
   │  ClipView.vue   │ ───────────────► │ POST /clips/{id}/view │
   └─────────────────┘                  └──────────┬───────────┘
@@ -55,7 +55,7 @@ Files:
 
 Each view is keyed and looked up in `IMemoryCache`:
 
-```
+```text
 key = "view:{clipId}:{viewerKey}"
 viewerKey = "u:{jwt_sub}"   // authenticated
           | "ip:{remoteIp}" // anonymous
@@ -154,7 +154,7 @@ Handler: `GetFeed` → `BuildTrendingFeedAsync` in
 
 ### Score formula
 
-```
+```text
 score = (likes_in_window × 3 + views_in_window) / (max(0, hours_since_post) + 2) ^ 1.5
 ```
 

--- a/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
+++ b/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
@@ -14,6 +14,7 @@ namespace GankedTV.Api.Clips;
 public static class ClipsRateLimiting
 {
     public const string ClipsWritePolicy = "clips-write";
+    public const string ClipsViewPolicy = "clips-view";
 
     // 30 writes per minute. Per-user when the caller is authenticated, per-IP otherwise.
     // Fixed window (not sliding) — same shape as the credentials policy, no extra state.
@@ -29,6 +30,13 @@ public static class ClipsRateLimiting
     // moves to a Redis-backed limiter for cluster-wide enforcement.
     public const int WritePermitLimit = 30;
     public static readonly TimeSpan WriteWindow = TimeSpan.FromMinutes(1);
+
+    // POST /clips/{id}/view is anonymous-friendly, so the bucket is per-IP only: a user-keyed
+    // partition wouldn't bound abuse from logged-out clients (the dominant case for view pings).
+    // 20/min is generous for legitimate playback (one view-ping per clip per 30 min on the dedup
+    // window above this layer) but tight enough that a single host can't run a write storm.
+    public const int ViewPermitLimit = 20;
+    public static readonly TimeSpan ViewWindow = TimeSpan.FromMinutes(1);
 
     // Machine-readable code stamped into the ProblemDetails extensions when any policy
     // rejects. Mirrors the convention from ProblemResults.* used elsewhere in the API.
@@ -65,6 +73,27 @@ public static class ClipsRateLimiting
             }));
         return options;
     }
+
+    public static RateLimiterOptions AddClipsViewPolicy(this RateLimiterOptions options)
+    {
+        options.AddPolicy<string>(ClipsViewPolicy, ctx =>
+            RateLimitPartition.GetFixedWindowLimiter(ResolveIpPartitionKey(ctx), _ => new FixedWindowRateLimiterOptions
+            {
+                AutoReplenishment = true,
+                PermitLimit = ViewPermitLimit,
+                Window = ViewWindow,
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            }));
+        return options;
+    }
+
+    // Pure per-IP key: the view endpoint is anonymous, so authenticated callers and
+    // anonymous ones share the same per-host bucket. Fallback "unknown" guarantees a
+    // total function — a missing RemoteIpAddress (test harness, broken proxy) must not
+    // collapse every caller into one bucket and bypass the limit.
+    internal static string ResolveIpPartitionKey(HttpContext ctx) =>
+        $"ip:{ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
 
     // Internal so unit tests can exercise the fallback branches that the HTTP-level integration
     // tests can't reach (RequireAuthorization rejects pre-limiter, so the per-IP and

--- a/server/src/GankedTV.Api/Data/Entities/ClipView.cs
+++ b/server/src/GankedTV.Api/Data/Entities/ClipView.cs
@@ -1,0 +1,13 @@
+namespace GankedTV.Api.Data.Entities;
+
+// Append-only event row written on every dedup-passed POST /clips/{id}/view. Feeds the
+// time-windowed trending query (views in last 24h/7d) — separate from the denormalised
+// clips.view_count counter so we can answer "views since X" without scanning the clips table.
+public class ClipView
+{
+    public long Id { get; set; }
+    public Guid ClipId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public Clip Clip { get; set; } = null!;
+}

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -10,6 +10,7 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
     public DbSet<Game> Games => Set<Game>();
     public DbSet<Clip> Clips => Set<Clip>();
     public DbSet<Like> Likes => Set<Like>();
+    public DbSet<ClipView> ClipViews => Set<ClipView>();
     public DbSet<Follow> Follows => Set<Follow>();
     public DbSet<Comment> Comments => Set<Comment>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
@@ -147,6 +148,34 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
                 .WithMany(c => c.Likes)
                 .HasForeignKey(l => l.ClipId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            // Backs the time-window like aggregation used by the trending feed
+            // (likes_in_window per clip). PK is (user_id, clip_id), so without this
+            // a 24h-window scan would table-scan likes.
+            e.HasIndex(l => new { l.CreatedAt, l.ClipId })
+                .IsDescending(true, false)
+                .HasDatabaseName("idx_likes_created_at_clip_id");
+        });
+
+        modelBuilder.Entity<ClipView>(e =>
+        {
+            e.HasKey(v => v.Id);
+            e.Property(v => v.Id).UseIdentityByDefaultColumn();
+            e.Property(v => v.CreatedAt).HasDefaultValueSql("now()");
+
+            e.HasOne(v => v.Clip)
+                .WithMany()
+                .HasForeignKey(v => v.ClipId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Time-window scan (views_in_window across all clips).
+            e.HasIndex(v => v.CreatedAt)
+                .IsDescending()
+                .HasDatabaseName("idx_clip_views_created_at");
+            // Per-clip aggregation (views_in_window for a specific clip).
+            e.HasIndex(v => new { v.ClipId, v.CreatedAt })
+                .IsDescending(false, true)
+                .HasDatabaseName("idx_clip_views_clip_id_created_at");
         });
 
         modelBuilder.Entity<Tag>(e =>

--- a/server/src/GankedTV.Api/Data/Migrations/20260523154709_AddClipViewsAndLikesCreatedAtIndex.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260523154709_AddClipViewsAndLikesCreatedAtIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523154709_AddClipViewsAndLikesCreatedAtIndex")]
+    partial class AddClipViewsAndLikesCreatedAtIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/GankedTV.Api/Data/Migrations/20260523154709_AddClipViewsAndLikesCreatedAtIndex.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260523154709_AddClipViewsAndLikesCreatedAtIndex.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClipViewsAndLikesCreatedAtIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "clip_views",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    clip_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_clip_views", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_clip_views_clips_clip_id",
+                        column: x => x.clip_id,
+                        principalTable: "clips",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_likes_created_at_clip_id",
+                table: "likes",
+                columns: new[] { "created_at", "clip_id" },
+                descending: new[] { true, false });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_clip_views_clip_id_created_at",
+                table: "clip_views",
+                columns: new[] { "clip_id", "created_at" },
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_clip_views_created_at",
+                table: "clip_views",
+                column: "created_at",
+                descending: new bool[0]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "clip_views");
+
+            migrationBuilder.DropIndex(
+                name: "idx_likes_created_at_clip_id",
+                table: "likes");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -174,14 +174,22 @@ public static class ClipsReadEndpoints
         // already derived from the filtered candidate set. The micro-race window — a clip
         // flipping to unlisted or back to processing between scoring and rehydration — could
         // surface one stale row in a trending response; accepted as bounded and self-healing
-        // on the next request.
+        // on the next request. A clip *deleted* between scoring and rehydration just drops
+        // out of the result (TryGetValue skip) rather than 500ing.
         var ordered = await db.Clips.AsNoTracking()
             .Where(c => topIds.Contains(c.Id))
             .IncludeFeedRelations()
             .ToListAsync(ct);
 
         var byId = ordered.ToDictionary(c => c.Id);
-        var ranked = topIds.Select(id => byId[id]).ToList();
+        var ranked = new List<Clip>(topIds.Count);
+        foreach (var id in topIds)
+        {
+            if (byId.TryGetValue(id, out var clip))
+            {
+                ranked.Add(clip);
+            }
+        }
 
         var items = await ProjectFeedItemsAsync(ranked, principal, db, storage, s3, ct);
         return new ClipFeedResponse(items, NextCursor: null);

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -21,6 +21,9 @@ public static class ClipsReadEndpoints
     // value) constants there. Internal so the helper is callable cross-class.
     internal const int FeedDefaultLimit = 20;
     internal const int FeedMaxLimit = 100;
+    // Trending is a single ranked page (no keyset pagination) sized for the discovery UI
+    // top-10 with headroom. Capping here keeps the in-memory scoring step bounded.
+    internal const int TrendingMaxLimit = 50;
     private static readonly TimeSpan VideoUrlLifetime = TimeSpan.FromHours(1);
     // Thumbnail URLs ride the same 1-hour signed window as video URLs — keeping the
     // two lifetimes aligned means a feed page that's still fresh enough to play the
@@ -40,6 +43,8 @@ public static class ClipsReadEndpoints
         string? cursor,
         int? limit,
         string? source,
+        string? sort,
+        string? window,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
         IObjectStorageService storage,
@@ -63,8 +68,123 @@ public static class ClipsReadEndpoints
                 db.Follows.Any(f => f.FollowerId == me && f.FolloweeId == c.UserId));
         }
 
-        var response = await BuildFeedPageAsync(baseQuery, cursor, limit, principal, db, storage, s3, ct);
-        return Results.Ok(response);
+        // Symmetric with `window`: null/empty falls through to the default (latest), but an
+        // explicit non-null value outside the known set is a 400 to surface client typos
+        // (`?sort=trendng`) instead of silently serving latest under a different label.
+        if (!string.IsNullOrEmpty(sort)
+            && !string.Equals(sort, "latest", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(sort, "trending", StringComparison.OrdinalIgnoreCase))
+        {
+            return ProblemResults.BadRequest("invalid_sort");
+        }
+
+        if (string.Equals(sort, "trending", StringComparison.OrdinalIgnoreCase))
+        {
+            // `window` is required for trending — unlike `source`, an unknown value is a
+            // 400 rather than silent fall-back because trending is meaningless without a
+            // window and we'd rather surface the typo than guess.
+            if (!TryParseTrendingWindow(window, out var since))
+            {
+                return ProblemResults.BadRequest("invalid_window");
+            }
+
+            var response = await BuildTrendingFeedAsync(baseQuery, since, limit, principal, db, storage, s3, ct);
+            return Results.Ok(response);
+        }
+
+        var latest = await BuildFeedPageAsync(baseQuery, cursor, limit, principal, db, storage, s3, ct);
+        return Results.Ok(latest);
+    }
+
+    // Per-issue: only 24h and 7d are supported in v1. Other window strings (or null) are 400 —
+    // the web client sends the value verbatim, so a 400 surfaces a UI bug instead of returning
+    // an arbitrary fallback ranking.
+    internal static bool TryParseTrendingWindow(string? window, out DateTimeOffset since)
+    {
+        var now = DateTimeOffset.UtcNow;
+        switch (window)
+        {
+            case "24h":
+                since = now.AddHours(-24);
+                return true;
+            case "7d":
+                since = now.AddDays(-7);
+                return true;
+            default:
+                since = default;
+                return false;
+        }
+    }
+
+    // Time-weighted ranked feed. Score = (likes_in_window * 3 + views_in_window) / pow(hours+2, 1.5).
+    //
+    // SQL fetches: clip + engagement counts in the window, pre-filtered to clips with ANY
+    // engagement in the window (so we don't return a count tuple for every dormant clip).
+    // Scoring + ordering happen in-memory afterwards — Postgres' EF translation doesn't have a
+    // clean `pow` over interval-hours and the candidate set is bounded by the engagement filter.
+    //
+    // Revisit if active-clips per window climbs past ~10k (early-stage assumption: << that).
+    internal static async Task<ClipFeedResponse> BuildTrendingFeedAsync(
+        IQueryable<Clip> baseQuery,
+        DateTimeOffset since,
+        int? limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        var clampedLimit = Math.Clamp(limit ?? FeedDefaultLimit, 1, TrendingMaxLimit);
+
+        var candidates = await baseQuery
+            .Where(c => db.Likes.Any(l => l.ClipId == c.Id && l.CreatedAt > since)
+                     || db.ClipViews.Any(v => v.ClipId == c.Id && v.CreatedAt > since))
+            .Select(c => new
+            {
+                Clip = c,
+                LikesInWindow = db.Likes.Count(l => l.ClipId == c.Id && l.CreatedAt > since),
+                ViewsInWindow = db.ClipViews.Count(v => v.ClipId == c.Id && v.CreatedAt > since),
+            })
+            .ToListAsync(ct);
+
+        var now = DateTimeOffset.UtcNow;
+        var topIds = candidates
+            .Select(r => new
+            {
+                r.Clip,
+                Score = (r.LikesInWindow * 3 + r.ViewsInWindow)
+                    / Math.Pow(Math.Max(0, (now - r.Clip.CreatedAt).TotalHours) + 2, 1.5),
+            })
+            .OrderByDescending(r => r.Score)
+            .ThenByDescending(r => r.Clip.CreatedAt)
+            .Take(clampedLimit)
+            .Select(r => r.Clip.Id)
+            .ToList();
+
+        if (topIds.Count == 0)
+        {
+            return new ClipFeedResponse([], NextCursor: null);
+        }
+
+        // Re-hydrate with feed Includes (the candidate Select dropped them) and preserve
+        // ranking order. EF's Contains() generates IN (...) which doesn't preserve order, so
+        // we re-sort in C# after fetch using the topIds index.
+        //
+        // Visibility/status filters from `baseQuery` aren't reapplied here because `topIds` was
+        // already derived from the filtered candidate set. The micro-race window — a clip
+        // flipping to unlisted or back to processing between scoring and rehydration — could
+        // surface one stale row in a trending response; accepted as bounded and self-healing
+        // on the next request.
+        var ordered = await db.Clips.AsNoTracking()
+            .Where(c => topIds.Contains(c.Id))
+            .IncludeFeedRelations()
+            .ToListAsync(ct);
+
+        var byId = ordered.ToDictionary(c => c.Id);
+        var ranked = topIds.Select(id => byId[id]).ToList();
+
+        var items = await ProjectFeedItemsAsync(ranked, principal, db, storage, s3, ct);
+        return new ClipFeedResponse(items, NextCursor: null);
     }
 
     // Shared cursor-paginated feed builder. Callers pass a pre-filtered IQueryable<Clip>

--- a/server/src/GankedTV.Api/Endpoints/ClipsViewEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsViewEndpoints.cs
@@ -1,0 +1,94 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class ClipsViewEndpoints
+{
+    // Window inside which repeat POST /view from the same (clip, viewer) is collapsed to
+    // a single counted view. Sliding so a sustained-watch session doesn't suddenly count
+    // a second view 30 minutes after the first frame plays.
+    internal static readonly TimeSpan ViewDedupWindow = TimeSpan.FromMinutes(30);
+
+    public static IEndpointRouteBuilder MapClipsViewEndpoints(this IEndpointRouteBuilder app)
+    {
+        // Anonymous-friendly: no .RequireAuthorization(). Rate limit is per-IP so a single
+        // host can't run a view-pump regardless of whether they're logged in.
+        var group = app.MapGroup("/clips")
+            .RequireRateLimiting(ClipsRateLimiting.ClipsViewPolicy);
+        group.MapPost("/{id:guid}/view", RecordView);
+        return app;
+    }
+
+    private static async Task<IResult> RecordView(
+        Guid id,
+        HttpContext http,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IMemoryCache cache,
+        CancellationToken ct)
+    {
+        // Issue spec: every outcome (success, dedup, not-found, non-public) returns 204 as a
+        // silent no-op. Clients fire-and-forget — they neither need nor act on the result.
+        var viewerKey = ResolveViewerKey(principal, http);
+        var cacheKey = $"view:{id}:{viewerKey}";
+        if (cache.TryGetValue(cacheKey, out _))
+        {
+            return Results.NoContent();
+        }
+
+        // Wrap both writes in one tx so the denormalised `clips.view_count` counter and the
+        // `clip_views` event row can't drift on a partial failure — every counted view has
+        // exactly one event row backing it (and vice versa).
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
+
+        var rows = await db.Clips
+            .Where(c => c.Id == id && c.Visibility == "public" && c.Status == "ready")
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.ViewCount, c => c.ViewCount + 1), ct);
+
+        if (rows == 0)
+        {
+            // Clip is missing, draft, processing, or unlisted — silently no-op.
+            return Results.NoContent();
+        }
+
+        db.ClipViews.Add(new ClipView { ClipId = id, CreatedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        // Set AFTER the write commits so a transient DB failure doesn't poison the cache and
+        // silently swallow the next 30 min of legitimate views — the common failure case we
+        // care about. Cost of this ordering: under truly concurrent pings from the same
+        // (clip, viewer) arriving within milliseconds, both can pass TryGetValue above before
+        // either commits, producing an at-least-once over-count. Bounded by the per-IP rate
+        // limit (20/min) and per-(clip, viewer) cache key — acceptable for an engagement
+        // metric. If view_count ever needs to be exact, move to a DB-level unique constraint
+        // on (clip_id, viewer_key, time-bucket) instead of cache-before-commit.
+        cache.Set(cacheKey, true, new MemoryCacheEntryOptions
+        {
+            SlidingExpiration = ViewDedupWindow,
+        });
+
+        return Results.NoContent();
+    }
+
+    // Auth wins over IP: the same user moving between networks (mobile → wifi) is still the
+    // same viewer for dedup purposes, and shared NAT shouldn't make two logged-in viewers
+    // collapse into one.
+    private static string ResolveViewerKey(ClaimsPrincipal principal, HttpContext http)
+    {
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!string.IsNullOrEmpty(sub))
+        {
+            return $"u:{sub}";
+        }
+
+        return $"ip:{http.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+    }
+}

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -264,7 +264,13 @@ builder.Services.AddScoped<CredentialAuthService>();
 
 builder.Services.AddRateLimiter(opts => opts
     .AddCredentialsPolicy()
-    .AddClipsWritePolicy());
+    .AddClipsWritePolicy()
+    .AddClipsViewPolicy());
+
+// Backs the view-dedup window in ClipsViewEndpoints. In-process for v1; per-pod state is
+// fine for an anti-spam dedup (the worst-case drift on restart is a single bonus view per
+// client). Phase 4 swaps for Redis when limits + dedup go multi-instance.
+builder.Services.AddMemoryCache();
 
 builder.Services.AddSingleton<IOAuthProvider, DiscordOAuthProvider>();
 builder.Services.AddSingleton<IOAuthProvider, GoogleOAuthProvider>();
@@ -371,6 +377,7 @@ app.MapClipsUploadEndpoints();
 app.MapClipsReadEndpoints();
 app.MapClipsMutateEndpoints();
 app.MapLikesEndpoints();
+app.MapClipsViewEndpoints();
 app.MapCommentsEndpoints();
 app.MapUsersEndpoints();
 app.MapFollowsEndpoints();

--- a/server/tests/GankedTV.Api.Tests/Clips/ClipsRateLimitingTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Clips/ClipsRateLimitingTests.cs
@@ -59,6 +59,26 @@ public class ClipsRateLimitingTests
     }
 
     [Fact]
+    public void ResolveIpPartitionKey_UsesRemoteIp()
+    {
+        // The view-policy partition is IP-only — auth claims are ignored so a user behind
+        // shared NAT can't burn through the per-IP bucket faster than the anon equivalent.
+        var ctx = MakeContext(
+            claims: [new Claim(JwtRegisteredClaimNames.Sub, "should-be-ignored")],
+            remoteIp: IPAddress.Parse("192.0.2.7"));
+
+        ClipsRateLimiting.ResolveIpPartitionKey(ctx).Should().Be("ip:192.0.2.7");
+    }
+
+    [Fact]
+    public void ResolveIpPartitionKey_FallsBackToUnknown_WhenRemoteIpMissing()
+    {
+        var ctx = MakeContext(claims: [], remoteIp: null);
+
+        ClipsRateLimiting.ResolveIpPartitionKey(ctx).Should().Be("ip:unknown");
+    }
+
+    [Fact]
     public void ResolvePartitionKey_TreatsEmptySubAsMissing()
     {
         // ClaimsPrincipal.FindFirst returns the claim even when its Value is empty. Treating an

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -430,6 +430,272 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         byId[withoutGame].GetProperty("game").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
+    // ---- GET /clips/feed?sort=trending ----
+
+    [Fact]
+    public async Task Trending_24h_OrdersByScore()
+    {
+        // Score = (likes*3 + views) / pow(hours+2, 1.5). With matching ages, more engagement wins.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var (hot, _) = await SeedClipAsync(userId, now.AddHours(-1), title: "hot");
+        var (mid, _) = await SeedClipAsync(userId, now.AddHours(-1), title: "mid");
+        var (cool, _) = await SeedClipAsync(userId, now.AddHours(-1), title: "cool");
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.ClipViews.AddRange(
+                Enumerable.Range(0, 20).Select(_ => new ClipView { ClipId = hot, CreatedAt = now.AddMinutes(-5) }));
+            db.ClipViews.AddRange(
+                Enumerable.Range(0, 5).Select(_ => new ClipView { ClipId = mid, CreatedAt = now.AddMinutes(-5) }));
+            db.ClipViews.AddRange(
+                Enumerable.Range(0, 1).Select(_ => new ClipView { ClipId = cool, CreatedAt = now.AddMinutes(-5) }));
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?sort=trending&window=24h");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(hot, mid, cool);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Trending_LikesCountedTriple_VsViews()
+    {
+        // Score weighting locks the (likes*3 + views) coefficient: a clip with 1 like must
+        // outrank a clip with 2 views when ages match.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (likerId, _) = await SeedUserAndIssueTokenAsync("liker");
+        var now = DateTimeOffset.UtcNow;
+        var (oneLike, _) = await SeedClipAsync(userId, now.AddHours(-1), title: "one-like");
+        var (twoViews, _) = await SeedClipAsync(userId, now.AddHours(-1), title: "two-views");
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = likerId, ClipId = oneLike, CreatedAt = now.AddMinutes(-1) });
+            db.ClipViews.Add(new ClipView { ClipId = twoViews, CreatedAt = now.AddMinutes(-1) });
+            db.ClipViews.Add(new ClipView { ClipId = twoViews, CreatedAt = now.AddMinutes(-1) });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?sort=trending&window=24h");
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(oneLike, twoViews);
+    }
+
+    [Fact]
+    public async Task Trending_24hExcludesOlderEngagement_7dIncludes()
+    {
+        // A 3-day-old view falls outside the 24h window but inside 7d. Same clip, two
+        // windows, different result — the time-window filter is what makes trending "real".
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var (fresh, _) = await SeedClipAsync(userId, now.AddHours(-2), title: "fresh");
+        var (stale, _) = await SeedClipAsync(userId, now.AddDays(-3), title: "stale");
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.ClipViews.AddRange(
+                Enumerable.Range(0, 3).Select(_ => new ClipView { ClipId = fresh, CreatedAt = now.AddMinutes(-30) }));
+            db.ClipViews.AddRange(
+                Enumerable.Range(0, 50).Select(_ => new ClipView { ClipId = stale, CreatedAt = now.AddDays(-3) }));
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory!.CreateClient();
+
+        var dayResp = await client.GetAsync("/clips/feed?sort=trending&window=24h");
+        var dayIds = (await dayResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        dayIds.Should().Equal(fresh);
+
+        var weekResp = await client.GetAsync("/clips/feed?sort=trending&window=7d");
+        var weekIds = (await weekResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToHashSet();
+        weekIds.Should().Contain(fresh).And.Contain(stale);
+    }
+
+    [Fact]
+    public async Task Trending_ExcludesNonPublicAndNonReady()
+    {
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var (publicClip, _) = await SeedClipAsync(userId, now.AddHours(-1), title: "public-ready");
+        var (unlisted, _) = await SeedClipAsync(userId, now.AddHours(-1), visibility: "unlisted", title: "unlisted");
+        var (processing, _) = await SeedClipAsync(userId, now.AddHours(-1), status: "processing", title: "processing");
+
+        await using (var db = _fx.CreateContext())
+        {
+            foreach (var id in new[] { publicClip, unlisted, processing })
+            {
+                db.ClipViews.AddRange(
+                    Enumerable.Range(0, 5).Select(_ => new ClipView { ClipId = id, CreatedAt = now.AddMinutes(-10) }));
+            }
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?sort=trending&window=24h");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+
+        ids.Should().Equal(publicClip);
+    }
+
+    [Fact]
+    public async Task Trending_OmitsClipsWithoutEngagementInWindow()
+    {
+        // The trending feed is "what people are engaging with right now" — a clip with zero
+        // likes and zero views in the window has no place on the list even if it's recent.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var (engaged, _) = await SeedClipAsync(userId, now.AddHours(-1), title: "engaged");
+        await SeedClipAsync(userId, now.AddHours(-1), title: "dormant");
+
+        await using (var db = _fx.CreateContext())
+        {
+            db.ClipViews.Add(new ClipView { ClipId = engaged, CreatedAt = now.AddMinutes(-5) });
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?sort=trending&window=24h");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+
+        ids.Should().Equal(engaged);
+    }
+
+    [Fact]
+    public async Task Trending_InvalidWindow_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/clips/feed?sort=trending&window=bogus");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Feed_InvalidSort_Returns400()
+    {
+        // Symmetric with the window guard: an unknown explicit sort value is a 400 so client
+        // typos like `?sort=trendng` surface loudly instead of silently serving latest.
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/clips/feed?sort=bogus");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Trending_MissingWindow_Returns400()
+    {
+        // window is required for trending — unlike `source`, a missing value is a 400 because
+        // trending without a window has no defined meaning.
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/clips/feed?sort=trending");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Trending_EmptyResult_Returns200WithNoItems()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/clips/feed?sort=trending&window=24h");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Trending_LimitClampedToTrendingMax()
+    {
+        // Trending caps at TrendingMaxLimit (50) regardless of requested limit, since it's a
+        // single ranked page and the in-memory scoring step must stay bounded.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var clipIds = new List<Guid>(60);
+        for (var i = 0; i < 60; i++)
+        {
+            var (id, _) = await SeedClipAsync(userId, now.AddMinutes(-i), title: $"c{i}");
+            clipIds.Add(id);
+        }
+
+        await using (var db = _fx.CreateContext())
+        {
+            for (var i = 0; i < clipIds.Count; i++)
+            {
+                db.ClipViews.Add(new ClipView { ClipId = clipIds[i], CreatedAt = now.AddMinutes(-i) });
+            }
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/clips/feed?sort=trending&window=24h&limit=999");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        body.GetProperty("items").GetArrayLength().Should().Be(50);
+    }
+
+    [Fact]
+    public async Task Feed_DefaultSortLatest_UnchangedFromPreTrendingBehavior()
+    {
+        // Regression guard: passing sort=latest (or omitting sort) must keep the exact
+        // descending-by-created-at order + keyset cursor pagination the feed has always used.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync();
+        var now = DateTimeOffset.UtcNow;
+        var (a, _) = await SeedClipAsync(userId, now.AddMinutes(-3), title: "a");
+        var (b, _) = await SeedClipAsync(userId, now.AddMinutes(-2), title: "b");
+        var (c, _) = await SeedClipAsync(userId, now.AddMinutes(-1), title: "c");
+
+        using var client = _factory!.CreateClient();
+        var explicitResp = await client.GetAsync("/clips/feed?sort=latest");
+        var defaultResp = await client.GetAsync("/clips/feed");
+
+        explicitResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        defaultResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var explicitIds = (await explicitResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+        var defaultIds = (await defaultResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("items").EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid()).ToList();
+
+        explicitIds.Should().Equal(c, b, a);
+        defaultIds.Should().Equal(c, b, a);
+    }
+
     // ---- GET /clips/{id} ----
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsViewEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsViewEndpointsTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class ClipsViewEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public ClipsViewEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "viewer") =>
+        AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+
+    private HttpClient ClientWithBearer(string token) =>
+        AuthTestHelpers.CreateBearerClient(_factory!, token);
+
+    private async Task<Guid> SeedClipAsync(
+        Guid userId,
+        string status = "ready",
+        string visibility = "public",
+        int initialViewCount = 0)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = "viewable",
+            VideoKey = $"clips/{userId}/{id}.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
+            Status = status,
+            Visibility = visibility,
+            ViewCount = initialViewCount,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task RecordView_Anonymous_Returns204AndIncrementsCounter()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.PostAsync($"/clips/{clipId}/view", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await using var db = _fx.CreateContext();
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.ViewCount).FirstAsync()).Should().Be(1);
+        (await db.ClipViews.CountAsync(v => v.ClipId == clipId)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RecordView_RepeatedFromSameIp_IsDedupedToOne()
+    {
+        // 30-min dedup window must collapse a sustained-watch session into one counted view.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = _factory!.CreateClient();
+        var first = await client.PostAsync($"/clips/{clipId}/view", content: null);
+        var second = await client.PostAsync($"/clips/{clipId}/view", content: null);
+        var third = await client.PostAsync($"/clips/{clipId}/view", content: null);
+
+        first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        second.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        third.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var db = _fx.CreateContext();
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.ViewCount).FirstAsync()).Should().Be(1);
+        (await db.ClipViews.CountAsync(v => v.ClipId == clipId)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RecordView_NonExistentClip_Returns204Silently()
+    {
+        // Spec: "Returns 204 on success and on duplicate (silently no-op)." A missing clip is
+        // indistinguishable from an unlisted/processing clip from the client's perspective.
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsync($"/clips/{Guid.NewGuid()}/view", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await using var db = _fx.CreateContext();
+        (await db.ClipViews.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RecordView_NonPublicClip_Returns204AndNoIncrement()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var unlistedClip = await SeedClipAsync(authorId, visibility: "unlisted");
+        var processingClip = await SeedClipAsync(authorId, status: "processing");
+
+        using var client = _factory!.CreateClient();
+        var unlistedResp = await client.PostAsync($"/clips/{unlistedClip}/view", content: null);
+        var processingResp = await client.PostAsync($"/clips/{processingClip}/view", content: null);
+
+        unlistedResp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        processingResp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var db = _fx.CreateContext();
+        (await db.Clips.Where(c => c.Id == unlistedClip).Select(c => c.ViewCount).FirstAsync()).Should().Be(0);
+        (await db.Clips.Where(c => c.Id == processingClip).Select(c => c.ViewCount).FirstAsync()).Should().Be(0);
+        (await db.ClipViews.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RecordView_AuthenticatedDedupsByUserNotIp()
+    {
+        // Two different authed callers sharing one test-rig IP must both count: dedup keys on
+        // the JWT sub for authed callers, so shared NAT or office wifi doesn't collapse
+        // distinct viewers into one.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, viewerToken1) = await SeedUserAndIssueTokenAsync("v1");
+        var (_, viewerToken2) = await SeedUserAndIssueTokenAsync("v2");
+        var clipId = await SeedClipAsync(authorId);
+
+        using (var c1 = ClientWithBearer(viewerToken1))
+        {
+            (await c1.PostAsync($"/clips/{clipId}/view", content: null))
+                .StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+        using (var c2 = ClientWithBearer(viewerToken2))
+        {
+            (await c2.PostAsync($"/clips/{clipId}/view", content: null))
+                .StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        await using var db = _fx.CreateContext();
+        (await db.Clips.Where(c => c.Id == clipId).Select(c => c.ViewCount).FirstAsync()).Should().Be(2);
+        (await db.ClipViews.CountAsync(v => v.ClipId == clipId)).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RecordView_ExceedingRateLimit_Returns429()
+    {
+        // 20/min per IP. Fire 21 POSTs against distinct clip ids (so the cache dedup doesn't
+        // kick in and mask the limiter) and the last one must hit the limit.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var clipIds = new List<Guid>();
+        for (var i = 0; i < 22; i++)
+        {
+            clipIds.Add(await SeedClipAsync(authorId));
+        }
+
+        using var client = _factory!.CreateClient();
+        var statuses = new List<HttpStatusCode>();
+        foreach (var id in clipIds)
+        {
+            var resp = await client.PostAsync($"/clips/{id}/view", content: null);
+            statuses.Add(resp.StatusCode);
+        }
+
+        statuses.Take(ClipsRateLimiting.ViewPermitLimit).Should()
+            .OnlyContain(s => s == HttpStatusCode.NoContent);
+        statuses.Skip(ClipsRateLimiting.ViewPermitLimit).Should()
+            .OnlyContain(s => s == HttpStatusCode.TooManyRequests);
+    }
+}

--- a/web/src/api/__tests__/clips.spec.ts
+++ b/web/src/api/__tests__/clips.spec.ts
@@ -75,6 +75,63 @@ describe('api/clips', () => {
       const [url] = vi.mocked(fetch).mock.calls[0] as [string]
       expect(url).not.toContain('source=')
     })
+
+    it('encodes sort and window for trending queries', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await clips.feed({ sort: 'trending', window: '24h', limit: 50 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('sort=trending')
+      expect(url).toContain('window=24h')
+      expect(url).toContain('limit=50')
+    })
+
+    it('omits sort and window for default (latest) queries', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await clips.feed({ limit: 20 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).not.toContain('sort=')
+      expect(url).not.toContain('window=')
+    })
+  })
+
+  describe('recordView()', () => {
+    it('POSTs to /clips/{id}/view with no body', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      )
+
+      const result = await clips.recordView('abc-123')
+
+      expect(result).toBeUndefined()
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/clips/abc-123/view`)
+      expect(init.method).toBe('POST')
+      // No body should be sent — the server reads (clip_id, viewer) from the URL/JWT/IP only.
+      expect(init.body).toBeUndefined()
+    })
+
+    it('URI-encodes the id', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      )
+
+      await clips.recordView('weird id/with?chars')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/clips/${encodeURIComponent('weird id/with?chars')}/view`)
+    })
   })
 
   describe('getDetail()', () => {

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -68,15 +68,18 @@ export interface ClipFeedPage {
   nextCursor: string | null
 }
 
-export interface ClipFeedQuery {
+interface ClipFeedQueryBase {
   cursor?: string | null
   limit?: number
   source?: 'public' | 'following'
-  // Default 'latest' (omitted). 'trending' returns a single ranked page (no cursor)
-  // and REQUIRES `window` — the server 400s on a missing/unknown window.
-  sort?: 'latest' | 'trending'
-  window?: '24h' | '7d'
 }
+
+// Discriminated union: trending REQUIRES a window (server 400s without one) and
+// `latest` is the default omitted shape, so `window` is meaningless there. Encoding
+// this in the type stops callers from constructing combos the server will reject.
+export type ClipFeedQuery =
+  | (ClipFeedQueryBase & { sort?: 'latest'; window?: never })
+  | (ClipFeedQueryBase & { sort: 'trending'; window: '24h' | '7d' })
 
 export interface UploadUrl {
   url: string
@@ -113,8 +116,13 @@ export const clips = {
     if (query.cursor) params.set('cursor', query.cursor)
     if (query.limit !== undefined) params.set('limit', String(query.limit))
     if (query.source) params.set('source', query.source)
-    if (query.sort) params.set('sort', query.sort)
-    if (query.window) params.set('window', query.window)
+    // Only serialize sort/window when trending — `sort=latest` is the default
+    // and the latest variant has no window. The type union enforces this shape
+    // statically; the runtime check just mirrors it for the emitted JS.
+    if (query.sort === 'trending') {
+      params.set('sort', 'trending')
+      params.set('window', query.window)
+    }
     const qs = params.toString()
     return api<ClipFeedPage>(`/clips/feed${qs ? `?${qs}` : ''}`)
   },

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -72,6 +72,10 @@ export interface ClipFeedQuery {
   cursor?: string | null
   limit?: number
   source?: 'public' | 'following'
+  // Default 'latest' (omitted). 'trending' returns a single ranked page (no cursor)
+  // and REQUIRES `window` — the server 400s on a missing/unknown window.
+  sort?: 'latest' | 'trending'
+  window?: '24h' | '7d'
 }
 
 export interface UploadUrl {
@@ -109,8 +113,17 @@ export const clips = {
     if (query.cursor) params.set('cursor', query.cursor)
     if (query.limit !== undefined) params.set('limit', String(query.limit))
     if (query.source) params.set('source', query.source)
+    if (query.sort) params.set('sort', query.sort)
+    if (query.window) params.set('window', query.window)
     const qs = params.toString()
     return api<ClipFeedPage>(`/clips/feed${qs ? `?${qs}` : ''}`)
+  },
+
+  // POST /clips/{id}/view — anonymous-friendly view ping. Server returns 204 on success,
+  // dedup hit, and not-found (silent no-op). Fire-and-forget from the player after ~3s
+  // of playback; failures don't bubble.
+  recordView(id: string): Promise<void> {
+    return api<void>(`/clips/${encodeURIComponent(id)}/view`, { method: 'POST' })
   },
 
   getDetail(id: string): Promise<ClipDetail> {

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -35,6 +35,24 @@ const toastText = ref('')
 const videoEl = useTemplateRef<HTMLVideoElement>('videoEl')
 let player: Plyr | null = null
 
+// View tracking: fire POST /clips/{id}/view exactly once per mount after ~3s of
+// accumulated playback. Bounded per-tick delta caps seeking jumps (current_time can
+// jump forwards on a scrub) so a single seek doesn't trigger an instant record.
+// `viewRecordedForClipId` is intentionally never cleared: re-navigating to the same
+// clip within the SPA session won't re-ping. The server-side 30-min dedup would
+// collapse it anyway, and erring on under-count beats over-counting on remount.
+let viewRecordedForClipId: string | null = null
+let playedMs = 0
+let lastTickTime = 0
+let viewTickListener: { el: HTMLVideoElement; handler: () => void } | null = null
+
+function detachViewTracking() {
+  if (viewTickListener) {
+    viewTickListener.el.removeEventListener('timeupdate', viewTickListener.handler)
+    viewTickListener = null
+  }
+}
+
 // Monotonic request counter — guards against A→B→A races where comparing
 // `clipId.value === id` would falsely accept the first A response after the
 // second A request supersedes it.
@@ -95,11 +113,44 @@ watch(
       controls: ['play-large', 'play', 'progress', 'current-time', 'mute', 'volume', 'fullscreen'],
       tooltips: { controls: true, seek: true },
     })
+    attachViewTracking(detail.id, el)
   },
   { flush: 'post' },
 )
 
+// Bind to the underlying <video> element's `timeupdate` (not Plyr's wrapper) — Plyr
+// re-fires the same DOM event but the element listener stays valid across Plyr lifecycle
+// quirks. Per-tick delta is clamped to [0, 1000ms] so a scrub forward doesn't credit the
+// gap, and a scrub backward doesn't subtract.
+function attachViewTracking(targetClipId: string, el: HTMLVideoElement) {
+  detachViewTracking()
+  playedMs = 0
+  lastTickTime = el.currentTime * 1000
+  const onTick = () => {
+    if (viewRecordedForClipId === targetClipId || el.paused) {
+      lastTickTime = el.currentTime * 1000
+      return
+    }
+    const now = el.currentTime * 1000
+    const delta = now - lastTickTime
+    lastTickTime = now
+    if (delta > 0 && delta < 1000) {
+      playedMs += delta
+    }
+    if (playedMs >= 3000) {
+      viewRecordedForClipId = targetClipId
+      void clips.recordView(targetClipId).catch(() => {
+        // Silent: view tracking is best-effort. A failed ping shouldn't surface to the user
+        // and shouldn't retry — the server's rate limit + dedup means retries hurt more than help.
+      })
+    }
+  }
+  el.addEventListener('timeupdate', onTick)
+  viewTickListener = { el, handler: onTick }
+}
+
 function teardownPlayer() {
+  detachViewTracking()
   if (player) {
     player.destroy()
     player = null

--- a/web/src/views/TrendingView.vue
+++ b/web/src/views/TrendingView.vue
@@ -30,7 +30,13 @@ const errored = ref(false)
 
 const hotGames = ref<GameListItem[]>([])
 
+// Monotonic token so rapid `timeWindow` toggles (24h → 7d → 24h …) don't let a slow
+// earlier response overwrite a newer one. Without this, the user can land on `7d` and
+// see `24h` results blink in a moment later.
+let latestLoadId = 0
+
 async function load() {
+  const loadId = ++latestLoadId
   loading.value = true
   errored.value = false
   try {
@@ -38,13 +44,15 @@ async function load() {
       clips.feed({ sort: 'trending', window: timeWindow.value, limit: 50 }),
       gamesApi.list(8),
     ])
+    if (loadId !== latestLoadId) return
     topClips.value = feed.items.slice(0, 10)
     hotGames.value = games
   } catch (err) {
+    if (loadId !== latestLoadId) return
     console.error('trending: load failed', err)
     errored.value = true
   } finally {
-    loading.value = false
+    if (loadId === latestLoadId) loading.value = false
   }
 }
 

--- a/web/src/views/TrendingView.vue
+++ b/web/src/views/TrendingView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { clips, type ClipFeedItem } from '@/api/clips'
 import { games as gamesApi, type GameListItem } from '@/api/games'
 import { formatNum } from '@/lib/format'
@@ -10,26 +10,23 @@ import StatusPanel from '@/components/StatusPanel.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import IconChevronRight from '@/components/icons/IconChevronRight.vue'
 
+// Only 24h and 7d hit the server-side trending feed today. The other windows surface the
+// UX intent (and the issue's "drop fake arrows for v1" sentiment is to ship what the
+// server actually supports), so they're rendered but aria-disabled until follow-up windows land.
+type TrendingWindow = '24h' | '7d'
 const TIME_WINDOWS = [
-  { key: '1h', label: 'Last hour' },
-  { key: '24h', label: '24 hours' },
-  { key: '7d', label: 'This week' },
-  { key: '30d', label: 'This month' },
-  { key: 'all', label: 'All time' },
+  { key: '1h', label: 'Last hour', enabled: false },
+  { key: '24h', label: '24 hours', enabled: true },
+  { key: '7d', label: 'This week', enabled: true },
+  { key: '30d', label: 'This month', enabled: false },
+  { key: 'all', label: 'All time', enabled: false },
 ] as const
 
-// The server doesn't filter by time window yet — these tabs are visual until that
-// lands. Surfacing them keeps the UX intent visible (and lets the server-side
-// follow-up just wire `?since=` without UI work).
-const timeWindow = ref<string>('24h')
+const timeWindow = ref<TrendingWindow>('24h')
 
-const allClips = ref<ClipFeedItem[]>([])
+const topClips = ref<ClipFeedItem[]>([])
 const loading = ref(false)
 const errored = ref(false)
-
-const topClips = computed(() =>
-  [...allClips.value].sort((a, b) => b.likeCount - a.likeCount).slice(0, 10),
-)
 
 const hotGames = ref<GameListItem[]>([])
 
@@ -37,8 +34,11 @@ async function load() {
   loading.value = true
   errored.value = false
   try {
-    const [feed, games] = await Promise.all([clips.feed({ limit: 100 }), gamesApi.list(8)])
-    allClips.value = feed.items
+    const [feed, games] = await Promise.all([
+      clips.feed({ sort: 'trending', window: timeWindow.value, limit: 50 }),
+      gamesApi.list(8),
+    ])
+    topClips.value = feed.items.slice(0, 10)
     hotGames.value = games
   } catch (err) {
     console.error('trending: load failed', err)
@@ -50,42 +50,33 @@ async function load() {
 
 onMounted(load)
 
-// Visual-only indicator on the leaderboard rows — *not* derived from real
-// trend data. We don't track engagement deltas yet (server has no time-window
-// query). Top 3 always show ▲, 3–5 show —, the rest alternate. Replace once a
-// real `trendDelta` field lands on the trending response.
-function trendFor(i: number): 'up' | 'hold' | 'down' {
-  if (i < 3) return 'up'
-  if (i < 6) return 'hold'
-  return i % 2 === 0 ? 'up' : 'down'
+// Window change → re-fetch. Hot games don't depend on the window, so reloading them is
+// wasted work but the simplicity wins; the request is cheap and small.
+watch(timeWindow, load)
+
+function selectWindow(key: string, enabled: boolean) {
+  if (!enabled || key === timeWindow.value) return
+  timeWindow.value = key as TrendingWindow
 }
 
 const timeBtnBase =
-  'px-3.5 py-1.5 rounded-sm font-mono text-[11px] uppercase tracking-[0.06em] border-none cursor-pointer'
-const timeBtnActive = `${timeBtnBase} bg-brand text-white transition-[background] duration-150`
-const timeBtnInactive = `${timeBtnBase} bg-transparent text-text-secondary transition-[color] duration-150`
+  'px-3.5 py-1.5 rounded-sm font-mono text-[11px] uppercase tracking-[0.06em] border-none'
+const timeBtnActive = `${timeBtnBase} bg-brand text-white cursor-pointer transition-[background] duration-150`
+const timeBtnInactiveEnabled = `${timeBtnBase} bg-transparent text-text-secondary cursor-pointer transition-[color] duration-150`
+const timeBtnInactiveDisabled = `${timeBtnBase} bg-transparent text-text-secondary opacity-50 cursor-not-allowed`
 
 const rankBase = 'font-heading font-bold text-[28px] leading-none'
 const rankTop = `${rankBase} text-brand-light`
 const rankRest = `${rankBase} text-text-muted`
-
-const trendBase = 'font-mono text-[11px] leading-none'
-const trendUp = `${trendBase} text-neon`
-const trendDown = `${trendBase} text-error`
-const trendHold = `${trendBase} text-text-muted`
 </script>
 
 <template>
   <main class="mx-auto max-w-360 px-6 pt-8 pb-30">
     <PageHeader title="Trending">
-      <template #caption>Ranked by likes (server-side trending coming soon)</template>
+      <template #caption>Ranked by recent engagement (likes × 3 + views, decayed by age)</template>
 
-      <!-- Time window toggle. Server doesn't support `?since=` yet — non-active
-           tabs are visually inert until the backend filter lands. We use
-           aria-disabled (not the native `disabled` attr) so the buttons stay
-           focusable and screen readers can announce the "coming soon" hint. -->
       <p id="time-window-hint" class="sr-only">
-        Server-side time filtering coming soon — only the active window is selectable.
+        24-hour and 7-day windows are available; the other ranges are coming soon.
       </p>
       <div
         class="mt-5 inline-flex gap-0.5 p-1 bg-surface-raised border border-border rounded-sm"
@@ -96,13 +87,17 @@ const trendHold = `${trendBase} text-text-muted`
           v-for="tw in TIME_WINDOWS"
           :key="tw.key"
           type="button"
-          :class="[
-            timeWindow === tw.key ? timeBtnActive : timeBtnInactive,
-            tw.key === timeWindow ? '' : 'opacity-50 cursor-not-allowed',
-          ]"
-          :aria-disabled="tw.key !== timeWindow"
+          :class="
+            timeWindow === tw.key
+              ? timeBtnActive
+              : tw.enabled
+                ? timeBtnInactiveEnabled
+                : timeBtnInactiveDisabled
+          "
+          :aria-disabled="!tw.enabled"
           :aria-pressed="tw.key === timeWindow"
           aria-describedby="time-window-hint"
+          @click="selectWindow(tw.key, tw.enabled)"
         >
           {{ tw.label }}
         </button>
@@ -123,7 +118,7 @@ const trendHold = `${trendBase} text-text-muted`
     <StatusPanel
       v-else-if="!loading && topClips.length === 0"
       kind="empty"
-      message="No clips yet — be the first."
+      message="No clips trending yet — check back soon."
     />
 
     <!-- Two-column layout -->
@@ -135,7 +130,7 @@ const trendHold = `${trendBase} text-text-muted`
       <div class="bg-surface-raised border border-border rounded-md overflow-hidden mt-7">
         <div class="px-4 py-3.5 border-b border-border">
           <span class="font-heading font-bold text-sm uppercase text-text-secondary tracking-wider"
-            >Top 10 by likes</span
+            >Top 10 right now</span
           >
         </div>
 
@@ -144,17 +139,9 @@ const trendHold = `${trendBase} text-text-muted`
           :key="clip.id"
           :to="{ name: 'clip', params: { id: clip.id } }"
           :aria-label="`#${i + 1}: ${clip.title}`"
-          class="grid grid-cols-[60px_120px_1fr_auto_auto] gap-4 items-center px-4 py-3 transition-[background] duration-150 border-b border-border last:border-b-0 outline-none hover:bg-surface-overlay focus-visible:bg-surface-overlay focus-visible:ring-2 focus-visible:ring-brand-light"
+          class="grid grid-cols-[40px_120px_1fr_auto_auto] gap-4 items-center px-4 py-3 transition-[background] duration-150 border-b border-border last:border-b-0 outline-none hover:bg-surface-overlay focus-visible:bg-surface-overlay focus-visible:ring-2 focus-visible:ring-brand-light"
         >
-          <div class="flex flex-col items-start gap-0.5">
-            <span :class="i < 3 ? rankTop : rankRest">#{{ i + 1 }}</span>
-            <span
-              :class="
-                trendFor(i) === 'up' ? trendUp : trendFor(i) === 'down' ? trendDown : trendHold
-              "
-              >{{ trendFor(i) === 'up' ? '▲' : trendFor(i) === 'down' ? '▼' : '—' }}</span
-            >
-          </div>
+          <span :class="i < 3 ? rankTop : rankRest">#{{ i + 1 }}</span>
 
           <div class="relative rounded-[4px] overflow-hidden aspect-video bg-surface-sunken">
             <img :src="clip.thumbnailUrl" alt="" class="w-full h-full object-cover block" />


### PR DESCRIPTION
## Summary

Closes the trending-feed milestone in issue #87: backend now ranks clips by a time-weighted engagement score (likes weighted 3× views, decayed by clip age) over a 24h or 7d window, and the web app records real view counts from the player and renders the ranked result on `/trending`.

Replaces the placeholder TrendingView (which sorted client-side by all-time likes and faked the trend arrows) with a real server-side ranked feed; the fake `▲/▼/—` indicators are gone until a real `trendDelta` field lands.

## What's here

- **Schema:** new append-only `clip_views` event table with `(clip_id, created_at)` and `(created_at)` indexes; added `(created_at, clip_id)` to `likes` to keep the window-aggregation query off a full scan.
- **`POST /clips/{id}/view`:** anonymous-friendly, per-IP rate limited (20/min), 30-min sliding in-memory dedup keyed by `(clip, viewer)` — auth wins over IP so shared NAT doesn't collapse two logged-in viewers into one. Increments `clips.view_count` and inserts a `clip_views` row atomically.
- **`GET /clips/feed?sort=trending&window=24h|7d`:** single ranked page (no cursor), capped at 50. Score = `(likes×3 + views_in_window) / pow(hours+2, 1.5)`. 400 on invalid/missing `window`, 400 on unknown `sort` (null still defaults to latest).
- **Web — `ClipView.vue`:** player fires exactly one view ping per mount after ~3s of actually-played time. Per-tick delta clamped to `[0, 1000ms]` so a scrub forward doesn't credit the gap.
- **Web — `TrendingView.vue`:** wired to the trending endpoint with a 24h/7d toggle (1h / 30d / all aria-disabled until those windows land server-side).
- Design notes in `docs/trending-and-views.md`.

Closes #87

## How to test manually

1. `make up && make seed && make server` (separately: `cd web && bun dev`).
2. **View ping:** open a clip at http://localhost:5173, play past 3s. In DevTools Network you should see exactly one `POST /clips/{id}/view` → `204`. Replay the clip in the same tab — no second ping (client-side dedup). Confirm the counter incremented:
   ```
   psql -h localhost -p 5435 -U gankedtv -c "select id, view_count from clips order by updated_at desc limit 5;"
   ```
3. **Rate limit:** fire >20 view pings against distinct clip ids from the same IP within a minute — last request should return `429`.
4. **Trending feed:** seed engagement (a few likes / view pings on different clips), then visit http://localhost:5173/trending. Switch between 24h and 7d — the list re-fetches and rankings should differ when engagement is age-distributed.
5. **Validation:**
   ```
   curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/clips/feed?sort=bogus'                  # 400
   curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/clips/feed?sort=trending'               # 400 (missing window)
   curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/clips/feed?sort=trending&window=bogus'  # 400
   curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/clips/feed?sort=trending&window=24h'   # 200
   curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/clips/feed'                            # 200 (default latest)
   ```

## Follow-ups (not in this PR)

- The trending query materialises every clip with engagement in the window into memory before scoring. Documented inline; needs a SQL `GROUP BY` rewrite if active-clips-per-window approaches ~10k.
- The in-memory dedup cache is per-pod; revisit when limits + dedup need to go multi-instance (likely Redis).
- 1h / 30d / all-time windows on the trending UI are aria-disabled pending server support.

## Checklist

- [x] `make ci` passes locally (server + web, coverage gates met)
- [x] Manual smoke (view ping + trending toggle) verified in browser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic view tracking for clips that records views as users watch videos, with intelligent deduplication to avoid counting the same viewer multiple times
  * Trending feed now features server-side engagement scoring across selectable 24h and 7d time windows
  * Rate limiting applied to view tracking

* **Improvements**
  * Enhanced trending algorithm weights likes 3x higher than views for more accurate engagement scoring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->