### PR TITLE
[server][web] Notifications: schema + event recording + bell/dropdown/page

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Notifications/ClipSummary.cs
+++ b/server/src/GankedTV.Api/Contracts/Notifications/ClipSummary.cs
@@ -1,0 +1,6 @@
+namespace GankedTV.Api.Contracts.Notifications;
+
+// Slim shape — the notification dropdown only needs enough to route to the clip and label the
+// row ("liked your clip 'Ace clutch'"). Full feed item / detail responses carry presigned
+// media URLs which are pointless here.
+public sealed record ClipSummary(Guid Id, string ShareCode, string Title);

--- a/server/src/GankedTV.Api/Contracts/Notifications/CommentPreview.cs
+++ b/server/src/GankedTV.Api/Contracts/Notifications/CommentPreview.cs
@@ -1,0 +1,5 @@
+namespace GankedTV.Api.Contracts.Notifications;
+
+// Body is nullable to mirror CommentItem — a soft-deleted comment surfaces as null so the UI
+// can render a `[deleted]` placeholder without losing the row's anchor.
+public sealed record CommentPreview(Guid Id, string? Body);

--- a/server/src/GankedTV.Api/Contracts/Notifications/MarkAllReadResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Notifications/MarkAllReadResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Notifications;
+
+public sealed record MarkAllReadResponse(int Marked);

--- a/server/src/GankedTV.Api/Contracts/Notifications/NotificationItem.cs
+++ b/server/src/GankedTV.Api/Contracts/Notifications/NotificationItem.cs
@@ -1,0 +1,12 @@
+using GankedTV.Api.Contracts.Clips;
+
+namespace GankedTV.Api.Contracts.Notifications;
+
+public sealed record NotificationItem(
+    Guid Id,
+    string Type,
+    AuthorSummary Actor,
+    ClipSummary? Clip,
+    CommentPreview? Comment,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ReadAt);

--- a/server/src/GankedTV.Api/Contracts/Notifications/NotificationListResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Notifications/NotificationListResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Notifications;
+
+public sealed record NotificationListResponse(IReadOnlyList<NotificationItem> Items, string? NextCursor);

--- a/server/src/GankedTV.Api/Contracts/Notifications/NotificationMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Notifications/NotificationMappings.cs
@@ -1,0 +1,24 @@
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Contracts.Notifications;
+
+public static class NotificationMappings
+{
+    /// <summary>
+    /// Maps a notification entity to its API shape. Callers must <c>.Include(n =&gt; n.Actor)</c>
+    /// and (where present) <c>.Include(n =&gt; n.Clip)</c> / <c>.Include(n =&gt; n.Comment)</c>
+    /// — an un-included nav silently surfaces as <c>null</c>, masking bugs.
+    /// </summary>
+    public static NotificationItem ToItem(this Notification n) =>
+        new(
+            n.Id,
+            n.Type,
+            n.Actor.ToAuthorSummary(),
+            n.Clip is null ? null : new ClipSummary(n.Clip.Id, n.Clip.ShareCode, n.Clip.Title),
+            n.Comment is null
+                ? null
+                : new CommentPreview(n.Comment.Id, n.Comment.DeletedAt is null ? n.Comment.Body : null),
+            n.CreatedAt,
+            n.ReadAt);
+}

--- a/server/src/GankedTV.Api/Contracts/Notifications/UnreadCountResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Notifications/UnreadCountResponse.cs
@@ -1,0 +1,3 @@
+namespace GankedTV.Api.Contracts.Notifications;
+
+public sealed record UnreadCountResponse(int Count);

--- a/server/src/GankedTV.Api/Data/Entities/Notification.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Notification.cs
@@ -1,0 +1,26 @@
+namespace GankedTV.Api.Data.Entities;
+
+public class Notification
+{
+    public Guid Id { get; set; }
+    public Guid RecipientId { get; set; }
+    public Guid ActorId { get; set; }
+
+    // 'like' | 'comment' | 'follow'. Kept as a short string to mirror Clip.Status / Visibility —
+    // an EF enum mapping would add ceremony for three values that the UI also treats as strings.
+    public required string Type { get; set; }
+
+    // Populated on like and comment notifications (so the UI can link to the clip); null on follow.
+    public Guid? ClipId { get; set; }
+
+    // Populated on comment notifications only.
+    public Guid? CommentId { get; set; }
+
+    public DateTimeOffset? ReadAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public User Recipient { get; set; } = null!;
+    public User Actor { get; set; } = null!;
+    public Clip? Clip { get; set; }
+    public Comment? Comment { get; set; }
+}

--- a/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
+++ b/server/src/GankedTV.Api/Data/GankedTvDbContext.cs
@@ -15,6 +15,7 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
     public DbSet<Tag> Tags => Set<Tag>();
     public DbSet<ClipTag> ClipTags => Set<ClipTag>();
+    public DbSet<Notification> Notifications => Set<Notification>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -241,6 +242,55 @@ public class GankedTvDbContext(DbContextOptions<GankedTvDbContext> options) : Db
             // EF auto-generates an index on the UserId FK; name it explicitly to match the
             // `idx_*` convention used elsewhere (otherwise it lands as `ix_comments_user_id`).
             e.HasIndex(c => c.UserId).HasDatabaseName("idx_comments_user_id");
+        });
+
+        modelBuilder.Entity<Notification>(e =>
+        {
+            e.HasKey(n => n.Id);
+            e.Property(n => n.Id).HasDefaultValueSql("gen_random_uuid()");
+            e.Property(n => n.Type).HasMaxLength(20);
+            e.Property(n => n.CreatedAt).HasDefaultValueSql("now()");
+
+            // Two FKs to the same `users` table (recipient + actor): use parameterless WithMany()
+            // so we don't have to carry two collections on User just for cascade configuration.
+            e.HasOne(n => n.Recipient)
+                .WithMany()
+                .HasForeignKey(n => n.RecipientId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(n => n.Actor)
+                .WithMany()
+                .HasForeignKey(n => n.ActorId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Deleting a clip clears any notifications anchored to it; same for a comment. Both
+            // FKs are nullable since a `follow` notification has neither.
+            e.HasOne(n => n.Clip)
+                .WithMany()
+                .HasForeignKey(n => n.ClipId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(n => n.Comment)
+                .WithMany()
+                .HasForeignKey(n => n.CommentId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Defence in depth: the service layer filters self-actions, but the DB-level CHECK
+            // guards against a buggy future call site (mirrors ck_follows_no_self).
+            e.ToTable(t => t.HasCheckConstraint(
+                "ck_notifications_no_self",
+                "actor_id <> recipient_id"));
+
+            // Drives the recipient's listing (RecipientId filter, CreatedAt desc keyset).
+            e.HasIndex(n => new { n.RecipientId, n.CreatedAt })
+                .IsDescending(false, true)
+                .HasDatabaseName("idx_notifications_recipient");
+
+            // Partial index — only unread rows, so the unread-count probe stays bounded by the
+            // tail of in-flight notifications even as the table grows.
+            e.HasIndex(n => n.RecipientId)
+                .HasFilter("read_at IS NULL")
+                .HasDatabaseName("idx_notifications_unread");
         });
 
         modelBuilder.Entity<RefreshToken>(e =>

--- a/server/src/GankedTV.Api/Data/Migrations/20260523154640_AddNotifications.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260523154640_AddNotifications.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523154640_AddNotifications")]
+    partial class AddNotifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/GankedTV.Api/Data/Migrations/20260523154640_AddNotifications.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260523154640_AddNotifications.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "notifications",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    recipient_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    actor_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    type = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    clip_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    comment_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    read_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_notifications", x => x.id);
+                    table.CheckConstraint("ck_notifications_no_self", "actor_id <> recipient_id");
+                    table.ForeignKey(
+                        name: "fk_notifications_clips_clip_id",
+                        column: x => x.clip_id,
+                        principalTable: "clips",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_notifications_comments_comment_id",
+                        column: x => x.comment_id,
+                        principalTable: "comments",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_notifications_users_actor_id",
+                        column: x => x.actor_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_notifications_users_recipient_id",
+                        column: x => x.recipient_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_notifications_recipient",
+                table: "notifications",
+                columns: new[] { "recipient_id", "created_at" },
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_notifications_unread",
+                table: "notifications",
+                column: "recipient_id",
+                filter: "read_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notifications_actor_id",
+                table: "notifications",
+                column: "actor_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notifications_clip_id",
+                table: "notifications",
+                column: "clip_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notifications_comment_id",
+                table: "notifications",
+                column: "comment_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "notifications");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
@@ -4,6 +4,7 @@ using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Comments;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Notifications;
 using GankedTV.Api.Pagination;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Validation;
@@ -44,6 +45,7 @@ public static class CommentsEndpoints
         [FromBody] CreateCommentRequest? req,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
+        INotificationService notifications,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -60,7 +62,11 @@ public static class CommentsEndpoints
 
         var body = req.Body.Trim();
 
-        if (!await db.Clips.AnyAsync(c => c.Id == clipId, ct))
+        var clipOwnerId = await db.Clips.AsNoTracking()
+            .Where(c => c.Id == clipId)
+            .Select(c => (Guid?)c.UserId)
+            .FirstOrDefaultAsync(ct);
+        if (clipOwnerId is null)
         {
             return ProblemResults.NotFound("not_found");
         }
@@ -89,6 +95,11 @@ public static class CommentsEndpoints
         };
         db.Comments.Add(comment);
         await db.SaveChangesAsync(ct);
+
+        // Notify the clip owner — replies-to-replies still notify the clip owner only; notifying
+        // the parent commenter is a Phase 4 follow-up. Self-comments are dropped by the service.
+        await notifications.RecordAsync(
+            clipOwnerId.Value, userId, NotificationTypes.Comment, clipId, comment.Id, ct);
 
         // Author is needed for the response shape; the authenticated user always exists.
         comment.User = (await db.Users.FindAsync([userId], ct))!;

--- a/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/CommentsEndpoints.cs
@@ -93,6 +93,12 @@ public static class CommentsEndpoints
             ParentId = req.ParentId,
             Body = body,
         };
+
+        // Wrap comment insert + notification so a notification failure rolls back the comment —
+        // INotificationService promises to enlist in the caller's transaction, and the comment
+        // would otherwise be visible without the notification ever being recorded.
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
+
         db.Comments.Add(comment);
         await db.SaveChangesAsync(ct);
 
@@ -100,6 +106,8 @@ public static class CommentsEndpoints
         // the parent commenter is a Phase 4 follow-up. Self-comments are dropped by the service.
         await notifications.RecordAsync(
             clipOwnerId.Value, userId, NotificationTypes.Comment, clipId, comment.Id, ct);
+
+        await tx.CommitAsync(ct);
 
         // Author is needed for the response shape; the authenticated user always exists.
         comment.User = (await db.Users.FindAsync([userId], ct))!;

--- a/server/src/GankedTV.Api/Endpoints/FollowsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/FollowsEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using GankedTV.Api.Contracts.Users;
 using GankedTV.Api.Data;
+using GankedTV.Api.Notifications;
 using GankedTV.Api.Pagination;
 using GankedTV.Api.Problems;
 using Microsoft.EntityFrameworkCore;
@@ -28,6 +29,7 @@ public static class FollowsEndpoints
         string username,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
+        INotificationService notifications,
         CancellationToken ct)
     {
         if (!ClipsReadEndpoints.TryGetUserId(principal, out var followerId))
@@ -48,9 +50,17 @@ public static class FollowsEndpoints
 
         // ON CONFLICT DO NOTHING collapses both sequential double-clicks and concurrent
         // requests from the same follower into a single row — same pattern as Like.
-        await db.Database.ExecuteSqlInterpolatedAsync(
+        var inserted = await db.Database.ExecuteSqlInterpolatedAsync(
             $"INSERT INTO follows (follower_id, followee_id) VALUES ({followerId}, {target.Id}) ON CONFLICT DO NOTHING",
             ct);
+
+        if (inserted == 1)
+        {
+            // Notify the followee. Re-following after an unfollow still produces a new
+            // notification — mirrors the like / re-like semantics elsewhere.
+            await notifications.RecordAsync(
+                target.Id, followerId, NotificationTypes.Follow, null, null, ct);
+        }
 
         return Results.NoContent();
     }

--- a/server/src/GankedTV.Api/Endpoints/FollowsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/FollowsEndpoints.cs
@@ -48,6 +48,12 @@ public static class FollowsEndpoints
             return ProblemResults.BadRequest("self_follow", "Cannot follow yourself.");
         }
 
+        // Wrap insert + RecordAsync so a notification failure rolls the follow back —
+        // INotificationService promises to enlist in the caller's transaction, and there's
+        // no retry path (dedup is `inserted == 1`), so an event without its notification
+        // would be lost forever.
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
+
         // ON CONFLICT DO NOTHING collapses both sequential double-clicks and concurrent
         // requests from the same follower into a single row — same pattern as Like.
         var inserted = await db.Database.ExecuteSqlInterpolatedAsync(
@@ -61,6 +67,8 @@ public static class FollowsEndpoints
             await notifications.RecordAsync(
                 target.Id, followerId, NotificationTypes.Follow, null, null, ct);
         }
+
+        await tx.CommitAsync(ct);
 
         return Results.NoContent();
     }

--- a/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LikesEndpoints.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
+using GankedTV.Api.Notifications;
 using GankedTV.Api.Problems;
 using Microsoft.EntityFrameworkCore;
 
@@ -24,6 +25,7 @@ public static class LikesEndpoints
         Guid id,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
+        INotificationService notifications,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -33,8 +35,11 @@ public static class LikesEndpoints
 
         await using var tx = await db.Database.BeginTransactionAsync(ct);
 
-        var clipExists = await db.Clips.AnyAsync(c => c.Id == id, ct);
-        if (!clipExists)
+        var clipOwnerId = await db.Clips.AsNoTracking()
+            .Where(c => c.Id == id)
+            .Select(c => (Guid?)c.UserId)
+            .FirstOrDefaultAsync(ct);
+        if (clipOwnerId is null)
         {
             return ProblemResults.NotFound("not_found");
         }
@@ -53,6 +58,12 @@ public static class LikesEndpoints
                 .ExecuteUpdateAsync(
                     s => s.SetProperty(c => c.LikeCount, c => c.LikeCount + 1),
                     ct);
+
+            // Record only on the first like (re-likes after an unlike still register because the
+            // row was reinserted). The service drops self-likes; the surrounding transaction
+            // means a notification failure rolls back the like row too.
+            await notifications.RecordAsync(
+                clipOwnerId.Value, userId, NotificationTypes.Like, id, null, ct);
         }
 
         var count = await db.Clips.AsNoTracking()

--- a/server/src/GankedTV.Api/Endpoints/NotificationsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/NotificationsEndpoints.cs
@@ -115,16 +115,19 @@ public static class NotificationsEndpoints
         }
 
         var now = DateTimeOffset.UtcNow;
-        // Filter on RecipientId so a caller can't reveal or mutate someone else's row. If the
-        // notification is already read, ExecuteUpdateAsync still affects the row (it overwrites
-        // ReadAt with the new timestamp) — idempotent enough for a UI action.
+        // Filter on RecipientId so a caller can't reveal or mutate someone else's row. The
+        // ReadAt == null guard preserves the original read timestamp when the row is already
+        // read — important if read_at is ever used for analytics. On zero rows we cheaply
+        // distinguish "already read" (204, idempotent) from "missing / not yours" (404).
         var updated = await db.Notifications
-            .Where(n => n.Id == id && n.RecipientId == userId)
+            .Where(n => n.Id == id && n.RecipientId == userId && n.ReadAt == null)
             .ExecuteUpdateAsync(s => s.SetProperty(n => n.ReadAt, now), ct);
 
         if (updated == 0)
         {
-            return ProblemResults.NotFound("not_found");
+            var existsForCaller = await db.Notifications
+                .AnyAsync(n => n.Id == id && n.RecipientId == userId, ct);
+            return existsForCaller ? Results.NoContent() : ProblemResults.NotFound("not_found");
         }
 
         return Results.NoContent();

--- a/server/src/GankedTV.Api/Endpoints/NotificationsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/NotificationsEndpoints.cs
@@ -1,0 +1,132 @@
+using GankedTV.Api.Contracts.Notifications;
+using GankedTV.Api.Data;
+using GankedTV.Api.Pagination;
+using GankedTV.Api.Problems;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class NotificationsEndpoints
+{
+    private const int DefaultLimit = 20;
+    private const int MaxLimit = 100;
+
+    public static IEndpointRouteBuilder MapNotificationsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/me/notifications").RequireAuthorization();
+        group.MapGet("/", ListNotifications);
+        group.MapGet("/unread-count", UnreadCount);
+        group.MapPost("/read", MarkAllRead);
+        group.MapPost("/{id:guid}/read", MarkOneRead);
+        return app;
+    }
+
+    private static async Task<IResult> ListNotifications(
+        string? cursor,
+        int? limit,
+        System.Security.Claims.ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+        var hasCursor = KeysetCursor.TryParse(cursor, out var cursorCreatedAt, out var cursorId);
+
+        var query = db.Notifications.AsNoTracking()
+            .Where(n => n.RecipientId == userId);
+
+        if (hasCursor)
+        {
+            query = query.Where(n =>
+                n.CreatedAt < cursorCreatedAt
+                || (n.CreatedAt == cursorCreatedAt && n.Id.CompareTo(cursorId) < 0));
+        }
+
+        // Include the actor (always present), and the clip / comment when set so the dropdown
+        // can label the row without a follow-up request. An un-included nav silently surfaces as
+        // null in NotificationMappings.ToItem, so the Includes here matter for correctness.
+        var rows = await query
+            .OrderByDescending(n => n.CreatedAt)
+            .ThenByDescending(n => n.Id)
+            .Include(n => n.Actor)
+            .Include(n => n.Clip)
+            .Include(n => n.Comment)
+            .Take(clampedLimit + 1)
+            .ToListAsync(ct);
+
+        var hasMore = rows.Count > clampedLimit;
+        var page = hasMore ? rows.GetRange(0, clampedLimit) : rows;
+
+        var items = page.Select(n => n.ToItem()).ToList();
+        var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
+        return Results.Ok(new NotificationListResponse(items, nextCursor));
+    }
+
+    private static async Task<IResult> UnreadCount(
+        System.Security.Claims.ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        // The partial index idx_notifications_unread covers this — it's the hot-path probe
+        // the web client polls every 30s, so it must stay O(unread rows for this user).
+        var count = await db.Notifications
+            .Where(n => n.RecipientId == userId && n.ReadAt == null)
+            .CountAsync(ct);
+
+        return Results.Ok(new UnreadCountResponse(count));
+    }
+
+    private static async Task<IResult> MarkAllRead(
+        System.Security.Claims.ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var marked = await db.Notifications
+            .Where(n => n.RecipientId == userId && n.ReadAt == null)
+            .ExecuteUpdateAsync(s => s.SetProperty(n => n.ReadAt, now), ct);
+
+        return Results.Ok(new MarkAllReadResponse(marked));
+    }
+
+    private static async Task<IResult> MarkOneRead(
+        Guid id,
+        System.Security.Claims.ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (!ClipsReadEndpoints.TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        // Filter on RecipientId so a caller can't reveal or mutate someone else's row. If the
+        // notification is already read, ExecuteUpdateAsync still affects the row (it overwrites
+        // ReadAt with the new timestamp) — idempotent enough for a UI action.
+        var updated = await db.Notifications
+            .Where(n => n.Id == id && n.RecipientId == userId)
+            .ExecuteUpdateAsync(s => s.SetProperty(n => n.ReadAt, now), ct);
+
+        if (updated == 0)
+        {
+            return ProblemResults.NotFound("not_found");
+        }
+
+        return Results.NoContent();
+    }
+}

--- a/server/src/GankedTV.Api/Notifications/INotificationService.cs
+++ b/server/src/GankedTV.Api/Notifications/INotificationService.cs
@@ -1,0 +1,18 @@
+namespace GankedTV.Api.Notifications;
+
+/// <summary>
+/// Records an in-app notification for the recipient. Implementations are expected to use the
+/// caller's <c>GankedTvDbContext</c> so the insert joins any open transaction (e.g. the
+/// like / unlike counter update). Self-actions are dropped silently — every call site is free
+/// to invoke this without first checking <c>recipient != actor</c>.
+/// </summary>
+public interface INotificationService
+{
+    Task RecordAsync(
+        Guid recipientId,
+        Guid actorId,
+        string type,
+        Guid? clipId,
+        Guid? commentId,
+        CancellationToken ct);
+}

--- a/server/src/GankedTV.Api/Notifications/NotificationService.cs
+++ b/server/src/GankedTV.Api/Notifications/NotificationService.cs
@@ -1,0 +1,33 @@
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+
+namespace GankedTV.Api.Notifications;
+
+public class NotificationService(GankedTvDbContext db) : INotificationService
+{
+    public async Task RecordAsync(
+        Guid recipientId,
+        Guid actorId,
+        string type,
+        Guid? clipId,
+        Guid? commentId,
+        CancellationToken ct)
+    {
+        // Self-actions never produce a notification. The DB also has a CHECK constraint to
+        // guard against a buggy call site bypassing this filter.
+        if (recipientId == actorId)
+        {
+            return;
+        }
+
+        db.Notifications.Add(new Notification
+        {
+            RecipientId = recipientId,
+            ActorId = actorId,
+            Type = type,
+            ClipId = clipId,
+            CommentId = commentId,
+        });
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/server/src/GankedTV.Api/Notifications/NotificationTypes.cs
+++ b/server/src/GankedTV.Api/Notifications/NotificationTypes.cs
@@ -1,0 +1,8 @@
+namespace GankedTV.Api.Notifications;
+
+public static class NotificationTypes
+{
+    public const string Like = "like";
+    public const string Comment = "comment";
+    public const string Follow = "follow";
+}

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -10,6 +10,7 @@ using GankedTV.Api.Configuration;
 using GankedTV.Api.Data;
 using GankedTV.Api.Endpoints;
 using GankedTV.Api.Middleware;
+using GankedTV.Api.Notifications;
 using GankedTV.Api.Services.Clips;
 using GankedTV.Api.Services.Igdb;
 using GankedTV.Api.Services.Maintenance;
@@ -156,6 +157,7 @@ builder.Services.AddOptions<ClipValidationOptions>()
 
 builder.Services.AddScoped<IClipUploadService, ClipUploadService>();
 builder.Services.AddScoped<ITagsResolver, TagsResolver>();
+builder.Services.AddScoped<INotificationService, NotificationService>();
 
 // ---- Auth configuration ----
 
@@ -374,6 +376,7 @@ app.MapLikesEndpoints();
 app.MapCommentsEndpoints();
 app.MapUsersEndpoints();
 app.MapFollowsEndpoints();
+app.MapNotificationsEndpoints();
 app.MapGamesEndpoints();
 app.MapTagsEndpoints();
 app.MapSearchEndpoints();

--- a/server/src/GankedTV.Api/Tools/SeedCommand.cs
+++ b/server/src/GankedTV.Api/Tools/SeedCommand.cs
@@ -34,6 +34,15 @@ public sealed class SeedCommand(
     public const string SeedUserEmail = $"{SeedUsername}@dev.local";
     // Documented in the README so contributors can hit /auth/login directly after `make seed`.
     public const string SeedUserPassword = "testpass123!";
+
+    // Second seeded login — the "other user" for two-browser smoke tests (notifications,
+    // follows, likes-on-someone-else's-clip). Owns no clips of their own; they're the actor
+    // that creates social events against seeduser's clips.
+    public static readonly Guid SeedUser2Id = new("00000000-0000-0000-0000-00000000F00D");
+    public const string SeedUser2Username = "seeduser2";
+    public const string SeedUser2Email = $"{SeedUser2Username}@dev.local";
+    public const string SeedUser2Password = SeedUserPassword;
+
     public const int SeedClipCount = 10;
     private const int GameRotationCount = 5;
 
@@ -61,50 +70,14 @@ public sealed class SeedCommand(
 
         var now = clock.GetUtcNow();
 
-        // Match by id first, then fall back to email/username. The columns have unique
-        // indexes (idx_users_email, idx_users_username), so an id-only lookup followed by
-        // an unconditional INSERT used to crash with 23505 when a non-canonical row
-        // already occupied the seed's email or username — e.g. someone registering via
-        // /auth/register with the documented seed credentials. Reuse that row instead.
-        var user = await db.Users.FirstOrDefaultAsync(
-            u => u.Id == SeedUserId || u.Email == SeedUserEmail || u.Username == SeedUsername,
-            ct);
-        if (user is null)
-        {
-            user = new User
-            {
-                Id = SeedUserId,
-                Username = SeedUsername,
-                Email = SeedUserEmail,
-                Bio = "Seeded dev user.",
-                PasswordHash = hasher.Hash(SeedUserPassword),
-                PasswordAlgo = hasher.Algorithm,
-                CreatedAt = now,
-                UpdatedAt = now,
-            };
-            db.Users.Add(user);
-            await db.SaveChangesAsync(ct);
-            logger.LogInformation("Seed: created user {Username}", user.Username);
-        }
-        else
-        {
-            if (user.Id != SeedUserId)
-            {
-                logger.LogWarning(
-                    "Seed: existing user matches by email/username under id {Id} (expected {Expected}). Reusing existing row.",
-                    user.Id, SeedUserId);
-            }
-            if (string.IsNullOrEmpty(user.PasswordHash))
-            {
-                // Migrate older seed runs that created the user before passwords existed.
-                // Don't overwrite an existing password — a contributor may have rotated it via /auth/password.
-                user.PasswordHash = hasher.Hash(SeedUserPassword);
-                user.PasswordAlgo = hasher.Algorithm;
-                user.UpdatedAt = now;
-                await db.SaveChangesAsync(ct);
-                logger.LogInformation("Seed: attached default password to existing user {Username}", user.Username);
-            }
-        }
+        var user = await EnsureSeedUserAsync(
+            SeedUserId, SeedUsername, SeedUserEmail, SeedUserPassword, "Seeded dev user.", now, ct);
+        // seeduser2 is a second login with the same documented password — used for two-browser
+        // smoke tests (notifications, follows). They own no clips of their own; their job is to
+        // act on seeduser's content.
+        _ = await EnsureSeedUserAsync(
+            SeedUser2Id, SeedUser2Username, SeedUser2Email, SeedUser2Password,
+            "Seeded dev user (actor).", now, ct);
 
         // Ensure buckets exist before any PutObject. Seed runs via the `--seed` short-circuit
         // which doesn't start hosted services, so BucketBootstrapHostedService hasn't run.
@@ -172,6 +145,61 @@ public sealed class SeedCommand(
         {
             logger.LogInformation("Seed: already present, no changes.");
         }
+    }
+
+    /// <summary>
+    /// Idempotently materialise a seeded user. Matches by id first, then by email or username,
+    /// so a row registered through <c>/auth/register</c> under the documented credentials gets
+    /// reused instead of colliding on <c>idx_users_email</c> / <c>idx_users_username</c>.
+    /// Attaches the documented password if missing (older seed runs predate password storage).
+    /// </summary>
+    private async Task<User> EnsureSeedUserAsync(
+        Guid id,
+        string username,
+        string email,
+        string password,
+        string bio,
+        DateTimeOffset now,
+        CancellationToken ct)
+    {
+        var user = await db.Users.FirstOrDefaultAsync(
+            u => u.Id == id || u.Email == email || u.Username == username, ct);
+
+        if (user is null)
+        {
+            user = new User
+            {
+                Id = id,
+                Username = username,
+                Email = email,
+                Bio = bio,
+                PasswordHash = hasher.Hash(password),
+                PasswordAlgo = hasher.Algorithm,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seed: created user {Username}", user.Username);
+            return user;
+        }
+
+        if (user.Id != id)
+        {
+            logger.LogWarning(
+                "Seed: existing user matches by email/username under id {Id} (expected {Expected}). Reusing existing row.",
+                user.Id, id);
+        }
+        if (string.IsNullOrEmpty(user.PasswordHash))
+        {
+            // Don't overwrite an existing password — a contributor may have rotated it via /auth/password.
+            user.PasswordHash = hasher.Hash(password);
+            user.PasswordAlgo = hasher.Algorithm;
+            user.UpdatedAt = now;
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seed: attached default password to existing user {Username}", user.Username);
+        }
+        return user;
     }
 
     /// <summary>

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
@@ -8,8 +8,12 @@ using GankedTV.Api.Notifications;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
 using GankedTV.Api.Validation;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace GankedTV.Api.Tests.Integration.Endpoints;
 
@@ -213,6 +217,39 @@ public class CommentsEndpointsTests : IAsyncLifetime
         notif.ActorId.Should().Be(commenterId);
         notif.ClipId.Should().Be(clipId);
         notif.CommentId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Create_NotificationFailure_RollsBackCommentRow()
+    {
+        // Contract: INotificationService.RecordAsync runs inside the caller's transaction.
+        // If recording throws, the comment row must NOT remain — otherwise commenters see a
+        // failed request but their comment is silently published without notifying the owner.
+        await _fx.ResetAsync();
+        var (ownerId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, token) = await SeedUserAndIssueTokenAsync("commenter");
+        var clipId = await SeedClipAsync(ownerId);
+
+        var throwing = Substitute.For<INotificationService>();
+        throwing.RecordAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("simulated notification failure"));
+
+        using var factory = _factory!.WithWebHostBuilder(b => b.ConfigureServices(s =>
+        {
+            s.RemoveAll<INotificationService>();
+            s.AddScoped(_ => throwing);
+        }));
+
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "doomed" });
+
+        resp.IsSuccessStatusCode.Should().BeFalse();
+        await using var db = _fx.CreateContext();
+        (await db.Comments.AnyAsync(c => c.ClipId == clipId)).Should().BeFalse();
+        (await db.Notifications.AnyAsync()).Should().BeFalse();
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/CommentsEndpointsTests.cs
@@ -4,9 +4,11 @@ using System.Text.Json;
 using FluentAssertions;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Notifications;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
 using GankedTV.Api.Validation;
+using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 
 namespace GankedTV.Api.Tests.Integration.Endpoints;
@@ -190,6 +192,42 @@ public class CommentsEndpointsTests : IAsyncLifetime
         var createdAt = item.GetProperty("createdAt").GetDateTimeOffset();
         createdAt.Should().BeOnOrAfter(before.AddSeconds(-1));
         createdAt.Should().BeOnOrBefore(DateTimeOffset.UtcNow.AddSeconds(1));
+    }
+
+    [Fact]
+    public async Task Create_OnOthersClip_RecordsNotificationForClipOwner()
+    {
+        await _fx.ResetAsync();
+        var (ownerId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (commenterId, token) = await SeedUserAndIssueTokenAsync("commenter");
+        var clipId = await SeedClipAsync(ownerId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "great clip" });
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await using var db = _fx.CreateContext();
+        var notif = await db.Notifications.SingleAsync();
+        notif.Type.Should().Be(NotificationTypes.Comment);
+        notif.RecipientId.Should().Be(ownerId);
+        notif.ActorId.Should().Be(commenterId);
+        notif.ClipId.Should().Be(clipId);
+        notif.CommentId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Create_OnOwnClip_DoesNotRecordNotification()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync("author");
+        var clipId = await SeedClipAsync(userId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsJsonAsync($"/clips/{clipId}/comments", new { body = "self" });
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.AnyAsync()).Should().BeFalse();
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/FollowsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/FollowsEndpointsTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using FluentAssertions;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Notifications;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
@@ -144,6 +145,40 @@ public class FollowsEndpointsTests : IAsyncLifetime
         await using var db = _fx.CreateContext();
         (await db.Follows.CountAsync(f => f.FollowerId == followerId && f.FolloweeId == followeeId))
             .Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Follow_FirstTime_RecordsNotificationForFollowee()
+    {
+        await _fx.ResetAsync();
+        var (followerId, token) = await SeedUserAndIssueTokenAsync("follower");
+        var (followeeId, _) = await SeedUserAndIssueTokenAsync("followee");
+        using var client = ClientWithBearer(token);
+
+        (await client.PostAsync("/users/followee/follow", content: null)).EnsureSuccessStatusCode();
+
+        await using var db = _fx.CreateContext();
+        var notif = await db.Notifications.SingleAsync();
+        notif.Type.Should().Be(NotificationTypes.Follow);
+        notif.RecipientId.Should().Be(followeeId);
+        notif.ActorId.Should().Be(followerId);
+        notif.ClipId.Should().BeNull();
+        notif.CommentId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Follow_DuplicateFollow_OnlyRecordsOneNotification()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync("follower");
+        await SeedUserAndIssueTokenAsync("followee");
+        using var client = ClientWithBearer(token);
+
+        (await client.PostAsync("/users/followee/follow", content: null)).EnsureSuccessStatusCode();
+        (await client.PostAsync("/users/followee/follow", content: null)).EnsureSuccessStatusCode();
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.CountAsync()).Should().Be(1);
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/FollowsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/FollowsEndpointsTests.cs
@@ -7,8 +7,12 @@ using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Notifications;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace GankedTV.Api.Tests.Integration.Endpoints;
 
@@ -179,6 +183,39 @@ public class FollowsEndpointsTests : IAsyncLifetime
 
         await using var db = _fx.CreateContext();
         (await db.Notifications.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Follow_NotificationFailure_RollsBackFollowRow()
+    {
+        // Contract: INotificationService.RecordAsync runs inside the caller's transaction.
+        // If recording throws, the follow row must NOT remain — otherwise re-follows can never
+        // produce a notification (dedup is `inserted == 1`) and the event is lost forever.
+        await _fx.ResetAsync();
+        var (followerId, token) = await SeedUserAndIssueTokenAsync("follower");
+        var (followeeId, _) = await SeedUserAndIssueTokenAsync("followee");
+
+        var throwing = Substitute.For<INotificationService>();
+        throwing.RecordAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("simulated notification failure"));
+
+        using var factory = _factory!.WithWebHostBuilder(b => b.ConfigureServices(s =>
+        {
+            s.RemoveAll<INotificationService>();
+            s.AddScoped(_ => throwing);
+        }));
+
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        var resp = await client.PostAsync("/users/followee/follow", content: null);
+
+        resp.IsSuccessStatusCode.Should().BeFalse();
+        await using var db = _fx.CreateContext();
+        (await db.Follows.AnyAsync(f => f.FollowerId == followerId && f.FolloweeId == followeeId))
+            .Should().BeFalse();
+        (await db.Notifications.AnyAsync()).Should().BeFalse();
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LikesEndpointsTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using FluentAssertions;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Notifications;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
@@ -266,6 +267,76 @@ public class LikesEndpointsTests : IAsyncLifetime
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         await using var db = _fx.CreateContext();
         (await db.Clips.Where(c => c.Id == clipId).Select(c => c.LikeCount).FirstAsync()).Should().Be(0);
+    }
+
+    // ---- Notification side-effects ----
+
+    [Fact]
+    public async Task Like_RecordsNotificationForClipOwner()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (fanId, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        (await client.PostAsync($"/clips/{clipId}/like", content: null)).EnsureSuccessStatusCode();
+
+        await using var db = _fx.CreateContext();
+        var notif = await db.Notifications.SingleAsync();
+        notif.Type.Should().Be(NotificationTypes.Like);
+        notif.RecipientId.Should().Be(authorId);
+        notif.ActorId.Should().Be(fanId);
+        notif.ClipId.Should().Be(clipId);
+    }
+
+    [Fact]
+    public async Task Like_OwnClip_DoesNotRecordNotification()
+    {
+        await _fx.ResetAsync();
+        var (authorId, token) = await SeedUserAndIssueTokenAsync("author");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        (await client.PostAsync($"/clips/{clipId}/like", content: null)).EnsureSuccessStatusCode();
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Like_DoubleLike_OnlyRecordsOneNotification()
+    {
+        // The endpoint already collapses re-likes into a single Like row via ON CONFLICT DO
+        // NOTHING — the notification must follow the same guard.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        (await client.PostAsync($"/clips/{clipId}/like", content: null)).EnsureSuccessStatusCode();
+        (await client.PostAsync($"/clips/{clipId}/like", content: null)).EnsureSuccessStatusCode();
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Unlike_DoesNotDeleteExistingLikeNotification()
+    {
+        // Per the issue: unliking must not erase the historical notification.
+        await _fx.ResetAsync();
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author");
+        var (_, token) = await SeedUserAndIssueTokenAsync("fan");
+        var clipId = await SeedClipAsync(authorId);
+
+        using var client = ClientWithBearer(token);
+        (await client.PostAsync($"/clips/{clipId}/like", content: null)).EnsureSuccessStatusCode();
+        (await client.DeleteAsync($"/clips/{clipId}/like")).EnsureSuccessStatusCode();
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.CountAsync()).Should().Be(1);
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/NotificationsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/NotificationsEndpointsTests.cs
@@ -272,6 +272,35 @@ public class NotificationsEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task MarkOneRead_AlreadyRead_Returns204_AndPreservesOriginalReadAt()
+    {
+        // Idempotent re-mark: a second call must NOT overwrite the original read timestamp.
+        // Important if read_at is ever used for analytics (time-to-read), and matches the
+        // 204-on-repeat semantics that the dropdown depends on for offline re-syncing.
+        await _fx.ResetAsync();
+        var (recipientId, token) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var originalReadAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var notifId = await SeedNotificationAsync(
+            recipientId, actorId, NotificationTypes.Follow, readAt: originalReadAt);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/me/notifications/{notifId}/read", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var db = _fx.CreateContext();
+        var storedReadAt = await db.Notifications
+            .Where(n => n.Id == notifId)
+            .Select(n => n.ReadAt)
+            .FirstAsync();
+        storedReadAt.Should().NotBeNull();
+        // Timestamp tolerance: Postgres stores µs precision, the seeded value comes from
+        // DateTimeOffset (100ns ticks), so compare with a sub-millisecond budget.
+        storedReadAt!.Value.Should().BeCloseTo(originalReadAt, TimeSpan.FromMilliseconds(1));
+    }
+
+    [Fact]
     public async Task MarkOneRead_NotMine_Returns404()
     {
         // Cross-user safety: caller should never be able to mutate another user's row.

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/NotificationsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/NotificationsEndpointsTests.cs
@@ -1,0 +1,348 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Notifications;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class NotificationsEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public NotificationsEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "recipient") =>
+        AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+
+    private HttpClient ClientWithBearer(string token) =>
+        AuthTestHelpers.CreateBearerClient(_factory!, token);
+
+    private async Task<Guid> SeedClipAsync(Guid userId)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            Title = "seed",
+            VideoKey = $"clips/{userId}/{id}.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
+            Status = "ready",
+            Visibility = "public",
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    private async Task<Guid> SeedNotificationAsync(
+        Guid recipientId,
+        Guid actorId,
+        string type,
+        Guid? clipId = null,
+        Guid? commentId = null,
+        DateTimeOffset? createdAt = null,
+        DateTimeOffset? readAt = null)
+    {
+        var id = Guid.NewGuid();
+        var when = createdAt ?? DateTimeOffset.UtcNow;
+        await using var db = _fx.CreateContext();
+        db.Notifications.Add(new Notification
+        {
+            Id = id,
+            RecipientId = recipientId,
+            ActorId = actorId,
+            Type = type,
+            ClipId = clipId,
+            CommentId = commentId,
+            CreatedAt = when,
+            ReadAt = readAt,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    // ---- GET /me/notifications ----
+
+    [Fact]
+    public async Task List_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/me/notifications");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task List_OnlyOwnNotifications_NewestFirst()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, token) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var (otherId, _) = await SeedUserAndIssueTokenAsync("other");
+
+        var older = await SeedNotificationAsync(
+            recipientId, actorId, NotificationTypes.Follow,
+            createdAt: DateTimeOffset.UtcNow.AddMinutes(-10));
+        var newer = await SeedNotificationAsync(
+            recipientId, actorId, NotificationTypes.Follow,
+            createdAt: DateTimeOffset.UtcNow);
+        // Belongs to another user — must NOT appear in this caller's list.
+        await SeedNotificationAsync(
+            otherId, actorId, NotificationTypes.Follow,
+            createdAt: DateTimeOffset.UtcNow);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.GetAsync("/me/notifications");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items").EnumerateArray().ToList();
+        items.Should().HaveCount(2);
+        items[0].GetProperty("id").GetGuid().Should().Be(newer);
+        items[1].GetProperty("id").GetGuid().Should().Be(older);
+    }
+
+    [Fact]
+    public async Task List_HydratesActorClipAndComment()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, token) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var clipId = await SeedClipAsync(recipientId);
+
+        var commentId = Guid.NewGuid();
+        await using (var db = _fx.CreateContext())
+        {
+            db.Comments.Add(new Comment
+            {
+                Id = commentId,
+                ClipId = clipId,
+                UserId = actorId,
+                Body = "nice play",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Comment, clipId, commentId);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.GetAsync("/me/notifications");
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("type").GetString().Should().Be("comment");
+        item.GetProperty("actor").GetProperty("username").GetString().Should().Be("actor");
+        item.GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clipId);
+        item.GetProperty("comment").GetProperty("body").GetString().Should().Be("nice play");
+    }
+
+    [Fact]
+    public async Task List_CursorPaginates()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, token) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedNotificationAsync(
+                recipientId, actorId, NotificationTypes.Follow,
+                createdAt: now.AddSeconds(-i));
+        }
+
+        using var client = ClientWithBearer(token);
+        var firstPage = await client.GetFromJsonAsync<JsonElement>("/me/notifications?limit=2");
+        firstPage.GetProperty("items").GetArrayLength().Should().Be(2);
+        var cursor = firstPage.GetProperty("nextCursor").GetString();
+        cursor.Should().NotBeNull();
+
+        var secondPage = await client.GetFromJsonAsync<JsonElement>(
+            $"/me/notifications?limit=2&cursor={Uri.EscapeDataString(cursor!)}");
+        secondPage.GetProperty("items").GetArrayLength().Should().Be(2);
+
+        var thirdPage = await client.GetFromJsonAsync<JsonElement>(
+            $"/me/notifications?limit=2&cursor={Uri.EscapeDataString(secondPage.GetProperty("nextCursor").GetString()!)}");
+        thirdPage.GetProperty("items").GetArrayLength().Should().Be(1);
+        thirdPage.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    // ---- GET /me/notifications/unread-count ----
+
+    [Fact]
+    public async Task UnreadCount_OnlyCountsUnreadForCaller()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, token) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var (otherId, _) = await SeedUserAndIssueTokenAsync("other");
+
+        await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Follow);
+        await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Follow);
+        // Read — must be excluded.
+        await SeedNotificationAsync(
+            recipientId, actorId, NotificationTypes.Follow,
+            readAt: DateTimeOffset.UtcNow);
+        // Belongs to someone else.
+        await SeedNotificationAsync(otherId, actorId, NotificationTypes.Follow);
+
+        using var client = ClientWithBearer(token);
+        var body = await client.GetFromJsonAsync<JsonElement>("/me/notifications/unread-count");
+
+        body.GetProperty("count").GetInt32().Should().Be(2);
+    }
+
+    // ---- POST /me/notifications/read ----
+
+    [Fact]
+    public async Task MarkAllRead_MarksOnlyCallersUnread_ReturnsCount()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, token) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var (otherId, _) = await SeedUserAndIssueTokenAsync("other");
+
+        await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Follow);
+        await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Follow);
+        var othersUnread = await SeedNotificationAsync(otherId, actorId, NotificationTypes.Follow);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync("/me/notifications/read", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("marked").GetInt32().Should().Be(2);
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.CountAsync(n => n.RecipientId == recipientId && n.ReadAt == null))
+            .Should().Be(0);
+        // Other user's row is untouched.
+        (await db.Notifications.Where(n => n.Id == othersUnread).Select(n => n.ReadAt).FirstAsync())
+            .Should().BeNull();
+    }
+
+    // ---- POST /me/notifications/{id}/read ----
+
+    [Fact]
+    public async Task MarkOneRead_Success_Returns204()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, token) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var notifId = await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Follow);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.PostAsync($"/me/notifications/{notifId}/read", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.Where(n => n.Id == notifId).Select(n => n.ReadAt).FirstAsync())
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task MarkOneRead_NotMine_Returns404()
+    {
+        // Cross-user safety: caller should never be able to mutate another user's row.
+        await _fx.ResetAsync();
+        var (recipientId, _) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var (_, otherToken) = await SeedUserAndIssueTokenAsync("other");
+        var notifId = await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Follow);
+
+        using var client = ClientWithBearer(otherToken);
+        var resp = await client.PostAsync($"/me/notifications/{notifId}/read", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        await using var db = _fx.CreateContext();
+        (await db.Notifications.Where(n => n.Id == notifId).Select(n => n.ReadAt).FirstAsync())
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MarkOneRead_Missing_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsync($"/me/notifications/{Guid.NewGuid()}/read", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ---- Cascade behaviour ----
+
+    [Fact]
+    public async Task DeletingClip_CascadesNotifications()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, _) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+        var clipId = await SeedClipAsync(recipientId);
+        var notifId = await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Like, clipId);
+
+        await using (var db = _fx.CreateContext())
+        {
+            await db.Clips.Where(c => c.Id == clipId).ExecuteDeleteAsync();
+        }
+
+        await using var verify = _fx.CreateContext();
+        (await verify.Notifications.AnyAsync(n => n.Id == notifId)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeletingUser_CascadesAsRecipientAndActor()
+    {
+        await _fx.ResetAsync();
+        var (recipientId, _) = await SeedUserAndIssueTokenAsync("recipient");
+        var (actorId, _) = await SeedUserAndIssueTokenAsync("actor");
+
+        var asRecipient = await SeedNotificationAsync(recipientId, actorId, NotificationTypes.Follow);
+
+        // Flip the roles: same actor is now the recipient of a row authored by the soon-to-be-
+        // deleted user, so we can prove the cascade fires from either side of the FK.
+        var asActor = await SeedNotificationAsync(actorId, recipientId, NotificationTypes.Follow);
+
+        await using (var db = _fx.CreateContext())
+        {
+            await db.Users.Where(u => u.Id == recipientId).ExecuteDeleteAsync();
+        }
+
+        await using var verify = _fx.CreateContext();
+        (await verify.Notifications.AnyAsync(n => n.Id == asRecipient)).Should().BeFalse();
+        (await verify.Notifications.AnyAsync(n => n.Id == asActor)).Should().BeFalse();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Tools/SeedCommandTests.cs
@@ -42,7 +42,7 @@ public class SeedCommandTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task FreshDb_CreatesOneUserAndTenClips()
+    public async Task FreshDb_CreatesTwoUsersAndTenClips()
     {
         await using var db = _fx.CreateContext();
         var seed = NewSeed(db, out _, out _);
@@ -50,9 +50,14 @@ public class SeedCommandTests : IAsyncLifetime
         await seed.RunAsync(CancellationToken.None);
 
         await using var verify = _fx.CreateContext();
-        (await verify.Users.CountAsync()).Should().Be(1);
+        (await verify.Users.CountAsync()).Should().Be(2);
         (await verify.Clips.CountAsync()).Should().Be(SeedCommand.SeedClipCount);
-        (await verify.Users.SingleAsync()).Username.Should().Be(SeedCommand.SeedUsername);
+        var usernames = await verify.Users.Select(u => u.Username).ToListAsync();
+        usernames.Should().Contain([SeedCommand.SeedUsername, SeedCommand.SeedUser2Username]);
+        // Clips all belong to the primary seeded user; seeduser2 has none — they're the
+        // "actor" persona used by two-browser smoke tests, not a content owner.
+        (await verify.Clips.CountAsync(c => c.UserId == SeedCommand.SeedUserId))
+            .Should().Be(SeedCommand.SeedClipCount);
     }
 
     [Fact]
@@ -69,7 +74,7 @@ public class SeedCommandTests : IAsyncLifetime
         }
 
         await using var verify = _fx.CreateContext();
-        (await verify.Users.CountAsync()).Should().Be(1);
+        (await verify.Users.CountAsync()).Should().Be(2);
         (await verify.Clips.CountAsync()).Should().Be(SeedCommand.SeedClipCount);
     }
 
@@ -117,14 +122,24 @@ public class SeedCommandTests : IAsyncLifetime
     {
         // The README documents seeduser@dev.local / testpass123! as the local-dev login;
         // contributors should be able to call /auth/login with that pair after `make seed`.
+        // seeduser2 ships with the same password — it's an alternate identity for two-browser
+        // smoke tests, not a different credential surface to maintain.
         await using var db = _fx.CreateContext();
         await NewSeed(db, out _, out _).RunAsync(CancellationToken.None);
 
+        var hasher = new Argon2idPasswordHasher();
         await using var verify = _fx.CreateContext();
-        var user = await verify.Users.SingleAsync();
-        user.PasswordHash.Should().NotBeNullOrEmpty();
-        user.PasswordAlgo.Should().Be("argon2id");
-        new Argon2idPasswordHasher().Verify(SeedCommand.SeedUserPassword, user.PasswordHash!).Should().BeTrue();
+        foreach (var (username, password) in new[]
+                 {
+                     (SeedCommand.SeedUsername, SeedCommand.SeedUserPassword),
+                     (SeedCommand.SeedUser2Username, SeedCommand.SeedUser2Password),
+                 })
+        {
+            var user = await verify.Users.SingleAsync(u => u.Username == username);
+            user.PasswordHash.Should().NotBeNullOrEmpty();
+            user.PasswordAlgo.Should().Be("argon2id");
+            hasher.Verify(password, user.PasswordHash!).Should().BeTrue();
+        }
     }
 
     [Fact]
@@ -154,8 +169,9 @@ public class SeedCommandTests : IAsyncLifetime
         }
 
         await using var verify = _fx.CreateContext();
-        (await verify.Users.CountAsync()).Should().Be(1);
-        var user = await verify.Users.SingleAsync();
+        // Two users total: the reused primary + the new seeduser2.
+        (await verify.Users.CountAsync()).Should().Be(2);
+        var user = await verify.Users.SingleAsync(u => u.Username == SeedCommand.SeedUsername);
         user.Id.Should().Be(preExistingId, "the existing row is reused, not replaced");
         // Seed should have attached the documented password to the reused row so /auth/login still works.
         user.PasswordHash.Should().NotBeNullOrEmpty();
@@ -179,7 +195,7 @@ public class SeedCommandTests : IAsyncLifetime
         var rotated = hasher.Hash("rotated-password-1234");
         await using (var db = _fx.CreateContext())
         {
-            var user = await db.Users.SingleAsync();
+            var user = await db.Users.SingleAsync(u => u.Username == SeedCommand.SeedUsername);
             user.PasswordHash = rotated;
             await db.SaveChangesAsync();
         }
@@ -191,7 +207,7 @@ public class SeedCommandTests : IAsyncLifetime
         }
 
         await using var verify = _fx.CreateContext();
-        var after = await verify.Users.SingleAsync();
+        var after = await verify.Users.SingleAsync(u => u.Username == SeedCommand.SeedUsername);
         after.PasswordHash.Should().Be(rotated);
     }
 
@@ -219,7 +235,7 @@ public class SeedCommandTests : IAsyncLifetime
         // Plus one placeholder cover per game in the game-covers bucket.
         storage.PutCalls.Where(p => p.Bucket == "game-covers").Should().HaveCount(gameCount);
 
-        var seedUserId = (await db.Users.SingleAsync()).Id;
+        var seedUserId = (await db.Users.SingleAsync(u => u.Username == SeedCommand.SeedUsername)).Id;
         foreach (var i in Enumerable.Range(1, SeedCommand.SeedClipCount))
         {
             var clipId = SeedCommand.SeedClipId(i);
@@ -320,7 +336,7 @@ public class SeedCommandTests : IAsyncLifetime
 
         await using (var db = _fx.CreateContext())
         {
-            var seedUserId = (await db.Users.SingleAsync()).Id;
+            var seedUserId = (await db.Users.SingleAsync(u => u.Username == SeedCommand.SeedUsername)).Id;
             foreach (var i in Enumerable.Range(1, SeedCommand.SeedClipCount))
             {
                 var clipId = SeedCommand.SeedClipId(i);

--- a/web/src/api/__tests__/notifications.spec.ts
+++ b/web/src/api/__tests__/notifications.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { notifications } from '../notifications'
+import { configureAuth, BASE_URL } from '../client'
+
+beforeEach(() => {
+  configureAuth({
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    onTokenRefreshed: () => {},
+    onRefreshFailed: () => {},
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function emptyResponse(status = 204): Response {
+  return new Response(null, { status, headers: { 'content-length': '0' } })
+}
+
+const NOTIF_ID = 'b5f2e3d1-0000-0000-0000-000000000007'
+
+describe('api/notifications', () => {
+  describe('list()', () => {
+    it('GETs /me/notifications without query when no params supplied', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      const result = await notifications.list()
+
+      expect(result).toEqual({ items: [], nextCursor: null })
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`${BASE_URL}/me/notifications`)
+      expect(init.method ?? 'GET').toBe('GET')
+    })
+
+    it('encodes cursor and limit into the query string', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ items: [], nextCursor: null })),
+      )
+
+      await notifications.list({ cursor: 'abc=', limit: 5 })
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      const parsed = new URL(url)
+      expect(parsed.pathname).toBe('/me/notifications')
+      expect(parsed.searchParams.get('cursor')).toBe('abc=')
+      expect(parsed.searchParams.get('limit')).toBe('5')
+    })
+  })
+
+  it('unreadCount() GETs /me/notifications/unread-count', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ count: 7 })),
+    )
+
+    const result = await notifications.unreadCount()
+
+    expect(result.count).toBe(7)
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+    expect(url).toBe(`${BASE_URL}/me/notifications/unread-count`)
+  })
+
+  it('markAllRead() POSTs /me/notifications/read', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ marked: 3 })),
+    )
+
+    const result = await notifications.markAllRead()
+
+    expect(result.marked).toBe(3)
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/me/notifications/read`)
+    expect(init.method).toBe('POST')
+  })
+
+  it('markOneRead() POSTs /me/notifications/{id}/read and tolerates 204', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => emptyResponse(204)),
+    )
+
+    await expect(notifications.markOneRead(NOTIF_ID)).resolves.toBeUndefined()
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${BASE_URL}/me/notifications/${NOTIF_ID}/read`)
+    expect(init.method).toBe('POST')
+  })
+})

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -1,0 +1,76 @@
+import { api } from './client'
+import type { AuthorSummary } from './clips'
+
+export type NotificationType = 'like' | 'comment' | 'follow'
+
+// Slim shape — the dropdown only needs enough to label the row and route on click. Full clip
+// thumbnails would force presigning into the unread-count hot path, so the server keeps the
+// payload narrow on purpose.
+export interface NotificationClipSummary {
+  id: string
+  shareCode: string
+  title: string
+}
+
+export interface NotificationCommentPreview {
+  id: string
+  // null when the comment is soft-deleted — mirrors CommentItem.body.
+  body: string | null
+}
+
+export interface NotificationItem {
+  id: string
+  type: NotificationType
+  actor: AuthorSummary
+  // Set on `like` and `comment`; null on `follow`.
+  clip: NotificationClipSummary | null
+  // Set on `comment` only.
+  comment: NotificationCommentPreview | null
+  createdAt: string
+  // null = unread.
+  readAt: string | null
+}
+
+export interface NotificationListResponse {
+  items: NotificationItem[]
+  nextCursor: string | null
+}
+
+export interface NotificationListQuery {
+  cursor?: string | null
+  limit?: number
+}
+
+export interface UnreadCountResponse {
+  count: number
+}
+
+export interface MarkAllReadResponse {
+  marked: number
+}
+
+function buildQuery(query: NotificationListQuery): string {
+  const params = new URLSearchParams()
+  if (query.cursor) params.set('cursor', query.cursor)
+  if (query.limit !== undefined) params.set('limit', String(query.limit))
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export const notifications = {
+  list(query: NotificationListQuery = {}): Promise<NotificationListResponse> {
+    return api<NotificationListResponse>(`/me/notifications${buildQuery(query)}`)
+  },
+
+  unreadCount(): Promise<UnreadCountResponse> {
+    return api<UnreadCountResponse>('/me/notifications/unread-count')
+  },
+
+  markAllRead(): Promise<MarkAllReadResponse> {
+    return api<MarkAllReadResponse>('/me/notifications/read', { method: 'POST' })
+  },
+
+  markOneRead(id: string): Promise<void> {
+    return api<void>(`/me/notifications/${encodeURIComponent(id)}/read`, { method: 'POST' })
+  },
+}

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -3,18 +3,38 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, wa
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useThemeStore } from '@/stores/theme'
+import { useNotificationsStore } from '@/stores/notifications'
 import { search, type SearchResponse } from '@/api/search'
 import ThemePicker from './ThemePicker.vue'
 import UserAvatar from './UserAvatar.vue'
 import GameSearchResult from './GameSearchResult.vue'
+import NotificationsDropdown from './notifications/NotificationsDropdown.vue'
 import IconSearch from './icons/IconSearch.vue'
 import IconSun from './icons/IconSun.vue'
 import IconMoon from './icons/IconMoon.vue'
 import IconPlus from './icons/IconPlus.vue'
+import IconBell from './icons/IconBell.vue'
 
 const auth = useAuthStore()
 const theme = useThemeStore()
 const router = useRouter()
+const notificationsStore = useNotificationsStore()
+
+// Start/stop polling whenever the auth state flips. Wiring it here (vs App.vue) keeps the
+// nav self-contained — every authenticated session is rendered through the nav, so the bell
+// component owns the lifetime.
+watch(
+  () => auth.isAuthenticated,
+  (isAuthed) => {
+    if (isAuthed) {
+      notificationsStore.startPolling()
+    } else {
+      notificationsStore.reset()
+    }
+  },
+  { immediate: true },
+)
+onBeforeUnmount(() => notificationsStore.stopPolling())
 
 const navLinkActive =
   "text-text-primary after:content-[''] after:absolute after:left-3.5 after:right-3.5 after:bottom-0.5 after:h-0.5 after:bg-brand-light"
@@ -158,6 +178,61 @@ function onBlur() {
     isFocused.value = false
   }, 120)
 }
+
+// --- Notifications bell + dropdown --------------------------------------------
+
+const bellRef = useTemplateRef<HTMLButtonElement>('bellRef')
+const isBellOpen = ref(false)
+const bellPopoverPos = ref({ top: 0, right: 0 })
+
+function updateBellPos() {
+  const el = bellRef.value
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  bellPopoverPos.value = {
+    top: rect.bottom + 4,
+    // Anchor to the right edge of the bell so the dropdown sits flush with the nav's right side.
+    right: Math.max(8, window.innerWidth - rect.right),
+  }
+}
+
+const bellPopoverStyle = computed(() => ({
+  top: `${bellPopoverPos.value.top}px`,
+  right: `${bellPopoverPos.value.right}px`,
+  width: '360px',
+}))
+
+async function toggleBell() {
+  isBellOpen.value = !isBellOpen.value
+  if (isBellOpen.value) {
+    await nextTick()
+    updateBellPos()
+  }
+}
+
+function closeBell() {
+  isBellOpen.value = false
+}
+
+const unreadBadge = computed(() => {
+  const n = notificationsStore.unreadCount
+  if (n <= 0) return null
+  return n > 9 ? '9+' : String(n)
+})
+
+// Close-on-outside-click. Listening on `mousedown` (not click) so the bell can swallow its own
+// open-click without immediately reclosing.
+function onDocumentMouseDown(e: MouseEvent) {
+  if (!isBellOpen.value) return
+  const target = e.target as Node | null
+  if (target && bellRef.value && bellRef.value.contains(target)) return
+  const popover = document.getElementById('nav-notifications-popover')
+  if (popover && target && popover.contains(target)) return
+  isBellOpen.value = false
+}
+
+onMounted(() => document.addEventListener('mousedown', onDocumentMouseDown))
+onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentMouseDown))
 </script>
 
 <template>
@@ -313,6 +388,26 @@ function onBlur() {
           <IconMoon v-else :size="16" />
         </button>
 
+        <!-- Notifications bell (authenticated only) -->
+        <button
+          v-if="auth.isAuthenticated"
+          ref="bellRef"
+          type="button"
+          class="relative inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border bg-transparent text-text-secondary transition-all duration-150 hover:border-border-hover hover:text-text-primary"
+          :class="isBellOpen ? 'border-brand text-text-primary' : 'border-border'"
+          :aria-label="`Notifications${unreadBadge ? ` (${unreadBadge} unread)` : ''}`"
+          :aria-expanded="isBellOpen"
+          @click="toggleBell"
+        >
+          <IconBell :size="16" />
+          <span
+            v-if="unreadBadge"
+            class="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-error px-1 font-mono text-[10px] leading-none font-semibold text-white"
+          >
+            {{ unreadBadge }}
+          </span>
+        </button>
+
         <!-- Upload button -->
         <RouterLink
           v-if="auth.isAuthenticated"
@@ -344,5 +439,18 @@ function onBlur() {
         </RouterLink>
       </div>
     </div>
+
+    <!-- Bell popover — teleported to body so the header's backdrop-filter context can't trap or
+         clip it (same reasoning as the search dropdown). Positioned by updateBellPos(). -->
+    <Teleport to="body">
+      <div
+        v-if="isBellOpen"
+        id="nav-notifications-popover"
+        :style="bellPopoverStyle"
+        class="fixed z-[60]"
+      >
+        <NotificationsDropdown @close="closeBell" />
+      </div>
+    </Teleport>
   </header>
 </template>

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -231,8 +231,23 @@ function onDocumentMouseDown(e: MouseEvent) {
   isBellOpen.value = false
 }
 
-onMounted(() => document.addEventListener('mousedown', onDocumentMouseDown))
-onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentMouseDown))
+// Esc closes the popover from anywhere. Listening at the document level (not on the popover)
+// because focus may sit on the row link, the "see all" button, or the bell itself — a scoped
+// handler would miss most of those cases. Returning focus to the bell preserves keyboard flow.
+function onDocumentKeyDown(e: KeyboardEvent) {
+  if (!isBellOpen.value || e.key !== 'Escape') return
+  isBellOpen.value = false
+  bellRef.value?.focus()
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', onDocumentMouseDown)
+  document.addEventListener('keydown', onDocumentKeyDown)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', onDocumentMouseDown)
+  document.removeEventListener('keydown', onDocumentKeyDown)
+})
 </script>
 
 <template>

--- a/web/src/components/icons/IconBell.vue
+++ b/web/src/components/icons/IconBell.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number; strokeWidth?: number }>(), {
+  size: 16,
+  strokeWidth: 2,
+})
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    :stroke-width="strokeWidth"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+    <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+  </svg>
+</template>

--- a/web/src/components/notifications/NotificationRow.vue
+++ b/web/src/components/notifications/NotificationRow.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { NotificationItem } from '@/api/notifications'
+import { formatRelativeTime } from '@/lib/format'
+import UserAvatar from '@/components/UserAvatar.vue'
+
+const props = defineProps<{ notification: NotificationItem }>()
+
+const actionLabel = computed(() => {
+  switch (props.notification.type) {
+    case 'like':
+      return 'liked your clip'
+    case 'comment':
+      return 'commented on your clip'
+    case 'follow':
+      return 'started following you'
+    default:
+      return ''
+  }
+})
+
+const clipTitle = computed(() => props.notification.clip?.title ?? null)
+const commentSnippet = computed(() => {
+  const body = props.notification.comment?.body
+  if (!body) return null
+  // Trim a long comment so the dropdown row stays single-line.
+  return body.length > 80 ? `${body.slice(0, 80)}…` : body
+})
+</script>
+
+<template>
+  <div class="flex items-start gap-3 px-4 py-3">
+    <UserAvatar :user="notification.actor" :size="32" />
+    <div class="flex min-w-0 flex-1 flex-col">
+      <p class="m-0 truncate font-body text-sm text-text-primary">
+        <span class="font-semibold">{{ notification.actor.username }}</span>
+        <span class="text-text-secondary"> {{ actionLabel }}</span>
+        <span v-if="clipTitle" class="text-text-secondary"> &ldquo;{{ clipTitle }}&rdquo;</span>
+      </p>
+      <p
+        v-if="commentSnippet"
+        class="m-0 mt-0.5 truncate font-body text-xs text-text-secondary italic"
+      >
+        {{ commentSnippet }}
+      </p>
+      <span class="mt-0.5 font-mono text-[11px] tracking-[0.04em] text-text-muted uppercase">
+        {{ formatRelativeTime(notification.createdAt) }}
+      </span>
+    </div>
+    <span
+      v-if="notification.readAt === null"
+      class="mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full bg-brand"
+      aria-label="Unread"
+    ></span>
+  </div>
+</template>

--- a/web/src/components/notifications/NotificationsDropdown.vue
+++ b/web/src/components/notifications/NotificationsDropdown.vue
@@ -28,8 +28,10 @@ function destinationFor(n: NotificationItem) {
   return { name: 'user', params: { username: n.actor.username } }
 }
 
-async function onRowClick(n: NotificationItem) {
-  await store.markOneRead(n.id)
+function onRowClick(n: NotificationItem) {
+  // Fire-and-forget: the store paints the row read optimistically, so awaiting the network
+  // round-trip would only delay navigation. A failed mark-read reconciles on the next poll.
+  void store.markOneRead(n.id)
   emit('close')
   void router.push(destinationFor(n))
 }

--- a/web/src/components/notifications/NotificationsDropdown.vue
+++ b/web/src/components/notifications/NotificationsDropdown.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useNotificationsStore } from '@/stores/notifications'
+import type { NotificationItem } from '@/api/notifications'
+import NotificationRow from './NotificationRow.vue'
+
+const store = useNotificationsStore()
+const router = useRouter()
+const emit = defineEmits<{ close: [] }>()
+
+// Lazily load the first page when the dropdown opens — the polled unread-count is enough to
+// drive the badge; the full list only matters when the user actually looks at it.
+onMounted(() => {
+  void store.loadFirstPage(10)
+})
+
+function destinationFor(n: NotificationItem) {
+  // Like/comment → the clip detail; follow → the actor's profile.
+  if (n.type === 'follow') {
+    return { name: 'user', params: { username: n.actor.username } }
+  }
+  if (n.clip) {
+    return { name: 'clip', params: { id: n.clip.id } }
+  }
+  // Defensive: a comment/like notification without a clip means the clip was deleted. Send
+  // the user to the actor's profile rather than a broken clip route.
+  return { name: 'user', params: { username: n.actor.username } }
+}
+
+async function onRowClick(n: NotificationItem) {
+  await store.markOneRead(n.id)
+  emit('close')
+  void router.push(destinationFor(n))
+}
+
+function onMarkAll() {
+  void store.markAllRead()
+}
+
+function onSeeAll() {
+  emit('close')
+  void router.push({ name: 'notifications' })
+}
+</script>
+
+<template>
+  <div
+    class="overflow-hidden rounded-md border border-border-strong bg-surface-raised shadow-[0_18px_50px_-18px_rgba(0,0,0,0.6)]"
+  >
+    <div class="flex items-center justify-between border-b border-border px-4 py-2">
+      <span class="font-heading text-sm font-bold uppercase tracking-[0.06em] text-text-primary">
+        Notifications
+      </span>
+      <button
+        type="button"
+        class="cursor-pointer border-0 bg-transparent font-mono text-[11px] uppercase tracking-[0.04em] text-text-secondary transition-colors duration-150 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+        :disabled="store.unreadCount === 0"
+        @click="onMarkAll"
+      >
+        Mark all read
+      </button>
+    </div>
+
+    <div
+      v-if="store.loading && store.items.length === 0"
+      class="px-4 py-6 text-center font-mono text-[11px] uppercase tracking-widest text-text-muted"
+    >
+      Loading…
+    </div>
+    <div
+      v-else-if="store.items.length === 0"
+      class="px-4 py-6 text-center font-mono text-[11px] uppercase tracking-widest text-text-muted"
+    >
+      No notifications yet
+    </div>
+    <ul v-else class="m-0 max-h-96 list-none overflow-y-auto p-0">
+      <li
+        v-for="n in store.items"
+        :key="n.id"
+        class="cursor-pointer border-b border-border last:border-b-0 transition-colors duration-150 hover:bg-surface-overlay"
+        :class="n.readAt === null ? 'border-l-2 border-l-brand' : ''"
+        @click="onRowClick(n)"
+      >
+        <NotificationRow :notification="n" />
+      </li>
+    </ul>
+
+    <button
+      type="button"
+      class="block w-full cursor-pointer border-0 border-t border-border bg-transparent px-4 py-2 text-center font-mono text-[11px] uppercase tracking-[0.04em] text-text-secondary transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary"
+      @click="onSeeAll"
+    >
+      See all
+    </button>
+  </div>
+</template>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -87,6 +87,12 @@ const router = createRouter({
       meta: { kind: 'following' },
     },
     {
+      path: '/notifications',
+      name: 'notifications',
+      component: () => import('@/views/NotificationsView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/auth/callback',
       name: 'auth-callback',
       component: () => import('@/views/AuthCallbackView.vue'),

--- a/web/src/stores/__tests__/notifications.spec.ts
+++ b/web/src/stores/__tests__/notifications.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNotificationsStore } from '../notifications'
+import type { NotificationItem } from '@/api/notifications'
+
+const mockList = vi.fn()
+const mockUnreadCount = vi.fn()
+const mockMarkAllRead = vi.fn()
+const mockMarkOneRead = vi.fn()
+
+vi.mock('@/api/notifications', () => ({
+  notifications: {
+    list: (...args: unknown[]) => mockList(...args),
+    unreadCount: () => mockUnreadCount(),
+    markAllRead: () => mockMarkAllRead(),
+    markOneRead: (id: string) => mockMarkOneRead(id),
+  },
+}))
+
+function makeItem(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    type: overrides.type ?? 'follow',
+    actor: overrides.actor ?? { id: crypto.randomUUID(), username: 'actor', avatarUrl: null },
+    clip: overrides.clip ?? null,
+    comment: overrides.comment ?? null,
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    readAt: overrides.readAt ?? null,
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.useFakeTimers()
+  mockList.mockReset()
+  mockUnreadCount.mockReset()
+  mockMarkAllRead.mockReset()
+  mockMarkOneRead.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useNotificationsStore', () => {
+  it('startPolling fires unreadCount immediately and every 30s', async () => {
+    mockUnreadCount.mockResolvedValue({ count: 3 })
+    const store = useNotificationsStore()
+
+    store.startPolling()
+    // Drain the immediate microtask so the initial unreadCount lands.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+    expect(store.unreadCount).toBe(3)
+
+    mockUnreadCount.mockResolvedValue({ count: 5 })
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mockUnreadCount).toHaveBeenCalledTimes(2)
+    expect(store.unreadCount).toBe(5)
+  })
+
+  it('startPolling is idempotent — repeat calls do not double the interval', async () => {
+    mockUnreadCount.mockResolvedValue({ count: 0 })
+    const store = useNotificationsStore()
+
+    store.startPolling()
+    store.startPolling()
+    store.startPolling()
+    await vi.advanceTimersByTimeAsync(0)
+    // One immediate fire — not three.
+    expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    // One tick more — not three.
+    expect(mockUnreadCount).toHaveBeenCalledTimes(2)
+  })
+
+  it('stopPolling halts subsequent ticks (logout scenario)', async () => {
+    mockUnreadCount.mockResolvedValue({ count: 1 })
+    const store = useNotificationsStore()
+    store.startPolling()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+
+    store.stopPolling()
+    await vi.advanceTimersByTimeAsync(60_000)
+    // Polling stopped — no further requests.
+    expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+  })
+
+  it('reset clears state and stops polling', async () => {
+    mockUnreadCount.mockResolvedValue({ count: 7 })
+    const store = useNotificationsStore()
+    store.startPolling()
+    await vi.advanceTimersByTimeAsync(0)
+    store.items = [makeItem()]
+    store.cursor = 'opaque'
+
+    store.reset()
+
+    expect(store.unreadCount).toBe(0)
+    expect(store.items).toHaveLength(0)
+    expect(store.cursor).toBeNull()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+  })
+
+  it('loadFirstPage replaces items and stores cursor', async () => {
+    const item = makeItem()
+    mockList.mockResolvedValue({ items: [item], nextCursor: 'next' })
+    const store = useNotificationsStore()
+
+    await store.loadFirstPage(10)
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 10 })
+    expect(store.items).toEqual([item])
+    expect(store.cursor).toBe('next')
+    expect(store.hasMore).toBe(true)
+  })
+
+  it('loadMore appends and is a no-op when no cursor', async () => {
+    const store = useNotificationsStore()
+    store.cursor = null
+
+    await store.loadMore()
+    expect(mockList).not.toHaveBeenCalled()
+
+    const item = makeItem()
+    mockList.mockResolvedValue({ items: [item], nextCursor: null })
+    store.cursor = 'opaque'
+    await store.loadMore(20)
+
+    expect(mockList).toHaveBeenCalledWith({ cursor: 'opaque', limit: 20 })
+    expect(store.items).toEqual([item])
+    expect(store.cursor).toBeNull()
+  })
+
+  it('markAllRead optimistically zeroes the badge and stamps unread rows', async () => {
+    const unread = makeItem({ readAt: null })
+    const alreadyRead = makeItem({ readAt: '2026-01-01T00:00:00Z' })
+    const store = useNotificationsStore()
+    store.items = [unread, alreadyRead]
+    store.unreadCount = 1
+    mockMarkAllRead.mockResolvedValue({ marked: 1 })
+
+    await store.markAllRead()
+
+    expect(store.unreadCount).toBe(0)
+    expect(store.items[0].readAt).not.toBeNull()
+    expect(store.items[1].readAt).toBe('2026-01-01T00:00:00Z')
+    expect(mockMarkAllRead).toHaveBeenCalled()
+  })
+
+  it('markOneRead decrements unreadCount only for previously-unread rows', async () => {
+    const unread = makeItem({ readAt: null })
+    const store = useNotificationsStore()
+    store.items = [unread]
+    store.unreadCount = 2
+    mockMarkOneRead.mockResolvedValue(undefined)
+
+    await store.markOneRead(unread.id)
+    expect(store.unreadCount).toBe(1)
+    expect(store.items[0].readAt).not.toBeNull()
+
+    // Calling again on the same (now-read) row must NOT decrement again.
+    await store.markOneRead(unread.id)
+    expect(store.unreadCount).toBe(1)
+  })
+
+  it('refreshUnreadCount swallows transient failures', async () => {
+    mockUnreadCount.mockRejectedValueOnce(new Error('boom'))
+    const store = useNotificationsStore()
+    store.unreadCount = 4
+
+    // Must not throw — polling tick failures are silent.
+    await store.refreshUnreadCount()
+    expect(store.unreadCount).toBe(4)
+  })
+
+  it('loadFirstPage marks errored on failure and clears loading', async () => {
+    mockList.mockRejectedValue(new Error('5xx'))
+    const store = useNotificationsStore()
+
+    await store.loadFirstPage()
+    expect(store.errored).toBe(true)
+    expect(store.loading).toBe(false)
+  })
+})

--- a/web/src/stores/notifications.ts
+++ b/web/src/stores/notifications.ts
@@ -1,0 +1,134 @@
+import { defineStore } from 'pinia'
+import { notifications as api, type NotificationItem } from '@/api/notifications'
+
+// Cadence: every 30 s while authenticated. v1 polls; SSE / WebSocket is a Phase 4 follow-up.
+const POLL_INTERVAL_MS = 30_000
+
+const DROPDOWN_PREVIEW_LIMIT = 10
+const PAGE_LIMIT = 20
+
+interface State {
+  items: NotificationItem[]
+  cursor: string | null
+  unreadCount: number
+  // null when not currently polling. Stored on state so HMR / repeat startPolling() calls
+  // don't leak multiple intervals.
+  pollTimer: ReturnType<typeof setInterval> | null
+  loading: boolean
+  loadingMore: boolean
+  errored: boolean
+}
+
+export const useNotificationsStore = defineStore('notifications', {
+  state: (): State => ({
+    items: [],
+    cursor: null,
+    unreadCount: 0,
+    pollTimer: null,
+    loading: false,
+    loadingMore: false,
+    errored: false,
+  }),
+
+  getters: {
+    hasMore: (state): boolean => state.cursor !== null,
+  },
+
+  actions: {
+    startPolling() {
+      // Idempotent. App.vue watches `auth.isAuthenticated` and may fire start multiple times
+      // (e.g. on every store hydration); the guard keeps polling to a single interval.
+      if (this.pollTimer !== null) return
+      // Fire once immediately so the badge is correct without waiting 30 s.
+      void this.refreshUnreadCount()
+      this.pollTimer = setInterval(() => {
+        void this.refreshUnreadCount()
+      }, POLL_INTERVAL_MS)
+    },
+
+    stopPolling() {
+      if (this.pollTimer !== null) {
+        clearInterval(this.pollTimer)
+        this.pollTimer = null
+      }
+    },
+
+    // Resets everything to logged-out defaults. Called on auth logout so a subsequent login
+    // doesn't show stale notifications from the previous user.
+    reset() {
+      this.stopPolling()
+      this.items = []
+      this.cursor = null
+      this.unreadCount = 0
+      this.loading = false
+      this.loadingMore = false
+      this.errored = false
+    },
+
+    async refreshUnreadCount() {
+      try {
+        const { count } = await api.unreadCount()
+        this.unreadCount = count
+      } catch {
+        // Polling failures are silent — a transient 5xx shouldn't surface a UI error every 30 s.
+        // The next tick retries; if auth has truly broken the api client will trigger logout.
+      }
+    },
+
+    async loadFirstPage(limit: number = DROPDOWN_PREVIEW_LIMIT) {
+      this.loading = true
+      this.errored = false
+      try {
+        const page = await api.list({ limit })
+        this.items = page.items
+        this.cursor = page.nextCursor
+      } catch {
+        this.errored = true
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async loadMore(limit: number = PAGE_LIMIT) {
+      if (this.cursor === null || this.loadingMore) return
+      this.loadingMore = true
+      try {
+        const page = await api.list({ cursor: this.cursor, limit })
+        this.items.push(...page.items)
+        this.cursor = page.nextCursor
+      } catch {
+        this.errored = true
+      } finally {
+        this.loadingMore = false
+      }
+    },
+
+    async markAllRead() {
+      // Optimistic: zero the badge and stamp rows locally before the request lands so the UI
+      // doesn't flash. A server failure leaves things in a slightly stale state until the next
+      // poll corrects them — acceptable for a low-stakes UI action.
+      const now = new Date().toISOString()
+      this.unreadCount = 0
+      this.items = this.items.map((n) => (n.readAt === null ? { ...n, readAt: now } : n))
+      try {
+        await api.markAllRead()
+      } catch {
+        // Re-sync on next poll tick; nothing to do here.
+      }
+    },
+
+    async markOneRead(id: string) {
+      const item = this.items.find((n) => n.id === id)
+      const wasUnread = item?.readAt === null
+      if (item && wasUnread) {
+        item.readAt = new Date().toISOString()
+        this.unreadCount = Math.max(0, this.unreadCount - 1)
+      }
+      try {
+        await api.markOneRead(id)
+      } catch {
+        // Same optimistic-update rationale as markAllRead.
+      }
+    },
+  },
+})

--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -28,8 +28,9 @@ function destinationFor(n: NotificationItem) {
   return { name: 'user', params: { username: n.actor.username } }
 }
 
-async function onRowClick(n: NotificationItem) {
-  await store.markOneRead(n.id)
+function onRowClick(n: NotificationItem) {
+  // Fire-and-forget — see NotificationsDropdown.onRowClick for the rationale.
+  void store.markOneRead(n.id)
   void router.push(destinationFor(n))
 }
 

--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useNotificationsStore } from '@/stores/notifications'
+import type { NotificationItem } from '@/api/notifications'
+import PageHeader from '@/components/PageHeader.vue'
+import StatusPanel from '@/components/StatusPanel.vue'
+import LoadMoreButton from '@/components/LoadMoreButton.vue'
+import NotificationRow from '@/components/notifications/NotificationRow.vue'
+
+const store = useNotificationsStore()
+const router = useRouter()
+const paginationErrored = ref(false)
+
+onMounted(() => {
+  // Refresh from the server when the page mounts — the dropdown's cached items may be stale,
+  // and the user came here specifically to see the latest.
+  void store.loadFirstPage(20)
+})
+
+function destinationFor(n: NotificationItem) {
+  if (n.type === 'follow') {
+    return { name: 'user', params: { username: n.actor.username } }
+  }
+  if (n.clip) {
+    return { name: 'clip', params: { id: n.clip.id } }
+  }
+  return { name: 'user', params: { username: n.actor.username } }
+}
+
+async function onRowClick(n: NotificationItem) {
+  await store.markOneRead(n.id)
+  void router.push(destinationFor(n))
+}
+
+async function onLoadMore() {
+  paginationErrored.value = false
+  const before = store.errored
+  await store.loadMore(20)
+  if (!before && store.errored) {
+    paginationErrored.value = true
+    store.errored = false
+  }
+}
+</script>
+
+<template>
+  <main class="mx-auto max-w-3xl px-6 pt-8 pb-30 max-[899px]:px-3.5 max-[899px]:pt-4">
+    <PageHeader title="Notifications">
+      <template #caption>
+        <span>Recent activity</span>
+      </template>
+      <div class="mt-3 flex">
+        <button
+          type="button"
+          class="cursor-pointer rounded-sm border border-border bg-surface-raised px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.04em] text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+          :disabled="store.unreadCount === 0"
+          @click="store.markAllRead()"
+        >
+          Mark all read
+        </button>
+      </div>
+    </PageHeader>
+
+    <StatusPanel
+      v-if="store.loading && store.items.length === 0 && !store.errored"
+      kind="loading"
+      message="Loading…"
+    />
+
+    <StatusPanel v-else-if="store.errored" kind="error" message="Couldn't load notifications.">
+      <button
+        class="cursor-pointer rounded-sm border border-border bg-surface-raised px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="store.loadFirstPage(20)"
+      >
+        Retry
+      </button>
+    </StatusPanel>
+
+    <StatusPanel
+      v-else-if="!store.loading && store.items.length === 0"
+      kind="empty"
+      message="No notifications yet."
+    />
+
+    <template v-else>
+      <ul class="mt-6 grid grid-cols-1 gap-2 p-0">
+        <li
+          v-for="n in store.items"
+          :key="n.id"
+          class="list-none cursor-pointer rounded-sm border border-border bg-surface-raised transition-colors duration-150 hover:border-border-hover"
+          :class="n.readAt === null ? 'border-l-2 border-l-brand' : ''"
+          @click="onRowClick(n)"
+        >
+          <NotificationRow :notification="n" />
+        </li>
+      </ul>
+
+      <LoadMoreButton
+        v-if="store.cursor || paginationErrored"
+        class="mt-6"
+        :loading="store.loadingMore"
+        :errored="paginationErrored"
+        @load="onLoadMore"
+      />
+    </template>
+  </main>
+</template>


### PR DESCRIPTION
## Summary

Phase 3 (Discovery) — notifications for likes / comments / follows. Closes the social loop opened by #84 (comments) and #85 (follows): event recording is wired into the three existing endpoints behind a small `INotificationService`, the recipient hits `/me/notifications/*` to read and clear, and the web ships a bell+badge in the nav, a teleported dropdown, and a `/notifications` full-history view.

Closes #89

## What's here

**Server**
- Migration `AddNotifications` — `notifications` table with `(recipient_id, created_at DESC)` index for the listing query and a partial `WHERE read_at IS NULL` index sized to the unread tail (the 30 s poll's hot path). `ck_notifications_no_self` and cascade FKs from both user legs / clip / comment.
- `INotificationService.RecordAsync` injected into Likes / Follows / Comments. Self-actions dropped at the service (and again at the DB CHECK). Insert and notification share the caller's transaction so a notification failure rolls back the event.
- `NotificationsEndpoints`: `GET /me/notifications` (keyset paginated, hydrated actor + clip + comment), `GET /me/notifications/unread-count` (partial-index probe), `POST /me/notifications/read` (mark all), `POST /me/notifications/{id}/read` (mark one — idempotent, preserves the original `read_at` on re-mark).
- `SeedCommand` provisions a second dev user (`seeduser2 / testpass123!`) so the two-browser flow works straight from `make seed`.

**Web**
- `api/notifications.ts` + Pinia `stores/notifications.ts` — 30 s polling while authenticated, optimistic mark-read updates, full reset on logout so a re-login can't show the previous user's badge.
- `IconBell` + bell-with-badge in `AppNav`; teleported popover to dodge the header's `backdrop-filter` paint context. Outside-click and Esc both close.
- `NotificationsDropdown` (top 10, "see all" link) and `NotificationsView` (`/notifications`, paginated history). Row click marks read fire-and-forget and routes to the clip or the actor's profile.

**Pre-push hardening** (separate commit on top): transaction wrap for Follow + CreateComment, `MarkOneRead` no longer clobbers the original `read_at`, dropdown navigation no longer awaits the network round-trip, Esc closes the bell.

## How to test manually

```bash
make seed                      # provisions seeduser1 + seeduser2
make server                    # in one terminal
cd web && bun dev              # in another
```

- Sign in as `seeduser1` in one browser, `seeduser2` in another.
- From `seeduser2`: like / comment on a `seeduser1` clip, and follow `seeduser1`.
- `seeduser1`'s bell badge ticks within 30 s; opening the dropdown lists the three events newest-first.
- Click a row → it's marked read, the dropdown closes, the page navigates to the clip (like / comment) or to `seeduser2`'s profile (follow).
- `Esc` closes the dropdown and returns focus to the bell.
- "Mark all read" zeroes the badge; the unread strip on each row disappears.
- Visit `/notifications` for the full paginated history; "Load more" pages through.

API quick-check:
```bash
curl -H "Authorization: Bearer $TOKEN" http://localhost:5050/me/notifications/unread-count
curl -H "Authorization: Bearer $TOKEN" http://localhost:5050/me/notifications | jq
curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:5050/me/notifications/read
```

## Checklist

- [ ] Self-like / self-comment / self-follow do NOT create a notification
- [ ] Unliking does not create or delete a notification (history preserved)
- [ ] Deleting a clip cascades to its notifications; deleting a user cascades from both recipient and actor sides
- [ ] Unread-count uses the partial index (`EXPLAIN ANALYZE` shows `Index Scan` on `idx_notifications_unread`)
- [ ] Polling stops on logout and on tab close (`onBeforeUnmount`)
- [ ] 85/85 coverage gate still green
