### PR TITLE
discord.js implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,21 @@ IGDB_CLIENT_SECRET=
 # Background re-sync (keeps covers/names current). Off by default; opt in per environment.
 # IGDB_SYNC_ENABLED=false
 # IGDB_SYNC_INTERVAL_DAYS=7
+
+# Discord bot (issue #107) — OPTIONAL. Auto-posts new public clips to subscribed
+# Discord channels. The compose service is gated behind the `discord` profile
+# (`docker compose --profile discord up`), and even when it's running, leaving
+# DISCORD_BOT_TOKEN empty keeps it idle — the container logs "disabled; exiting"
+# and stops cleanly. Token + App ID come from the same Discord application as
+# the OAuth login above (Bot tab → token, General tab → application id).
+# DISCORD_BOT_GUILD_ID scopes slash-command registration to one dev guild for
+# instant propagation (vs up to an hour for global); leave unset in production.
+# DISCORD_DATABASE_URL is the libpq form of the API's DATABASE_URL — needed
+# because porsager's `postgres` driver can't parse the dotnet semicolon form
+# that DATABASE_URL above carries.
+# See discord/.env.example for the bot-process-local versions.
+DISCORD_BOT_TOKEN=
+DISCORD_BOT_APP_ID=
+DISCORD_BOT_GUILD_ID=
+DISCORD_POLL_INTERVAL_SECONDS=30
+DISCORD_DATABASE_URL=postgres://gankedtv:gankedtv_dev@localhost:5435/gankedtv

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -44,9 +44,10 @@ fi
 
 touched_server=$(echo "$changed_files" | grep -E '^server/' || true)
 touched_web=$(echo "$changed_files" | grep -E '^web/' || true)
+touched_discord=$(echo "$changed_files" | grep -E '^discord/' || true)
 
-if [ -z "$touched_server" ] && [ -z "$touched_web" ]; then
-  echo "pre-push: no changes under server/ or web/ — skipping."
+if [ -z "$touched_server" ] && [ -z "$touched_web" ] && [ -z "$touched_discord" ]; then
+  echo "pre-push: no changes under server/, web/, or discord/ — skipping."
   exit 0
 fi
 
@@ -67,6 +68,18 @@ if [ -n "$touched_web" ]; then
   echo "pre-push: formatting web…"
   (
     cd web
+    if [ -n "$manifest_changed" ]; then
+      bun install --frozen-lockfile
+    fi
+    bun run format
+  )
+fi
+
+if [ -n "$touched_discord" ]; then
+  manifest_changed=$(echo "$changed_files" | grep -E '^discord/(package\.json|bun\.lock)$' || true)
+  echo "pre-push: formatting discord…"
+  (
+    cd discord
     if [ -n "$manifest_changed" ]; then
       bun install --frozen-lockfile
     fi
@@ -96,6 +109,16 @@ if [ -n "$touched_web" ]; then
     cd web
     bun run lint:check
     bun run build
+    bun run test:coverage
+  )
+fi
+
+if [ -n "$touched_discord" ]; then
+  echo "pre-push: running discord checks…"
+  (
+    cd discord
+    bun run lint:check
+    bun run type-check
     bun run test:coverage
   )
 fi

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -16,6 +16,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for the workflow's GITHUB_TOKEN. The discord workflow
+# only reads source and runs tests — no writes back to the repo, no comments on
+# PRs, no package publishes. If a step ever needs more, scope it locally with a
+# job- or step-level `permissions:` block rather than relaxing this one.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,6 +31,8 @@ jobs:
         working-directory: discord
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -44,6 +53,8 @@ jobs:
         working-directory: discord
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -67,6 +78,8 @@ jobs:
         working-directory: discord
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,80 @@
+name: Discord
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'discord/**'
+      - '.github/workflows/discord.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'discord/**'
+      - '.github/workflows/discord.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: discord
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: discord/package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run type-check
+
+  format:
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: discord
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: discord/package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Lint
+        run: bun run lint:check
+
+  test:
+    needs: format
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: discord
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: discord/package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test with coverage (enforces 85% line / 85% function)
+        run: bun run test:coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,27 @@ cd web && bun run test:coverage  # Run with coverage + threshold gate (scoped)
 
 Web coverage gate: **85% line / 85% branch**, scoped to `src/api/**`, `src/router/**`, `src/stores/**` (HTTP client, auth, routing). Components, views, `App.vue`, `main.ts`, and `assets/` are deliberately excluded — the goal is protecting auth/network/routing logic, not display code. Coverage config lives in [web/vitest.config.ts](web/vitest.config.ts).
 
+### Discord bot (from repository root)
+```bash
+make discord-install          # Install dependencies (bun install)
+make discord                  # Run in watch mode (talks to host API + host Postgres)
+make discord-test             # Run tests (bun test)
+make discord-lint             # Lint (oxlint + eslint with auto-fix)
+make ci-discord               # Full CI mirror (format/lint/type-check/coverage)
+```
+
+The bot lives in [discord/](discord/) as a sibling of `server/` and `web/`. It's **off by default** — without `DISCORD_BOT_TOKEN` + `DISCORD_BOT_APP_ID` it logs `disabled; exiting` on boot and no-ops (same contract as `IgdbSyncHostedService`). The compose service is gated behind the `discord` profile (`docker compose --profile discord up`) so `make up` doesn't build the Bun image by default. Stack is **TypeScript + Bun + discord.js**, with `postgres` for direct DB access. The bot owns its own tables (`discord_subscriptions`, `discord_post_log`, `discord_bot_state`) — EF Core does NOT model them, so they live in the shared Postgres without colliding with API migrations. The bot applies its own SQL migrations from `discord/src/migrations/*.sql` on boot.
+
+Detection is **polling** (`GET /clips/feed` every `DISCORD_POLL_INTERVAL_SECONDS`, default 30s). Each round tracks a high-water-mark by `created_at` and uses a per-`(channel_id, clip_id)` post-log row as the dedupe guard, so a crash mid-fanout doesn't double-post on restart. A future upgrade to push-based delivery (webhook on `clip.ready`) would only swap the poller's entry-point — fanout, filters, dedupe, and command surface stay identical.
+
+Slash commands ship in two namespaces:
+- `/gankedtv subscribe|unsubscribe|subscriptions|pause|resume` — subscription CRUD per channel (gated to `ManageChannels`).
+- `/clip latest|top|search` — on-demand clip pulls; works in any guild even without a subscription.
+
+**Env loading:** the bot reads shared values from the repo-root [.env](.env) (mirrors web's `envDir: '../'` convention), then layers `discord/.env` on top (auto-loaded by Bun), then shell env wins. Precedence is first-set-wins, so the same `DATABASE_URL` you have at the root works automatically. See [discord/src/loadEnv.ts](discord/src/loadEnv.ts).
+
+Discord coverage gate: **85% line / 85% function** — enforced by [discord/scripts/check-coverage.ts](discord/scripts/check-coverage.ts), which parses `coverage/lcov.info` and exits non-zero when under threshold (Bun's own `coverageThreshold` setting in [discord/bunfig.toml](discord/bunfig.toml) is documentation-only on Bun 1.3.13 — it prints but doesn't enforce). The script also emits a markdown summary to `$GITHUB_STEP_SUMMARY` in CI. Excluded from the denominator: `src/index.ts` (boot wiring, covered indirectly), `src/db.ts` + `src/api.ts` (I/O wrappers; integration tests would need testcontainers), `src/migrator.ts`, `src/migrations/`.
+
 ## Architecture
 
 ```
@@ -111,6 +132,9 @@ gankedtv/
 │   └── tests/GankedTV.Api.Tests/  # xUnit tests with FluentAssertions
 ├── web/                      # Vue 3 frontend (Bun + Vite)
 │   └── src/
+├── discord/                  # Discord bot (Bun + discord.js, off by default)
+│   ├── src/
+│   └── tests/
 ├── docker-compose.dev.yml    # PostgreSQL + MinIO for local dev
 └── Makefile                  # Development commands
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ make ci-discord               # Full CI mirror (format/lint/type-check/coverage)
 
 The bot lives in [discord/](discord/) as a sibling of `server/` and `web/`. It's **off by default** — without `DISCORD_BOT_TOKEN` + `DISCORD_BOT_APP_ID` it logs `disabled; exiting` on boot and no-ops (same contract as `IgdbSyncHostedService`). The compose service is gated behind the `discord` profile (`docker compose --profile discord up`) so `make up` doesn't build the Bun image by default. Stack is **TypeScript + Bun + discord.js**, with `postgres` for direct DB access. The bot owns its own tables (`discord_subscriptions`, `discord_post_log`, `discord_bot_state`) — EF Core does NOT model them, so they live in the shared Postgres without colliding with API migrations. The bot applies its own SQL migrations from `discord/src/migrations/*.sql` on boot.
 
+**Postgres ≥ 15 required.** The initial migration uses `UNIQUE NULLS NOT DISTINCT` (added in PG15) to keep `(channel_id, NULL, NULL)` firehose subscriptions from duplicating. The dev compose stack runs PG18 so this is invisible locally; operators on shared older clusters need to upgrade or fork the migration.
+
 Detection is **polling** (`GET /clips/feed` every `DISCORD_POLL_INTERVAL_SECONDS`, default 30s). Each round tracks a high-water-mark by `created_at` and uses a per-`(channel_id, clip_id)` post-log row as the dedupe guard, so a crash mid-fanout doesn't double-post on restart. A future upgrade to push-based delivery (webhook on `clip.ready`) would only swap the poller's entry-point — fanout, filters, dedupe, and command surface stay identical.
 
 Slash commands ship in two namespaces:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export
 COMPOSE_ENV_FILE := $(if $(wildcard .env.worktree.local),--env-file .env.worktree.local,)
 COMPOSE := docker-compose -f docker-compose.dev.yml $(COMPOSE_ENV_FILE)
 
-.PHONY: setup server-install wait-postgres wait-minio up down clean logs server server-build server-test migrate migrate-add seed import-games web web-install web-build web-test web-lint dev-all hooks ci ci-server ci-web ports
+.PHONY: setup server-install wait-postgres wait-minio up down clean logs server server-build server-test migrate migrate-add seed import-games web web-install web-build web-test web-lint discord discord-install discord-test discord-lint dev-all hooks ci ci-server ci-web ci-discord ports
 
 # One-command dev bootstrap. DESTRUCTIVE: wipes the local Postgres + MinIO volumes
 # so every run lands you on a known-good state from migrations + seed. Steps:
@@ -159,13 +159,30 @@ dev-all: up
 	ASPNETCORE_URLS=$(ASPNETCORE_URLS) dotnet watch --project server/src/GankedTV.Api & \
 	cd web && bun dev --port $(VITE_PORT)
 
+# Discord bot. Run on the host (talks to host Postgres + host API) so iteration
+# is fast and you don't have to rebuild the container on every code change. The
+# compose service exists for parity / staging deploys, gated behind the
+# `discord` profile so `make up` doesn't pull the Bun image by default.
+discord-install:
+	cd discord && bun install
+
+discord:
+	cd discord && bun run dev
+
+discord-test:
+	cd discord && bun test
+
+discord-lint:
+	cd discord && bun run lint
+
 # CI mirror: runs the same checks the GitHub workflows run, in verify-only mode.
-# Mirrors `.github/workflows/server.yml` and `.github/workflows/web.yml` step-for-step
+# Mirrors `.github/workflows/server.yml`, `web.yml`, and `discord.yml` step-for-step
 # so contributors can reproduce CI locally with one command.
 #
 # Pre-push hook is intentionally NOT wired through here — it scopes to changed dirs
-# (server/ vs web/), `make ci` runs the full matrix. Use sub-targets for partial runs.
-ci: ci-server ci-web
+# (server/ vs web/ vs discord/), `make ci` runs the full matrix. Use sub-targets
+# for partial runs.
+ci: ci-server ci-web ci-discord
 
 ci-server:
 	cd server && dotnet format --verify-no-changes
@@ -178,6 +195,13 @@ ci-web:
 	cd web && bun run lint:check
 	cd web && bun run build
 	cd web && bun run test:coverage
+
+ci-discord:
+	cd discord && bun install --frozen-lockfile
+	cd discord && bun run format:check
+	cd discord && bun run lint:check
+	cd discord && bun run type-check
+	cd discord && bun run test:coverage
 
 # Git hooks — point git at the tracked .githooks/ directory.
 hooks:

--- a/discord/.env.example
+++ b/discord/.env.example
@@ -1,0 +1,33 @@
+# Discord bot env. Any var below can also live in the repo-root .env (the bot
+# reads ../.env first, then layers discord/.env on top — same convention as
+# web/vite.config.ts's envDir: '../'). Put shared values like DATABASE_URL at
+# the root and use this file only for bot-local overrides.
+#
+# Leave DISCORD_BOT_TOKEN empty to keep the service idle. When unset, the bot
+# logs "disabled; exiting" and no-ops, matching the IGDB sync hosted service
+# contract.
+DISCORD_BOT_TOKEN=
+DISCORD_BOT_APP_ID=
+
+# Optional: a guild id to register slash commands against during development.
+# Guild-scoped registration propagates within seconds; global registration can
+# take up to an hour. Leave empty in production.
+DISCORD_BOT_GUILD_ID=
+
+# Poll interval in seconds. Lower = lower lag, more API load.
+DISCORD_POLL_INTERVAL_SECONDS=30
+
+# Postgres connection string for the bot's own tables (discord_subscriptions,
+# discord_post_log, discord_bot_state). Same database as the API but distinct
+# env var: the API stores its connection string in dotnet semicolon form
+# (`Host=...;Port=...`) which porsager's `postgres` driver can't parse — the
+# bot needs libpq URL form. The bot applies its own SQL migrations from
+# src/migrations/ at startup and does not touch EF-managed tables for writes.
+DISCORD_DATABASE_URL=postgres://gankedtv:gankedtv_dev@localhost:5435/gankedtv
+
+# GankedTV API base — used to poll /clips/feed and serve /clip commands.
+GANKEDTV_API_BASE=http://localhost:5050
+
+# Public origin for share URLs (built as `${GANKEDTV_PUBLIC_BASE}/c/{code}`).
+# In production this should be the web origin (e.g. https://gankedtv.com).
+GANKEDTV_PUBLIC_BASE=http://localhost:5173

--- a/discord/.gitignore
+++ b/discord/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+.env.local
+*.log
+coverage/
+.eslintcache

--- a/discord/.prettierrc.json
+++ b/discord/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "arrowParens": "always"
+}

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -2,10 +2,17 @@ FROM oven/bun:1.3.13-alpine
 
 WORKDIR /app
 
+# Install + copy as root so the working tree ends up owned by root (cached layer
+# stays small), then chown to a dedicated unprivileged user for runtime. The bot
+# only needs read access to its own files + outbound network — no reason for it
+# to run as uid 0.
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production
 
 COPY src ./src
 COPY tsconfig.json bunfig.toml ./
+
+RUN addgroup -S bot && adduser -S bot -G bot && chown -R bot:bot /app
+USER bot
 
 CMD ["bun", "run", "src/index.ts"]

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.13-alpine
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+COPY src ./src
+COPY tsconfig.json bunfig.toml ./
+
+CMD ["bun", "run", "src/index.ts"]

--- a/discord/bun.lock
+++ b/discord/bun.lock
@@ -1,0 +1,325 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@gankedtv/discord",
+      "dependencies": {
+        "discord.js": "^14.26.4",
+        "postgres": "^3.4.9",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@types/bun": "^1.3.14",
+        "@types/node": "^25.9.1",
+        "eslint": "^10.4.0",
+        "eslint-config-prettier": "^10.1.8",
+        "npm-run-all2": "^8.0.4",
+        "oxlint": "^1.66.0",
+        "prettier": "^3.8.3",
+        "typescript": "~6.0.3",
+        "typescript-eslint": "^8.59.4",
+      },
+    },
+  },
+  "packages": {
+    "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
+
+    "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.66.0", "", { "os": "android", "cpu": "arm" }, "sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.66.0", "", { "os": "android", "cpu": "arm64" }, "sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.66.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.66.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.66.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.66.0", "", { "os": "linux", "cpu": "arm" }, "sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.66.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.66.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.66.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.66.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.66.0", "", { "os": "linux", "cpu": "none" }, "sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.66.0", "", { "os": "linux", "cpu": "none" }, "sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.66.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.66.0", "", { "os": "linux", "cpu": "x64" }, "sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.66.0", "", { "os": "linux", "cpu": "x64" }, "sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.66.0", "", { "os": "none", "cpu": "arm64" }, "sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.66.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.66.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.66.0", "", { "os": "win32", "cpu": "x64" }, "sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ=="],
+
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.4", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/type-utils": "8.59.4", "@typescript-eslint/utils": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.4", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.4", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.4", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.4", "@typescript-eslint/types": "^8.59.4", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4" } }, "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.4", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/utils": "8.59.4", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.4", "", {}, "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.4", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.4", "@typescript-eslint/tsconfig-utils": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "eslint-visitor-keys": "^5.0.0" } }, "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+
+    "discord.js": ["discord.js@14.26.4", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.4.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@4.0.0", "", {}, "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
+
+    "memorystream": ["memorystream@0.3.1", "", {}, "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "npm-normalize-package-bin": ["npm-normalize-package-bin@4.0.0", "", {}, "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w=="],
+
+    "npm-run-all2": ["npm-run-all2@8.0.4", "", { "dependencies": { "ansi-styles": "^6.2.1", "cross-spawn": "^7.0.6", "memorystream": "^0.3.1", "picomatch": "^4.0.2", "pidtree": "^0.6.0", "read-package-json-fast": "^4.0.0", "shell-quote": "^1.7.3", "which": "^5.0.0" }, "bin": { "run-p": "bin/run-p/index.js", "run-s": "bin/run-s/index.js", "npm-run-all": "bin/npm-run-all/index.js", "npm-run-all2": "bin/npm-run-all/index.js" } }, "sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "oxlint": ["oxlint@1.66.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.66.0", "@oxlint/binding-android-arm64": "1.66.0", "@oxlint/binding-darwin-arm64": "1.66.0", "@oxlint/binding-darwin-x64": "1.66.0", "@oxlint/binding-freebsd-x64": "1.66.0", "@oxlint/binding-linux-arm-gnueabihf": "1.66.0", "@oxlint/binding-linux-arm-musleabihf": "1.66.0", "@oxlint/binding-linux-arm64-gnu": "1.66.0", "@oxlint/binding-linux-arm64-musl": "1.66.0", "@oxlint/binding-linux-ppc64-gnu": "1.66.0", "@oxlint/binding-linux-riscv64-gnu": "1.66.0", "@oxlint/binding-linux-riscv64-musl": "1.66.0", "@oxlint/binding-linux-s390x-gnu": "1.66.0", "@oxlint/binding-linux-x64-gnu": "1.66.0", "@oxlint/binding-linux-x64-musl": "1.66.0", "@oxlint/binding-openharmony-arm64": "1.66.0", "@oxlint/binding-win32-arm64-msvc": "1.66.0", "@oxlint/binding-win32-ia32-msvc": "1.66.0", "@oxlint/binding-win32-x64-msvc": "1.66.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
+
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "read-package-json-fast": ["read-package-json-fast@4.0.0", "", { "dependencies": { "json-parse-even-better-errors": "^4.0.0", "npm-normalize-package-bin": "^4.0.0" } }, "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.59.4", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.4", "@typescript-eslint/parser": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/utils": "8.59.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ=="],
+
+    "undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+  }
+}

--- a/discord/bunfig.toml
+++ b/discord/bunfig.toml
@@ -6,5 +6,4 @@ coveragePathIgnorePatterns = [
   "src/migrations/",
   "src/migrator.ts",
   "src/db.ts",
-  "src/api.ts",
 ]

--- a/discord/bunfig.toml
+++ b/discord/bunfig.toml
@@ -1,0 +1,10 @@
+[test]
+coverageReporter = ["text", "lcov"]
+coverageThreshold = { line = 0.85, function = 0.85 }
+coveragePathIgnorePatterns = [
+  "src/index.ts",
+  "src/migrations/",
+  "src/migrator.ts",
+  "src/db.ts",
+  "src/api.ts",
+]

--- a/discord/eslint.config.js
+++ b/discord/eslint.config.js
@@ -1,0 +1,21 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  {
+    ignores: ['node_modules/', 'coverage/'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettier,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+);

--- a/discord/package.json
+++ b/discord/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@gankedtv/discord",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "bun@1.3.13",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "start": "bun run src/index.ts",
+    "type-check": "tsc --noEmit",
+    "lint": "run-s lint:oxlint lint:eslint",
+    "lint:oxlint": "oxlint . --fix",
+    "lint:eslint": "eslint . --fix --cache",
+    "lint:check": "run-s lint:oxlint:check lint:eslint:check",
+    "lint:oxlint:check": "oxlint .",
+    "lint:eslint:check": "eslint . --cache",
+    "format": "prettier --write --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/ tests/",
+    "format:check": "prettier --check --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/ tests/",
+    "test": "bun test",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov && bun run scripts/check-coverage.ts"
+  },
+  "dependencies": {
+    "discord.js": "^14.26.4",
+    "postgres": "^3.4.9",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^25.9.1",
+    "eslint": "^10.4.0",
+    "eslint-config-prettier": "^10.1.8",
+    "npm-run-all2": "^8.0.4",
+    "oxlint": "^1.66.0",
+    "prettier": "^3.8.3",
+    "typescript": "~6.0.3",
+    "typescript-eslint": "^8.59.4"
+  }
+}

--- a/discord/scripts/check-coverage.ts
+++ b/discord/scripts/check-coverage.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env bun
+// Enforces the discord/ coverage gate by parsing coverage/lcov.info and failing
+// when totals fall below thresholds. Bun's own `coverageThreshold` setting in
+// bunfig.toml prints the report but does NOT exit non-zero (verified on 1.3.13),
+// so without this script `make ci-discord` would silently pass under-covered
+// changes. Vitest enforces natively (see web/vitest.config.ts thresholds), so
+// this script exists only because Bun's enforcement is broken — once that's
+// fixed upstream, the script can be deleted and the bunfig.toml threshold
+// becomes the source of truth.
+//
+// Thresholds match web/: 85% lines, 85% functions (Bun's coverage doesn't emit
+// branch data, so we gate on functions instead — equivalent coverage signal in
+// practice for code that uses small focused functions).
+
+import { appendFile, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+const LCOV_PATH = 'coverage/lcov.info';
+const LINE_THRESHOLD = 0.85;
+const FUNCTION_THRESHOLD = 0.85;
+
+// Files included in test discovery but excluded from the coverage denominator —
+// kept in sync with bunfig.toml's coveragePathIgnorePatterns. Listed by prefix
+// match against the SF: path emitted by bun's lcov reporter.
+const EXCLUDE_PREFIXES = [
+  'src/index.ts',
+  'src/migrations/',
+  'src/migrator.ts',
+  'src/db.ts',
+  'src/api.ts',
+  'tests/',
+];
+
+if (!existsSync(LCOV_PATH)) {
+  console.error(`coverage gate: ${LCOV_PATH} not found — did 'bun test --coverage' run?`);
+  process.exit(1);
+}
+
+const lcov = await readFile(LCOV_PATH, 'utf8');
+
+let lineFound = 0;
+let lineHit = 0;
+let fnFound = 0;
+let fnHit = 0;
+let currentFile = '';
+let includeCurrent = true;
+
+for (const line of lcov.split('\n')) {
+  if (line.startsWith('SF:')) {
+    currentFile = line.slice(3);
+    includeCurrent = !EXCLUDE_PREFIXES.some((p) => currentFile.startsWith(p));
+    continue;
+  }
+  if (!includeCurrent) continue;
+  if (line.startsWith('LF:')) lineFound += Number(line.slice(3));
+  else if (line.startsWith('LH:')) lineHit += Number(line.slice(3));
+  else if (line.startsWith('FNF:')) fnFound += Number(line.slice(4));
+  else if (line.startsWith('FNH:')) fnHit += Number(line.slice(4));
+}
+
+const linePct = lineFound === 0 ? 1 : lineHit / lineFound;
+const fnPct = fnFound === 0 ? 1 : fnHit / fnFound;
+
+const fmt = (p: number) => (p * 100).toFixed(2) + '%';
+const linesLabel = `${fmt(linePct)} (${lineHit}/${lineFound})`;
+const fnLabel = `${fmt(fnPct)} (${fnHit}/${fnFound})`;
+const thresh = (n: number) => `${(n * 100).toFixed(0)}%`;
+
+console.log('');
+console.log('Discord coverage gate:');
+console.log(`  Lines:     ${linesLabel}  (threshold ${thresh(LINE_THRESHOLD)})`);
+console.log(`  Functions: ${fnLabel}  (threshold ${thresh(FUNCTION_THRESHOLD)})`);
+
+let failed = false;
+if (linePct < LINE_THRESHOLD) {
+  console.error(`  ✗ line coverage ${fmt(linePct)} below ${thresh(LINE_THRESHOLD)}`);
+  failed = true;
+}
+if (fnPct < FUNCTION_THRESHOLD) {
+  console.error(`  ✗ function coverage ${fmt(fnPct)} below ${thresh(FUNCTION_THRESHOLD)}`);
+  failed = true;
+}
+
+// Emit a GitHub Actions step summary (markdown table) when the runner exposes
+// the file. Mirrors web.yml's coverage-summary step but written in TS instead
+// of a shell+jq snippet to keep the parsing in one place.
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (summaryPath) {
+  const status = failed ? '❌ failed' : '✅ passed';
+  const md = [
+    `## Discord coverage (scoped: src/, excludes I/O wrappers + boot)`,
+    ``,
+    `Gate: ${status}`,
+    ``,
+    `| Metric    | %     | Covered / Total | Threshold |`,
+    `|-----------|-------|-----------------|-----------|`,
+    `| Lines     | ${fmt(linePct)} | ${lineHit}/${lineFound} | ${thresh(LINE_THRESHOLD)} |`,
+    `| Functions | ${fmt(fnPct)} | ${fnHit}/${fnFound} | ${thresh(FUNCTION_THRESHOLD)} |`,
+    ``,
+  ].join('\n');
+  await appendFile(summaryPath, md);
+}
+
+if (failed) process.exit(1);
+console.log('  ✓ coverage gate passed');

--- a/discord/scripts/check-coverage.ts
+++ b/discord/scripts/check-coverage.ts
@@ -22,12 +22,29 @@ const FUNCTION_THRESHOLD = 0.85;
 // Files included in test discovery but excluded from the coverage denominator —
 // kept in sync with bunfig.toml's coveragePathIgnorePatterns. Listed by prefix
 // match against the SF: path emitted by bun's lcov reporter.
+//
+// What's NOT here on purpose:
+//   - src/api.ts — pure URL building + fetch + JSON parse, mockable via the
+//     injected fetchImpl param (tests/api.test.ts). Reviewer M1 from PR #111.
+//   - src/poller.ts, commands/**, filters.ts, lib/**, loadEnv.ts, config.ts,
+//     posting.ts, replies.ts — all testable with pure-function or fake-injection
+//     patterns; live in the denominator.
+//
+// What IS excluded (deliberately):
+//   - src/index.ts — boot wiring (Discord client login, signal handlers,
+//     compose-time env reads). Covered indirectly when the bot boots.
+//   - src/db.ts — postgres-js queries that need a real Postgres to validate
+//     SQL syntax. Bun lacks a first-class testcontainers story; the smoke
+//     script that previously covered this was deleted (one-time validation,
+//     wasn't maintained). Real fix is a Postgres service container in CI
+//     plus integration tests in the regular suite — separate piece of work.
+//   - src/migrator.ts — same reason as db.ts; SQL execution against a real DB.
+//   - src/migrations/ — SQL files, not TS.
 const EXCLUDE_PREFIXES = [
   'src/index.ts',
   'src/migrations/',
   'src/migrator.ts',
   'src/db.ts',
-  'src/api.ts',
   'tests/',
 ];
 

--- a/discord/src/api.ts
+++ b/discord/src/api.ts
@@ -37,23 +37,36 @@ export type SearchResponse = {
   games: GameListItem[];
 };
 
+// Optional per-call timeout in ms. Defaults to FETCH_TIMEOUT_MS (10s) which is
+// fine for poll-loop calls but too long for slash-command autocomplete, which
+// Discord deadlines at 3 seconds — overshoot and `interaction.respond` throws
+// UnknownInteraction. Autocomplete handlers pass a tighter value (~2.5s).
+export type RequestOptions = { timeoutMs?: number };
+
 export type ApiClient = {
-  getFeed(opts?: {
-    cursor?: string;
-    limit?: number;
-    sort?: 'latest' | 'trending';
-    window?: '24h' | '7d';
-  }): Promise<ClipFeedResponse>;
-  getClipsForGame(slug: string, opts?: { limit?: number }): Promise<ClipFeedResponse>;
+  getFeed(
+    opts?: {
+      cursor?: string;
+      limit?: number;
+      sort?: 'latest' | 'trending';
+      window?: '24h' | '7d';
+    } & RequestOptions,
+  ): Promise<ClipFeedResponse>;
+  getClipsForGame(
+    slug: string,
+    opts?: { limit?: number } & RequestOptions,
+  ): Promise<ClipFeedResponse>;
   search(
     q: string,
-    opts?: { type?: 'all' | 'clips' | 'games'; limit?: number },
+    opts?: { type?: 'all' | 'clips' | 'games'; limit?: number } & RequestOptions,
   ): Promise<SearchResponse>;
-  listGames(opts?: {
-    search?: string;
-    limit?: number;
-    hasClips?: boolean;
-  }): Promise<GameListItem[]>;
+  listGames(
+    opts?: {
+      search?: string;
+      limit?: number;
+      hasClips?: boolean;
+    } & RequestOptions,
+  ): Promise<GameListItem[]>;
 };
 
 // Caps any single API call. The bot's HTTP queries are small reads from the
@@ -63,8 +76,12 @@ export type ApiClient = {
 // separate from the DB statement_timeout in db.ts.
 const FETCH_TIMEOUT_MS = 10_000;
 
-export function createApi(baseUrl: string): ApiClient {
-  const get = async <T>(path: string, query?: Record<string, string | number | undefined>) => {
+export function createApi(baseUrl: string, fetchImpl: typeof fetch = fetch): ApiClient {
+  const get = async <T>(
+    path: string,
+    query?: Record<string, string | number | undefined>,
+    opts?: RequestOptions,
+  ) => {
     const url = new URL(path, ensureTrailingSlash(baseUrl));
     if (query) {
       for (const [k, v] of Object.entries(query)) {
@@ -72,17 +89,16 @@ export function createApi(baseUrl: string): ApiClient {
         url.searchParams.set(k, String(v));
       }
     }
+    const timeoutMs = opts?.timeoutMs ?? FETCH_TIMEOUT_MS;
     let res: Response;
     try {
-      res = await fetch(url, {
+      res = await fetchImpl(url, {
         headers: { accept: 'application/json' },
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        signal: AbortSignal.timeout(timeoutMs),
       });
     } catch (err) {
       if (err instanceof Error && err.name === 'TimeoutError') {
-        throw new Error(`GET ${url.pathname} timed out after ${FETCH_TIMEOUT_MS}ms`, {
-          cause: err,
-        });
+        throw new Error(`GET ${url.pathname} timed out after ${timeoutMs}ms`, { cause: err });
       }
       throw err;
     }
@@ -94,28 +110,33 @@ export function createApi(baseUrl: string): ApiClient {
 
   return {
     getFeed: (opts = {}) =>
-      get<ClipFeedResponse>('clips/feed', {
-        cursor: opts.cursor,
-        limit: opts.limit,
-        sort: opts.sort,
-        window: opts.window,
-      }),
+      get<ClipFeedResponse>(
+        'clips/feed',
+        { cursor: opts.cursor, limit: opts.limit, sort: opts.sort, window: opts.window },
+        { timeoutMs: opts.timeoutMs },
+      ),
     getClipsForGame: (slug, opts = {}) =>
-      get<ClipFeedResponse>(`games/${encodeURIComponent(slug)}/clips`, {
-        limit: opts.limit,
-      }),
+      get<ClipFeedResponse>(
+        `games/${encodeURIComponent(slug)}/clips`,
+        { limit: opts.limit },
+        { timeoutMs: opts.timeoutMs },
+      ),
     search: (q, opts = {}) =>
-      get<SearchResponse>('search', {
-        q,
-        type: opts.type ?? 'clips',
-        limit: opts.limit,
-      }),
+      get<SearchResponse>(
+        'search',
+        { q, type: opts.type ?? 'clips', limit: opts.limit },
+        { timeoutMs: opts.timeoutMs },
+      ),
     listGames: (opts = {}) =>
-      get<GameListItem[]>('games', {
-        search: opts.search,
-        limit: opts.limit,
-        hasClips: opts.hasClips ? 'true' : undefined,
-      }),
+      get<GameListItem[]>(
+        'games',
+        {
+          search: opts.search,
+          limit: opts.limit,
+          hasClips: opts.hasClips ? 'true' : undefined,
+        },
+        { timeoutMs: opts.timeoutMs },
+      ),
   };
 }
 

--- a/discord/src/api.ts
+++ b/discord/src/api.ts
@@ -1,0 +1,104 @@
+// Thin HTTP client for the GankedTV REST API. Mirrors only the read endpoints
+// the bot needs — the bot never writes through the API. Contracts mirror the
+// server-side records in server/src/GankedTV.Api/Contracts/ (camelCase per the
+// minimal-API default System.Text.Json policy).
+
+export type ClipFeedItem = {
+  id: string;
+  shareCode: string;
+  title: string;
+  description: string | null;
+  thumbnailUrl: string;
+  durationSecs: number | null;
+  viewCount: number;
+  likeCount: number;
+  createdAt: string;
+  author: { id: string; username: string; avatarUrl: string | null };
+  game: { id: number; name: string; slug: string; tag: string } | null;
+  tags: { id: string; name: string; slug: string }[];
+  likedByMe: boolean;
+};
+
+export type ClipFeedResponse = {
+  items: ClipFeedItem[];
+  nextCursor: string | null;
+};
+
+export type GameListItem = {
+  id: number;
+  name: string;
+  slug: string;
+  tag: string;
+  coverUrl: string | null;
+};
+
+export type SearchResponse = {
+  clips: ClipFeedItem[];
+  games: GameListItem[];
+};
+
+export type ApiClient = {
+  getFeed(opts?: {
+    cursor?: string;
+    limit?: number;
+    sort?: 'latest' | 'trending';
+    window?: '24h' | '7d';
+  }): Promise<ClipFeedResponse>;
+  getClipsForGame(slug: string, opts?: { limit?: number }): Promise<ClipFeedResponse>;
+  search(
+    q: string,
+    opts?: { type?: 'all' | 'clips' | 'games'; limit?: number },
+  ): Promise<SearchResponse>;
+  listGames(opts?: {
+    search?: string;
+    limit?: number;
+    hasClips?: boolean;
+  }): Promise<GameListItem[]>;
+};
+
+export function createApi(baseUrl: string): ApiClient {
+  const get = async <T>(path: string, query?: Record<string, string | number | undefined>) => {
+    const url = new URL(path, ensureTrailingSlash(baseUrl));
+    if (query) {
+      for (const [k, v] of Object.entries(query)) {
+        if (v === undefined || v === null || v === '') continue;
+        url.searchParams.set(k, String(v));
+      }
+    }
+    const res = await fetch(url, { headers: { accept: 'application/json' } });
+    if (!res.ok) {
+      throw new Error(`GET ${url.pathname} → ${res.status}`);
+    }
+    return (await res.json()) as T;
+  };
+
+  return {
+    getFeed: (opts = {}) =>
+      get<ClipFeedResponse>('clips/feed', {
+        cursor: opts.cursor,
+        limit: opts.limit,
+        sort: opts.sort,
+        window: opts.window,
+      }),
+    getClipsForGame: (slug, opts = {}) =>
+      get<ClipFeedResponse>(`games/${encodeURIComponent(slug)}/clips`, {
+        limit: opts.limit,
+      }),
+    search: (q, opts = {}) =>
+      get<SearchResponse>('search', {
+        q,
+        type: opts.type ?? 'clips',
+        limit: opts.limit,
+      }),
+    listGames: (opts = {}) =>
+      get<GameListItem[]>('games', {
+        search: opts.search,
+        limit: opts.limit,
+        hasClips: opts.hasClips ? 'true' : undefined,
+      }),
+  };
+}
+
+function ensureTrailingSlash(s: string): string {
+  return s.endsWith('/') ? s : s + '/';
+}

--- a/discord/src/api.ts
+++ b/discord/src/api.ts
@@ -56,6 +56,13 @@ export type ApiClient = {
   }): Promise<GameListItem[]>;
 };
 
+// Caps any single API call. The bot's HTTP queries are small reads from the
+// local-network GankedTV API, so 10s is generous — anything slower is either
+// a deadlock or a stalled connection and should fail loudly rather than block
+// the poller (which would chain into overlapping ticks). Pure HTTP timeout;
+// separate from the DB statement_timeout in db.ts.
+const FETCH_TIMEOUT_MS = 10_000;
+
 export function createApi(baseUrl: string): ApiClient {
   const get = async <T>(path: string, query?: Record<string, string | number | undefined>) => {
     const url = new URL(path, ensureTrailingSlash(baseUrl));
@@ -65,7 +72,20 @@ export function createApi(baseUrl: string): ApiClient {
         url.searchParams.set(k, String(v));
       }
     }
-    const res = await fetch(url, { headers: { accept: 'application/json' } });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers: { accept: 'application/json' },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'TimeoutError') {
+        throw new Error(`GET ${url.pathname} timed out after ${FETCH_TIMEOUT_MS}ms`, {
+          cause: err,
+        });
+      }
+      throw err;
+    }
     if (!res.ok) {
       throw new Error(`GET ${url.pathname} → ${res.status}`);
     }

--- a/discord/src/commands/clip.ts
+++ b/discord/src/commands/clip.ts
@@ -1,0 +1,134 @@
+import {
+  MessageFlags,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  type AutocompleteInteraction,
+} from 'discord.js';
+import type { Command, CommandContext } from './index.ts';
+import { shareUrl } from '../lib/shareUrl.ts';
+
+const data = new SlashCommandBuilder()
+  .setName('clip')
+  .setDescription('Pull GankedTV clips on demand.')
+  .addSubcommand((s) =>
+    s
+      .setName('latest')
+      .setDescription('Post the latest public clip.')
+      .addStringOption((o) =>
+        o
+          .setName('game')
+          .setDescription('Restrict to a specific game (slug).')
+          .setAutocomplete(true)
+          .setRequired(false),
+      ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('top')
+      .setDescription('Post the top trending clip.')
+      .addStringOption((o) =>
+        o
+          .setName('window')
+          .setDescription('Trending window.')
+          .addChoices({ name: 'Last 24 hours', value: '24h' }, { name: 'Last 7 days', value: '7d' })
+          .setRequired(false),
+      ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('search')
+      .setDescription('Search clips by keyword and post the top match.')
+      .addStringOption((o) => o.setName('query').setDescription('Search terms.').setRequired(true)),
+  );
+
+const ephemeral = (content: string) => ({
+  content,
+  flags: MessageFlags.Ephemeral as MessageFlags.Ephemeral,
+});
+
+async function execute(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  switch (sub) {
+    case 'latest':
+      return handleLatest(interaction, ctx);
+    case 'top':
+      return handleTop(interaction, ctx);
+    case 'search':
+      return handleSearch(interaction, ctx);
+    default:
+      await interaction.reply(ephemeral('Unknown subcommand.'));
+  }
+}
+
+async function handleLatest(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  await interaction.deferReply();
+  const gameSlug = interaction.options.getString('game');
+
+  const page = gameSlug
+    ? await ctx.api.getClipsForGame(gameSlug, { limit: 1 })
+    : await ctx.api.getFeed({ limit: 1 });
+
+  const clip = page.items[0];
+  if (!clip) {
+    await interaction.editReply(
+      gameSlug ? `No clips found for **${gameSlug}**.` : 'No clips found.',
+    );
+    return;
+  }
+  await interaction.editReply(shareUrl(clip.shareCode, ctx.publicBase));
+}
+
+async function handleTop(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  await interaction.deferReply();
+  const window = (interaction.options.getString('window') ?? '24h') as '24h' | '7d';
+  const page = await ctx.api.getFeed({ sort: 'trending', window, limit: 1 });
+  const clip = page.items[0];
+  if (!clip) {
+    await interaction.editReply(`No trending clips in the last ${window}.`);
+    return;
+  }
+  await interaction.editReply(shareUrl(clip.shareCode, ctx.publicBase));
+}
+
+async function handleSearch(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  await interaction.deferReply();
+  const query = interaction.options.getString('query', true);
+  const res = await ctx.api.search(query, { type: 'clips', limit: 1 });
+  const clip = res.clips[0];
+  if (!clip) {
+    await interaction.editReply(`No clips matched "${query}".`);
+    return;
+  }
+  await interaction.editReply(shareUrl(clip.shareCode, ctx.publicBase));
+}
+
+async function autocomplete(
+  interaction: AutocompleteInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== 'game') return;
+  const query = focused.value?.toString() ?? '';
+  // Autocomplete sends slugs (matching what /games/{slug}/clips expects) so the
+  // returned value can flow straight back into the API call.
+  const games = await ctx.api.listGames({
+    search: query.length > 0 ? query : undefined,
+    limit: 25,
+    hasClips: true,
+  });
+  await interaction.respond(games.slice(0, 25).map((g) => ({ name: g.name, value: g.slug })));
+}
+
+export const command: Command = { data, execute, autocomplete };

--- a/discord/src/commands/clip.ts
+++ b/discord/src/commands/clip.ts
@@ -1,10 +1,10 @@
 import {
-  MessageFlags,
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
   type AutocompleteInteraction,
 } from 'discord.js';
 import type { Command, CommandContext } from './index.ts';
+import { ephemeral } from './replies.ts';
 import { shareUrl } from '../lib/shareUrl.ts';
 
 const data = new SlashCommandBuilder()
@@ -40,11 +40,6 @@ const data = new SlashCommandBuilder()
       .setDescription('Search clips by keyword and post the top match.')
       .addStringOption((o) => o.setName('query').setDescription('Search terms.').setRequired(true)),
   );
-
-const ephemeral = (content: string) => ({
-  content,
-  flags: MessageFlags.Ephemeral as MessageFlags.Ephemeral,
-});
 
 async function execute(
   interaction: ChatInputCommandInteraction,

--- a/discord/src/commands/clip.ts
+++ b/discord/src/commands/clip.ts
@@ -117,12 +117,20 @@ async function autocomplete(
   if (focused.name !== 'game') return;
   const query = focused.value?.toString() ?? '';
   // Autocomplete sends slugs (matching what /games/{slug}/clips expects) so the
-  // returned value can flow straight back into the API call.
-  const games = await ctx.api.listGames({
-    search: query.length > 0 ? query : undefined,
-    limit: 25,
-    hasClips: true,
-  });
+  // returned value can flow straight back into the API call. Tighter timeout
+  // than the default 10s because Discord deadlines autocomplete at 3s — if the
+  // games API is slow we'd rather respond with [] than throw UnknownInteraction.
+  let games: { name: string; slug: string }[];
+  try {
+    games = await ctx.api.listGames({
+      search: query.length > 0 ? query : undefined,
+      limit: 25,
+      hasClips: true,
+      timeoutMs: 2500,
+    });
+  } catch {
+    games = [];
+  }
   await interaction.respond(games.slice(0, 25).map((g) => ({ name: g.name, value: g.slug })));
 }
 

--- a/discord/src/commands/gankedtv.ts
+++ b/discord/src/commands/gankedtv.ts
@@ -5,6 +5,7 @@ import {
   type ChatInputCommandInteraction,
 } from 'discord.js';
 import type { Command, CommandContext } from './index.ts';
+import { ephemeral } from './replies.ts';
 import { requireManageChannels } from '../lib/permissions.ts';
 import type { Subscription } from '../db.ts';
 
@@ -65,11 +66,6 @@ const data = new SlashCommandBuilder()
   .addSubcommand((s) =>
     s.setName('resume').setDescription('Resume paused subscriptions in this channel.'),
   );
-
-const ephemeral = (content: string) => ({
-  content,
-  flags: MessageFlags.Ephemeral as MessageFlags.Ephemeral,
-});
 
 async function execute(
   interaction: ChatInputCommandInteraction,

--- a/discord/src/commands/gankedtv.ts
+++ b/discord/src/commands/gankedtv.ts
@@ -306,11 +306,19 @@ async function autocomplete(
   // than nothing. Non-empty: case-insensitive substring search via the games API.
   // Returns slug values (matching /clip autocomplete) so resolveGameId can take
   // an exact-slug shortcut over the noisier name search.
-  const games = await ctx.api.listGames({
-    search: query.length > 0 ? query : undefined,
-    limit: 25,
-    hasClips: true,
-  });
+  // Tight 2.5s timeout: Discord deadlines autocomplete at 3s — a slow games
+  // API would otherwise leave the interaction token expired (UnknownInteraction).
+  let games: { name: string; slug: string }[];
+  try {
+    games = await ctx.api.listGames({
+      search: query.length > 0 ? query : undefined,
+      limit: 25,
+      hasClips: true,
+      timeoutMs: 2500,
+    });
+  } catch {
+    games = [];
+  }
   await interaction.respond(games.slice(0, 25).map((g) => ({ name: g.name, value: g.slug })));
 }
 

--- a/discord/src/commands/gankedtv.ts
+++ b/discord/src/commands/gankedtv.ts
@@ -35,7 +35,7 @@ const data = new SlashCommandBuilder()
   .addSubcommand((s) =>
     s
       .setName('unsubscribe')
-      .setDescription('Remove a subscription from this channel.')
+      .setDescription('Remove a subscription from this channel. Pass all:true to wipe everything.')
       .addStringOption((o) =>
         o
           .setName('game')
@@ -47,6 +47,12 @@ const data = new SlashCommandBuilder()
         o
           .setName('creator')
           .setDescription('Creator filter of the subscription to remove (uuid).')
+          .setRequired(false),
+      )
+      .addBooleanOption((o) =>
+        o
+          .setName('all')
+          .setDescription('Remove EVERY subscription in this channel. Cannot combine with filters.')
           .setRequired(false),
       ),
   )
@@ -182,6 +188,29 @@ async function handleUnsubscribe(
 
   const gameRaw = interaction.options.getString('game');
   const creatorRaw = interaction.options.getString('creator');
+  const all = interaction.options.getBoolean('all') ?? false;
+
+  // Reject ambiguous input rather than silently dropping the filters — a user
+  // who passed both clearly meant one of them and shouldn't get a wipe by
+  // accident.
+  if (all && (gameRaw !== null || creatorRaw !== null)) {
+    await interaction.editReply(
+      'Cannot combine `all:true` with `game`/`creator` filters. Use one or the other.',
+    );
+    return;
+  }
+
+  if (all) {
+    const removed = await ctx.db.removeAllSubscriptionsForChannel(interaction.channelId);
+    if (removed === 0) {
+      await interaction.editReply('No subscriptions in this channel.');
+      return;
+    }
+    await interaction.editReply(
+      `Removed all ${removed} subscription${removed === 1 ? '' : 's'} in this channel.`,
+    );
+    return;
+  }
 
   const { gameId, error: gameErr } = await resolveGameId(ctx, gameRaw);
   if (gameErr) {
@@ -213,20 +242,43 @@ async function handleList(
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
   const subs = await ctx.db.listSubscriptionsForChannel(interaction.channelId);
   if (subs.length === 0) {
-    await interaction.editReply('No subscriptions in this channel.');
+    await interaction.editReply(
+      'No subscriptions in this channel. Use `/gankedtv subscribe` to add one.',
+    );
     return;
   }
-  const lines = subs.map(formatSubscription);
-  await interaction.editReply(`**Subscriptions in this channel:**\n${lines.join('\n')}`);
+
+  // Single batched lookup so we can show names/slugs instead of raw numeric
+  // ids — formatSubscription falls back to the id when a game isn't in the
+  // cache (covers catalogs > listGames's 50-item cap).
+  const games = await ctx.api.listGames({ limit: 50 });
+  const byId = new Map(games.map((g) => [g.id, g] as const));
+
+  const lines = subs.map((s, i) => formatSubscription(s, i + 1, byId));
+  const count = subs.length === 1 ? '1 subscription' : `${subs.length} subscriptions`;
+  await interaction.editReply(
+    `**${count} in this channel:**\n${lines.join('\n')}\n\n` +
+      '_Remove with `/gankedtv unsubscribe game:<slug>` (or `/gankedtv unsubscribe all:true` to wipe all)._',
+  );
 }
 
-function formatSubscription(sub: Subscription): string {
+function formatSubscription(
+  sub: Subscription,
+  index: number,
+  byId: Map<number, { name: string; slug: string }>,
+): string {
   const parts: string[] = [];
-  parts.push(sub.gameId !== null ? `game=${sub.gameId}` : 'game=any');
-  parts.push(sub.creatorId !== null ? `creator=${sub.creatorId}` : 'creator=any');
-  if (sub.pingRoleId) parts.push(`ping=<@&${sub.pingRoleId}>`);
+  if (sub.gameId !== null) {
+    const g = byId.get(sub.gameId);
+    parts.push(g ? `game **${g.name}** (\`${g.slug}\`)` : `game id \`${sub.gameId}\``);
+  }
+  if (sub.creatorId !== null) parts.push(`creator \`${sub.creatorId}\``);
+  if (sub.pingRoleId) parts.push(`ping <@&${sub.pingRoleId}>`);
   if (sub.paused) parts.push('**paused**');
-  return `• ${parts.join(' · ')}`;
+  // If no filters were set this is the firehose — say so explicitly rather
+  // than printing an empty bullet.
+  const body = parts.length ? parts.join(' · ') : '_all clips_';
+  return `${index}. ${body}`;
 }
 
 async function handlePauseToggle(

--- a/discord/src/commands/gankedtv.ts
+++ b/discord/src/commands/gankedtv.ts
@@ -1,0 +1,269 @@
+import {
+  MessageFlags,
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type ChatInputCommandInteraction,
+} from 'discord.js';
+import type { Command, CommandContext } from './index.ts';
+import { requireManageChannels } from '../lib/permissions.ts';
+import type { Subscription } from '../db.ts';
+
+const data = new SlashCommandBuilder()
+  .setName('gankedtv')
+  .setDescription('Manage clip subscriptions for this channel.')
+  .addSubcommand((s) =>
+    s
+      .setName('subscribe')
+      .setDescription('Subscribe this channel to new GankedTV clips.')
+      .addStringOption((o) =>
+        o
+          .setName('game')
+          .setDescription('Only post clips for this game.')
+          .setAutocomplete(true)
+          .setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('creator')
+          .setDescription('Only post clips from this creator (uuid).')
+          .setRequired(false),
+      )
+      .addRoleOption((o) =>
+        o.setName('ping_role').setDescription('Role to ping on each post.').setRequired(false),
+      ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('unsubscribe')
+      .setDescription('Remove a subscription from this channel.')
+      .addStringOption((o) =>
+        o
+          .setName('game')
+          .setDescription('Game filter of the subscription to remove.')
+          .setAutocomplete(true)
+          .setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('creator')
+          .setDescription('Creator filter of the subscription to remove (uuid).')
+          .setRequired(false),
+      ),
+  )
+  .addSubcommand((s) =>
+    s.setName('subscriptions').setDescription('List subscriptions for this channel.'),
+  )
+  .addSubcommand((s) =>
+    s.setName('pause').setDescription('Pause all subscriptions in this channel.'),
+  )
+  .addSubcommand((s) =>
+    s.setName('resume').setDescription('Resume paused subscriptions in this channel.'),
+  );
+
+const ephemeral = (content: string) => ({
+  content,
+  flags: MessageFlags.Ephemeral as MessageFlags.Ephemeral,
+});
+
+async function execute(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  if (!interaction.inGuild()) {
+    await interaction.reply(ephemeral('This command only works inside a server.'));
+    return;
+  }
+  const sub = interaction.options.getSubcommand();
+
+  // Read-only subcommands stay open to all members; mutations gate on ManageChannels
+  // so random members can't reconfigure the bot.
+  const isMutation =
+    sub === 'subscribe' || sub === 'unsubscribe' || sub === 'pause' || sub === 'resume';
+  if (isMutation && !requireManageChannels(interaction)) {
+    await interaction.reply(ephemeral('You need the **Manage Channels** permission to do that.'));
+    return;
+  }
+
+  switch (sub) {
+    case 'subscribe':
+      return handleSubscribe(interaction, ctx);
+    case 'unsubscribe':
+      return handleUnsubscribe(interaction, ctx);
+    case 'subscriptions':
+      return handleList(interaction, ctx);
+    case 'pause':
+      return handlePauseToggle(interaction, ctx, true);
+    case 'resume':
+      return handlePauseToggle(interaction, ctx, false);
+    default:
+      await interaction.reply(ephemeral('Unknown subcommand.'));
+  }
+}
+
+// UUID v4-ish: 8-4-4-4-12 hex with dashes. Used to validate `creator` filter
+// input before it hits the UUID column (otherwise Postgres throws a type error
+// that surfaces to the user as a generic "Something went wrong").
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function resolveGameId(
+  ctx: CommandContext,
+  raw: string | null,
+): Promise<{ gameId: number | null; gameName: string | null; error: string | null }> {
+  if (!raw) return { gameId: null, gameName: null, error: null };
+  // The autocomplete handler returns `value: g.slug`, so the happy path here
+  // is a slug match. Manual typing falls back to a name search.
+  const matches = await ctx.api.listGames({ search: raw, limit: 25 });
+  if (matches.length === 0)
+    return { gameId: null, gameName: null, error: `No game matched "${raw}".` };
+  // Prefer an exact slug hit (autocomplete-supplied) over the top name match,
+  // so picking a less-popular autocomplete suggestion doesn't get overridden
+  // by a more popular substring match.
+  const exact = matches.find((g) => g.slug === raw);
+  const chosen = exact ?? matches[0]!;
+  return { gameId: chosen.id, gameName: chosen.name, error: null };
+}
+
+function validateCreator(raw: string | null): { creatorId: string | null; error: string | null } {
+  if (!raw) return { creatorId: null, error: null };
+  if (!UUID_RE.test(raw))
+    return { creatorId: null, error: `Creator must be a UUID, got "${raw}".` };
+  return { creatorId: raw.toLowerCase(), error: null };
+}
+
+async function handleSubscribe(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const gameRaw = interaction.options.getString('game');
+  const creatorRaw = interaction.options.getString('creator');
+  const pingRole = interaction.options.getRole('ping_role');
+
+  const { gameId, gameName, error: gameErr } = await resolveGameId(ctx, gameRaw);
+  if (gameErr) {
+    await interaction.editReply(gameErr);
+    return;
+  }
+  const { creatorId, error: creatorErr } = validateCreator(creatorRaw);
+  if (creatorErr) {
+    await interaction.editReply(creatorErr);
+    return;
+  }
+
+  const result = await ctx.db.addSubscription({
+    guildId: interaction.guildId!,
+    channelId: interaction.channelId,
+    gameId,
+    creatorId,
+    pingRoleId: pingRole?.id ?? null,
+    createdBy: interaction.user.id,
+  });
+
+  if (result === null) {
+    await interaction.editReply('This channel is already subscribed with those filters.');
+    return;
+  }
+
+  const filterParts: string[] = [];
+  if (gameName) filterParts.push(`game **${gameName}**`);
+  if (creatorId) filterParts.push(`creator \`${creatorId}\``);
+  const filterDesc = filterParts.length
+    ? ` filtered by ${filterParts.join(' + ')}`
+    : ' (all clips)';
+  await interaction.editReply(`Subscribed${filterDesc}. New clips will post here.`);
+}
+
+async function handleUnsubscribe(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const gameRaw = interaction.options.getString('game');
+  const creatorRaw = interaction.options.getString('creator');
+
+  const { gameId, error: gameErr } = await resolveGameId(ctx, gameRaw);
+  if (gameErr) {
+    await interaction.editReply(gameErr);
+    return;
+  }
+  const { creatorId, error: creatorErr } = validateCreator(creatorRaw);
+  if (creatorErr) {
+    await interaction.editReply(creatorErr);
+    return;
+  }
+
+  const removed = await ctx.db.removeSubscription({
+    channelId: interaction.channelId,
+    gameId,
+    creatorId,
+  });
+  if (removed === 0) {
+    await interaction.editReply('No matching subscription found.');
+    return;
+  }
+  await interaction.editReply(`Removed ${removed} subscription${removed === 1 ? '' : 's'}.`);
+}
+
+async function handleList(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  const subs = await ctx.db.listSubscriptionsForChannel(interaction.channelId);
+  if (subs.length === 0) {
+    await interaction.editReply('No subscriptions in this channel.');
+    return;
+  }
+  const lines = subs.map(formatSubscription);
+  await interaction.editReply(`**Subscriptions in this channel:**\n${lines.join('\n')}`);
+}
+
+function formatSubscription(sub: Subscription): string {
+  const parts: string[] = [];
+  parts.push(sub.gameId !== null ? `game=${sub.gameId}` : 'game=any');
+  parts.push(sub.creatorId !== null ? `creator=${sub.creatorId}` : 'creator=any');
+  if (sub.pingRoleId) parts.push(`ping=<@&${sub.pingRoleId}>`);
+  if (sub.paused) parts.push('**paused**');
+  return `• ${parts.join(' · ')}`;
+}
+
+async function handlePauseToggle(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+  paused: boolean,
+): Promise<void> {
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  const changed = await ctx.db.setPaused(interaction.channelId, paused);
+  if (changed === 0) {
+    await interaction.editReply('No subscriptions in this channel.');
+    return;
+  }
+  await interaction.editReply(
+    paused
+      ? `Paused ${changed} subscription${changed === 1 ? '' : 's'}.`
+      : `Resumed ${changed} subscription${changed === 1 ? '' : 's'}.`,
+  );
+}
+
+async function autocomplete(
+  interaction: AutocompleteInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== 'game') return;
+  const query = focused.value?.toString() ?? '';
+  // Empty input: show first 25 games-with-clips so users see *something* rather
+  // than nothing. Non-empty: case-insensitive substring search via the games API.
+  // Returns slug values (matching /clip autocomplete) so resolveGameId can take
+  // an exact-slug shortcut over the noisier name search.
+  const games = await ctx.api.listGames({
+    search: query.length > 0 ? query : undefined,
+    limit: 25,
+    hasClips: true,
+  });
+  await interaction.respond(games.slice(0, 25).map((g) => ({ name: g.name, value: g.slug })));
+}
+
+export const command: Command = { data, execute, autocomplete };

--- a/discord/src/commands/index.ts
+++ b/discord/src/commands/index.ts
@@ -1,13 +1,13 @@
-import {
-  MessageFlags,
-  type AutocompleteInteraction,
-  type ChatInputCommandInteraction,
-  type RESTPostAPIChatInputApplicationCommandsJSONBody,
+import type {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord.js';
 import type { ApiClient } from '../api.ts';
 import type { Db } from '../db.ts';
 import * as gankedtv from './gankedtv.ts';
 import * as clipCommand from './clip.ts';
+import { ephemeral } from './replies.ts';
 
 export type CommandContext = {
   db: Db;
@@ -44,7 +44,7 @@ export async function dispatchChatInput(
 ): Promise<void> {
   const cmd = commands[interaction.commandName];
   if (!cmd) {
-    await interaction.reply({ content: 'Unknown command.', flags: MessageFlags.Ephemeral });
+    await interaction.reply(ephemeral('Unknown command.'));
     return;
   }
   await cmd.execute(interaction, ctx);

--- a/discord/src/commands/index.ts
+++ b/discord/src/commands/index.ts
@@ -1,0 +1,60 @@
+import {
+  MessageFlags,
+  type AutocompleteInteraction,
+  type ChatInputCommandInteraction,
+  type RESTPostAPIChatInputApplicationCommandsJSONBody,
+} from 'discord.js';
+import type { ApiClient } from '../api.ts';
+import type { Db } from '../db.ts';
+import * as gankedtv from './gankedtv.ts';
+import * as clipCommand from './clip.ts';
+
+export type CommandContext = {
+  db: Db;
+  api: ApiClient;
+  publicBase: string;
+};
+
+// SlashCommandBuilder + .addSubcommand() chains narrow to SlashCommandSubcommandsOnlyBuilder.
+// The only thing the registry actually needs is name + toJSON(), so we type the
+// data field by structural shape instead of binding to any one builder subtype.
+export type CommandData = {
+  readonly name: string;
+  toJSON(): RESTPostAPIChatInputApplicationCommandsJSONBody;
+};
+
+export type Command = {
+  data: CommandData;
+  execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void>;
+  autocomplete?(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void>;
+};
+
+export const commands: Record<string, Command> = {
+  gankedtv: gankedtv.command,
+  clip: clipCommand.command,
+};
+
+export function commandDefinitions(): RESTPostAPIChatInputApplicationCommandsJSONBody[] {
+  return Object.values(commands).map((c) => c.data.toJSON());
+}
+
+export async function dispatchChatInput(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  const cmd = commands[interaction.commandName];
+  if (!cmd) {
+    await interaction.reply({ content: 'Unknown command.', flags: MessageFlags.Ephemeral });
+    return;
+  }
+  await cmd.execute(interaction, ctx);
+}
+
+export async function dispatchAutocomplete(
+  interaction: AutocompleteInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  const cmd = commands[interaction.commandName];
+  if (!cmd?.autocomplete) return;
+  await cmd.autocomplete(interaction, ctx);
+}

--- a/discord/src/commands/replies.ts
+++ b/discord/src/commands/replies.ts
@@ -1,0 +1,11 @@
+import { MessageFlags } from 'discord.js';
+
+// Shared shape for ephemeral interaction replies. Centralised so the
+// `MessageFlags.Ephemeral as MessageFlags.Ephemeral` literal-widening cast
+// (a TS narrowing quirk — see commands/gankedtv.ts history) lives in exactly
+// one place, and so adding a new ephemeral reply elsewhere doesn't drift the
+// flag set out of sync.
+export const ephemeral = (content: string) => ({
+  content,
+  flags: MessageFlags.Ephemeral as MessageFlags.Ephemeral,
+});

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const Schema = z.object({
+  DISCORD_BOT_TOKEN: z.string().min(1).optional(),
+  DISCORD_BOT_APP_ID: z.string().min(1).optional(),
+  DISCORD_BOT_GUILD_ID: z.string().min(1).optional(),
+  DISCORD_POLL_INTERVAL_SECONDS: z.coerce.number().int().positive().default(30),
+  // Distinct from the API's DATABASE_URL because the API stores its connection
+  // string in dotnet semicolon form (Host=...;Port=...;...) which porsager's
+  // `postgres` driver can't parse — we need a libpq URL (postgres://...).
+  // Worktrees populate both: dotnet form in DATABASE_URL for the API, libpq form
+  // here for the bot. See scripts/new-worktree.sh.
+  DISCORD_DATABASE_URL: z.string().min(1),
+  GANKEDTV_API_BASE: z.string().url().default('http://localhost:5050'),
+  GANKEDTV_PUBLIC_BASE: z.string().url().default('http://localhost:5173'),
+});
+
+export type Config = z.infer<typeof Schema> & { enabled: boolean };
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const parsed = Schema.parse(env);
+  // Symmetric with IgdbSyncHostedService: presence of the token is the on-switch.
+  // Without it, boot logs "disabled" and exits — the compose service still starts,
+  // it just no-ops. App ID is required alongside the token because slash command
+  // registration uses the REST API and addresses commands by application id.
+  const enabled = Boolean(parsed.DISCORD_BOT_TOKEN && parsed.DISCORD_BOT_APP_ID);
+  return { ...parsed, enabled };
+}

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -29,6 +29,24 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   // Without it, boot logs "disabled" and exits — the compose service still starts,
   // it just no-ops. App ID is required alongside the token because slash command
   // registration uses the REST API and addresses commands by application id.
-  const enabled = Boolean(parsed.DISCORD_BOT_TOKEN && parsed.DISCORD_BOT_APP_ID);
+  const hasToken = Boolean(parsed.DISCORD_BOT_TOKEN);
+  const hasAppId = Boolean(parsed.DISCORD_BOT_APP_ID);
+
+  // Operator misconfiguration guard: if one half of the credential pair is set
+  // but the other isn't, the bot would silently disable with no visible signal
+  // that something was forgotten. Log a single warn line so it appears in any
+  // structured-log search before the disable message.
+  if (hasToken !== hasAppId) {
+    console.warn(
+      JSON.stringify({
+        level: 'warn',
+        msg: 'Discord bot config is partial — both DISCORD_BOT_TOKEN and DISCORD_BOT_APP_ID are required; bot will stay disabled',
+        hasToken,
+        hasAppId,
+      }),
+    );
+  }
+
+  const enabled = hasToken && hasAppId;
   return { ...parsed, enabled };
 }

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod';
 
 const Schema = z.object({
-  DISCORD_BOT_TOKEN: z.string().min(1).optional(),
-  DISCORD_BOT_APP_ID: z.string().min(1).optional(),
-  DISCORD_BOT_GUILD_ID: z.string().min(1).optional(),
+  // No .min(1) on the bot-credential triple: shell envs and root .env both
+  // represent "unset" as the empty string ("DISCORD_BOT_TOKEN=" with nothing
+  // after the equals). Rejecting empty strings would force users to delete
+  // the env var entirely just to get the "disabled" boot path — that breaks
+  // the contract from .env.example which ships these as empty placeholders.
+  // The `enabled` check below uses Boolean() which already treats "" as false.
+  DISCORD_BOT_TOKEN: z.string().optional(),
+  DISCORD_BOT_APP_ID: z.string().optional(),
+  DISCORD_BOT_GUILD_ID: z.string().optional(),
   DISCORD_POLL_INTERVAL_SECONDS: z.coerce.number().int().positive().default(30),
   // Distinct from the API's DATABASE_URL because the API stores its connection
   // string in dotnet semicolon form (Host=...;Port=...;...) which porsager's

--- a/discord/src/db.ts
+++ b/discord/src/db.ts
@@ -33,6 +33,7 @@ export type Db = {
   close(): Promise<void>;
   addSubscription(input: CreateSubscriptionInput): Promise<Subscription | null>;
   removeSubscription(input: RemoveSubscriptionInput): Promise<number>;
+  removeAllSubscriptionsForChannel(channelId: string): Promise<number>;
   listSubscriptionsForChannel(channelId: string): Promise<Subscription[]>;
   listAllSubscriptions(): Promise<Subscription[]>;
   setPaused(channelId: string, paused: boolean): Promise<number>;
@@ -77,6 +78,18 @@ export function createDb(sql: Sql): Db {
         WHERE channel_id = ${input.channelId}
           AND game_id IS NOT DISTINCT FROM ${input.gameId}::int
           AND creator_id IS NOT DISTINCT FROM ${input.creatorId}::uuid
+        RETURNING id
+      `;
+      return rows.length;
+    },
+
+    async removeAllSubscriptionsForChannel(channelId) {
+      // Unconditional channel-scoped delete. Callers (the /gankedtv unsubscribe
+      // all:true path) are responsible for confirming user intent — this method
+      // makes no judgements.
+      const rows = await sql`
+        DELETE FROM discord_subscriptions
+        WHERE channel_id = ${channelId}
         RETURNING id
       `;
       return rows.length;

--- a/discord/src/db.ts
+++ b/discord/src/db.ts
@@ -169,6 +169,10 @@ export function connect(url: string): Sql {
     // row. `undefined: null` coerces JS `undefined` parameter values to SQL
     // NULL (porsager/postgres throws by default — the coercion saves us from
     // sprinkling `?? null` at every nullable boundary).
+    //
+    // Gotcha: this transform is GLOBAL — it applies to system catalog queries
+    // too. If we ever SELECT from information_schema or pg_catalog, read the
+    // camelCased keys on the JS side (`tableName`, not `table_name`).
     transform: { ...postgres.camel, undefined: null },
     // Server-side safety timeouts. The bot's queries are all small lookups
     // and upserts, so anything slower than 30s is a sign of trouble (lock

--- a/discord/src/db.ts
+++ b/discord/src/db.ts
@@ -1,0 +1,182 @@
+import postgres from 'postgres';
+import type { Sql } from 'postgres';
+
+export type Subscription = {
+  id: string;
+  guildId: string;
+  channelId: string;
+  gameId: number | null;
+  creatorId: string | null;
+  paused: boolean;
+  pingRoleId: string | null;
+  createdAt: Date;
+  createdBy: string;
+};
+
+export type CreateSubscriptionInput = {
+  guildId: string;
+  channelId: string;
+  gameId: number | null;
+  creatorId: string | null;
+  pingRoleId: string | null;
+  createdBy: string;
+};
+
+export type RemoveSubscriptionInput = {
+  channelId: string;
+  gameId: number | null;
+  creatorId: string | null;
+};
+
+export type Db = {
+  sql: Sql;
+  close(): Promise<void>;
+  addSubscription(input: CreateSubscriptionInput): Promise<Subscription | null>;
+  removeSubscription(input: RemoveSubscriptionInput): Promise<number>;
+  listSubscriptionsForChannel(channelId: string): Promise<Subscription[]>;
+  listAllSubscriptions(): Promise<Subscription[]>;
+  setPaused(channelId: string, paused: boolean): Promise<number>;
+  isPosted(channelId: string, clipId: string): Promise<boolean>;
+  recordPost(channelId: string, clipId: string): Promise<void>;
+  getState(key: string): Promise<string | null>;
+  setState(key: string, value: string): Promise<void>;
+};
+
+export function createDb(sql: Sql): Db {
+  return {
+    sql,
+
+    async close() {
+      await sql.end({ timeout: 5 });
+    },
+
+    async addSubscription(input) {
+      // ON CONFLICT DO NOTHING + RETURNING gives us "inserted or already exists"
+      // in one round-trip; null return == "already subscribed with these filters".
+      // The UNIQUE constraint uses NULLS NOT DISTINCT (see migration), so an
+      // all-null firehose subscription correctly collides with itself.
+      const rows = await sql<Subscription[]>`
+        INSERT INTO discord_subscriptions
+          (guild_id, channel_id, game_id, creator_id, ping_role_id, created_by)
+        VALUES
+          (${input.guildId}, ${input.channelId}, ${input.gameId},
+           ${input.creatorId}, ${input.pingRoleId}, ${input.createdBy})
+        ON CONFLICT (channel_id, game_id, creator_id) DO NOTHING
+        RETURNING id, guild_id, channel_id, game_id, creator_id,
+                  paused, ping_role_id, created_at, created_by
+      `;
+      return rows[0] ?? null;
+    },
+
+    async removeSubscription(input) {
+      // IS NOT DISTINCT FROM is the Postgres-idiomatic NULL-safe equality:
+      // NULL "equals" NULL and otherwise behaves like =. Replaces the
+      // verbose (X IS NULL AND col IS NULL) OR (col = X) pattern.
+      const rows = await sql`
+        DELETE FROM discord_subscriptions
+        WHERE channel_id = ${input.channelId}
+          AND game_id IS NOT DISTINCT FROM ${input.gameId}::int
+          AND creator_id IS NOT DISTINCT FROM ${input.creatorId}::uuid
+        RETURNING id
+      `;
+      return rows.length;
+    },
+
+    async listSubscriptionsForChannel(channelId) {
+      return sql<Subscription[]>`
+        SELECT id, guild_id, channel_id, game_id, creator_id,
+               paused, ping_role_id, created_at, created_by
+        FROM discord_subscriptions
+        WHERE channel_id = ${channelId}
+        ORDER BY created_at ASC
+      `;
+    },
+
+    async listAllSubscriptions() {
+      return sql<Subscription[]>`
+        SELECT id, guild_id, channel_id, game_id, creator_id,
+               paused, ping_role_id, created_at, created_by
+        FROM discord_subscriptions
+        WHERE paused = false
+        ORDER BY created_at ASC
+      `;
+    },
+
+    async setPaused(channelId, paused) {
+      const rows = await sql`
+        UPDATE discord_subscriptions
+        SET paused = ${paused}
+        WHERE channel_id = ${channelId}
+        RETURNING id
+      `;
+      return rows.length;
+    },
+
+    async isPosted(channelId, clipId) {
+      // Read-only check used by the poller BEFORE sending, so we can skip
+      // clips we've already posted (idempotent on restart with un-advanced
+      // cursor, or with the tied-timestamp boundary case).
+      const rows = await sql<{ exists: boolean }[]>`
+        SELECT EXISTS (
+          SELECT 1 FROM discord_post_log
+          WHERE channel_id = ${channelId} AND clip_id = ${clipId}
+        ) AS exists
+      `;
+      return rows[0]?.exists ?? false;
+    },
+
+    async recordPost(channelId, clipId) {
+      // Called AFTER a successful send. ON CONFLICT DO NOTHING because a race
+      // (or restart) could repeat the insert — accepting at-least-once delivery
+      // is the correct tradeoff (exactly-once would require a 2PC between
+      // Discord and Postgres, which doesn't exist).
+      await sql`
+        INSERT INTO discord_post_log (channel_id, clip_id)
+        VALUES (${channelId}, ${clipId})
+        ON CONFLICT DO NOTHING
+      `;
+    },
+
+    async getState(key) {
+      const rows = await sql<{ value: string }[]>`
+        SELECT value FROM discord_bot_state WHERE key = ${key}
+      `;
+      return rows[0]?.value ?? null;
+    },
+
+    async setState(key, value) {
+      // updated_at omitted from the INSERT path so the column DEFAULT fires;
+      // the UPDATE path sets it explicitly because DEFAULT doesn't trigger on
+      // UPDATE. ON CONFLICT (key) targets the primary-key constraint.
+      await sql`
+        INSERT INTO discord_bot_state (key, value)
+        VALUES (${key}, ${value})
+        ON CONFLICT (key) DO UPDATE
+          SET value = EXCLUDED.value, updated_at = now()
+      `;
+    },
+  };
+}
+
+export function connect(url: string): Sql {
+  return postgres(url, {
+    // Mute server-side NOTICE messages (e.g. "IF NOT EXISTS" no-ops) so they
+    // don't clutter the bot's structured JSON logs.
+    onnotice: () => {},
+    // Automatic snake_case ↔ camelCase column-name transforms on read, so a
+    // SELECT returning `guild_id` lands in JS as `guildId` and we can type
+    // queries directly with `sql<Subscription[]>` instead of hand-mapping each
+    // row. `undefined: null` coerces JS `undefined` parameter values to SQL
+    // NULL (porsager/postgres throws by default — the coercion saves us from
+    // sprinkling `?? null` at every nullable boundary).
+    transform: { ...postgres.camel, undefined: null },
+    // Server-side safety timeouts. The bot's queries are all small lookups
+    // and upserts, so anything slower than 30s is a sign of trouble (lock
+    // contention, runaway query, dead replica). 60s for idle-in-tx prevents
+    // a hung connection from holding locks indefinitely on shutdown errors.
+    connection: {
+      statement_timeout: 30_000,
+      idle_in_transaction_session_timeout: 60_000,
+    },
+  });
+}

--- a/discord/src/filters.ts
+++ b/discord/src/filters.ts
@@ -1,0 +1,22 @@
+import type { ClipFeedItem } from './api.ts';
+import type { Subscription } from './db.ts';
+
+// Does this subscription want this clip? Three-way match:
+//   - paused subs never match (filtered upstream in listAllSubscriptions, but defended here)
+//   - NULL game_id means "any game"; otherwise the clip's game.id must equal it
+//   - NULL creator_id means "any creator"; otherwise clip.author.id must equal it
+// Returns boolean; pure function for easy testing.
+export function subscriptionMatchesClip(sub: Subscription, clip: ClipFeedItem): boolean {
+  if (sub.paused) return false;
+  if (sub.gameId !== null && (clip.game?.id ?? null) !== sub.gameId) return false;
+  if (sub.creatorId !== null && clip.author.id !== sub.creatorId) return false;
+  return true;
+}
+
+// For one clip, find every subscription that wants it. Used by the poller fanout.
+export function matchingSubscriptions<S extends Subscription>(
+  subscriptions: readonly S[],
+  clip: ClipFeedItem,
+): S[] {
+  return subscriptions.filter((s) => subscriptionMatchesClip(s, clip));
+}

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -132,10 +132,35 @@ async function main(): Promise<void> {
   // whether the post-log row is written. Returning false here means the poller
   // will isPosted()-check this pair again next round and retry.
   const fanout: Fanout = async (clip, target) => {
-    // fetch() pulls from the cache when warm, REST when cold. Returns null if
-    // the bot was kicked or the channel was deleted — treat as a permanent
-    // failure for this round (next round will isPosted()-check + retry).
-    const channel = await client.channels.fetch(target.channelId);
+    // fetch() pulls from the cache when warm, REST when cold. discord.js v14
+    // THROWS `DiscordAPIError` for missing/inaccessible resources (codes 10003,
+    // 10004, 50001, 50007 etc.); the `null` return is reserved for forced
+    // cache-miss configurations. The try/catch below (and the dead-channel
+    // cleanup) handles both paths.
+    let channel;
+    try {
+      channel = await client.channels.fetch(target.channelId);
+    } catch (err) {
+      const apiCode =
+        err && typeof err === 'object' && 'code' in err ? (err as { code: number }).code : null;
+      // Terminal channel errors → remove the sub so we don't loop on this
+      // channel for every future clip (M4 from review #111). 10003: Unknown
+      // Channel · 10004: Unknown Guild · 50001: Missing Access · 50007: Cannot
+      // Send Messages To This User.
+      if (apiCode === 10003 || apiCode === 10004 || apiCode === 50001 || apiCode === 50007) {
+        const removed = await db.removeAllSubscriptionsForChannel(target.channelId);
+        log.warn('channel inaccessible — removed subscriptions', {
+          channelId: target.channelId,
+          clipId: clip.id,
+          code: apiCode,
+          removed,
+        });
+        // Return false so the poller halts the cursor this round; next round
+        // the subs are gone and the cursor will advance cleanly.
+        return false;
+      }
+      throw err;
+    }
     if (!channel || !channel.isTextBased() || !('send' in channel)) {
       log.warn('channel unavailable or not text-based', {
         channelId: target.channelId,

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -2,14 +2,7 @@
 // loadConfig reads it. Mirrors web/vite.config.ts's `envDir: '../'`.
 import './loadEnv.ts';
 
-import {
-  Client,
-  GatewayIntentBits,
-  MessageFlags,
-  REST,
-  Routes,
-  type Interaction,
-} from 'discord.js';
+import { Client, GatewayIntentBits, REST, Routes, type Interaction } from 'discord.js';
 import { loadConfig } from './config.ts';
 import { connect, createDb } from './db.ts';
 import { runMigrations } from './migrator.ts';
@@ -20,6 +13,7 @@ import {
   dispatchChatInput,
   type CommandContext,
 } from './commands/index.ts';
+import { ephemeral } from './commands/replies.ts';
 import { buildMessage, postToChannel } from './posting.ts';
 import { startPoller, type Fanout, type PollerLogger } from './poller.ts';
 
@@ -85,10 +79,7 @@ async function main(): Promise<void> {
           if (interaction.deferred || interaction.replied) {
             await interaction.editReply({ content: 'Something went wrong.' });
           } else {
-            await interaction.reply({
-              content: 'Something went wrong.',
-              flags: MessageFlags.Ephemeral,
-            });
+            await interaction.reply(ephemeral('Something went wrong.'));
           }
         } catch {
           /* swallow — original error is already logged */

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -75,12 +75,21 @@ async function main(): Promise<void> {
         commandName: 'commandName' in interaction ? interaction.commandName : null,
         err: String(err),
       });
-      if (interaction.isRepliable() && !interaction.replied) {
+      if (interaction.isRepliable()) {
         try {
-          await interaction.reply({
-            content: 'Something went wrong.',
-            flags: MessageFlags.Ephemeral,
-          });
+          // All command handlers call deferReply() first, so by the time we
+          // catch here the interaction is typically `deferred && !replied`.
+          // Calling reply() in that state throws InteractionAlreadyReplied —
+          // we have to follow up via editReply() instead. The ephemeral flag
+          // was already set at deferReply time so editReply inherits it.
+          if (interaction.deferred || interaction.replied) {
+            await interaction.editReply({ content: 'Something went wrong.' });
+          } else {
+            await interaction.reply({
+              content: 'Something went wrong.',
+              flags: MessageFlags.Ephemeral,
+            });
+          }
         } catch {
           /* swallow — original error is already logged */
         }

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -1,0 +1,161 @@
+// Side-effect import — merges the repo-root .env into process.env BEFORE
+// loadConfig reads it. Mirrors web/vite.config.ts's `envDir: '../'`.
+import './loadEnv.ts';
+
+import {
+  Client,
+  GatewayIntentBits,
+  MessageFlags,
+  REST,
+  Routes,
+  type Interaction,
+} from 'discord.js';
+import { loadConfig } from './config.ts';
+import { connect, createDb } from './db.ts';
+import { runMigrations } from './migrator.ts';
+import { createApi } from './api.ts';
+import {
+  commandDefinitions,
+  dispatchAutocomplete,
+  dispatchChatInput,
+  type CommandContext,
+} from './commands/index.ts';
+import { buildMessage, postToChannel } from './posting.ts';
+import { startPoller, type Fanout, type PollerLogger } from './poller.ts';
+
+// Off-by-default contract mirrors IgdbSyncHostedService: if the bot token is
+// missing, log "disabled" and exit cleanly. The compose service still starts,
+// just no-ops. This keeps local-dev `make up` working for contributors who
+// haven't set up a Discord application yet.
+const log: PollerLogger = {
+  info: (m, f) => console.log(JSON.stringify({ level: 'info', msg: m, ...f })),
+  warn: (m, f) => console.warn(JSON.stringify({ level: 'warn', msg: m, ...f })),
+  error: (m, f) => console.error(JSON.stringify({ level: 'error', msg: m, ...f })),
+};
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+
+  if (!config.enabled) {
+    log.info('Discord bot disabled (DISCORD_BOT_TOKEN or DISCORD_BOT_APP_ID unset); exiting.');
+    return;
+  }
+
+  const sql = connect(config.DISCORD_DATABASE_URL);
+  const db = createDb(sql);
+  const api = createApi(config.GANKEDTV_API_BASE);
+
+  log.info('Running migrations...');
+  const ran = await runMigrations(sql);
+  log.info('Migrations complete', { applied: ran });
+
+  const ctx: CommandContext = {
+    db,
+    api,
+    publicBase: config.GANKEDTV_PUBLIC_BASE,
+  };
+
+  const client = new Client({
+    intents: [GatewayIntentBits.Guilds],
+  });
+
+  client.once('clientReady', () => {
+    log.info('Discord client ready', { user: client.user?.tag });
+  });
+
+  client.on('interactionCreate', async (interaction: Interaction) => {
+    try {
+      if (interaction.isChatInputCommand()) {
+        await dispatchChatInput(interaction, ctx);
+      } else if (interaction.isAutocomplete()) {
+        await dispatchAutocomplete(interaction, ctx);
+      }
+    } catch (err) {
+      log.error('interaction handler threw', {
+        commandName: 'commandName' in interaction ? interaction.commandName : null,
+        err: String(err),
+      });
+      if (interaction.isRepliable() && !interaction.replied) {
+        try {
+          await interaction.reply({
+            content: 'Something went wrong.',
+            flags: MessageFlags.Ephemeral,
+          });
+        } catch {
+          /* swallow — original error is already logged */
+        }
+      }
+    }
+  });
+
+  // Slash command registration: guild-scoped if a dev guild id is set (propagates
+  // within seconds), global otherwise (up to an hour). We register on every boot
+  // because the cost is one REST call and it keeps definitions in sync with code.
+  const rest = new REST({ version: '10' }).setToken(config.DISCORD_BOT_TOKEN!);
+  if (config.DISCORD_BOT_GUILD_ID) {
+    log.info('Registering guild-scoped slash commands', { guild: config.DISCORD_BOT_GUILD_ID });
+    await rest.put(
+      Routes.applicationGuildCommands(config.DISCORD_BOT_APP_ID!, config.DISCORD_BOT_GUILD_ID),
+      { body: commandDefinitions() },
+    );
+  } else {
+    log.info('Registering global slash commands');
+    await rest.put(Routes.applicationCommands(config.DISCORD_BOT_APP_ID!), {
+      body: commandDefinitions(),
+    });
+  }
+
+  // Graceful shutdown: stop the poller, disconnect Discord, close the DB pool.
+  const abort = new AbortController();
+  const shutdown = async (signal: string) => {
+    log.info('Shutdown signal received', { signal });
+    abort.abort();
+    try {
+      await client.destroy();
+    } catch (err) {
+      log.warn('client destroy threw', { err: String(err) });
+    }
+    try {
+      await db.close();
+    } catch (err) {
+      log.warn('db close threw', { err: String(err) });
+    }
+    process.exit(0);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+  await client.login(config.DISCORD_BOT_TOKEN!);
+
+  // One channel per call. The poller invokes this per matched (clip, sub) pair
+  // and the return value (true=delivered, false=transient failure) drives
+  // whether the post-log row is written. Returning false here means the poller
+  // will isPosted()-check this pair again next round and retry.
+  const fanout: Fanout = async (clip, target) => {
+    // fetch() pulls from the cache when warm, REST when cold. Returns null if
+    // the bot was kicked or the channel was deleted — treat as a permanent
+    // failure for this round (next round will isPosted()-check + retry).
+    const channel = await client.channels.fetch(target.channelId);
+    if (!channel || !channel.isTextBased() || !('send' in channel)) {
+      log.warn('channel unavailable or not text-based', {
+        channelId: target.channelId,
+        clipId: clip.id,
+      });
+      return false;
+    }
+    const content = buildMessage(
+      clip,
+      { pingRoleId: target.pingRoleId },
+      config.GANKEDTV_PUBLIC_BASE,
+    );
+    return postToChannel(channel, content);
+  };
+
+  log.info('Starting poller', { intervalSeconds: config.DISCORD_POLL_INTERVAL_SECONDS });
+  await startPoller({ db, api, fanout, log }, config.DISCORD_POLL_INTERVAL_SECONDS, abort.signal);
+}
+
+main().catch((err) => {
+  log.error('fatal', { err: String(err), stack: err instanceof Error ? err.stack : undefined });
+  process.exit(1);
+});

--- a/discord/src/lib/permissions.ts
+++ b/discord/src/lib/permissions.ts
@@ -1,0 +1,11 @@
+import { PermissionFlagsBits, type ChatInputCommandInteraction } from 'discord.js';
+
+// Subscribe/unsubscribe/pause/resume are channel-scoped admin actions; gating them
+// to ManageChannels stops random members from reconfiguring server-wide clip posts.
+// Listing + /clip * are open (return true).
+export function requireManageChannels(interaction: ChatInputCommandInteraction): boolean {
+  if (!interaction.inGuild()) return false;
+  const perms = interaction.memberPermissions;
+  if (!perms) return false;
+  return perms.has(PermissionFlagsBits.ManageChannels);
+}

--- a/discord/src/lib/shareUrl.ts
+++ b/discord/src/lib/shareUrl.ts
@@ -1,0 +1,8 @@
+// Build the public share URL for a clip. The /c/{code} route serves OG/Twitter
+// meta tags (ClipsReadEndpoints.GetByShareCode) so any Discord-supported client
+// auto-unfurls into title + thumbnail + video player. The bot's only job is to
+// emit this URL — Discord handles the rest.
+export function shareUrl(code: string, publicBase: string): string {
+  const trimmed = publicBase.endsWith('/') ? publicBase.slice(0, -1) : publicBase;
+  return `${trimmed}/c/${code}`;
+}

--- a/discord/src/loadEnv.ts
+++ b/discord/src/loadEnv.ts
@@ -1,0 +1,60 @@
+// Merges the repo-root `.env` into process.env so the bot picks up the same
+// shared values the API and web app use (DATABASE_URL, etc.) without forcing
+// contributors to duplicate them in discord/.env. Mirrors web/vite.config.ts's
+// `envDir: '../'` convention.
+//
+// Precedence (first-set wins; same as the standard 12-factor order):
+//   1. shell env (already in process.env before this runs)
+//   2. discord/.env (auto-loaded by Bun before the script starts)
+//   3. repo-root .env (loaded here)
+//
+// Pure helpers (parseEnvFile, mergeFirstWins) are exported for tests; the
+// bottom-of-file invocation is the side effect that makes import './loadEnv.ts'
+// "just work" from src/index.ts.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export function parseEnvFile(contents: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of contents.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    // Strip surrounding single or double quotes — matches dotenv/Bun behavior.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export function mergeFirstWins(
+  target: Record<string, string | undefined>,
+  source: Record<string, string>,
+): void {
+  for (const [k, v] of Object.entries(source)) {
+    if (!(k in target)) target[k] = v;
+  }
+}
+
+const ROOT_ENV_PATH = resolve(import.meta.dir, '..', '..', '.env');
+
+export function loadRootEnv(
+  envPath: string = ROOT_ENV_PATH,
+  target: Record<string, string | undefined> = process.env,
+): void {
+  if (!existsSync(envPath)) return;
+  mergeFirstWins(target, parseEnvFile(readFileSync(envPath, 'utf8')));
+}
+
+// Side effect at import time. Tests of the helpers above pass an explicit
+// fake path/target and never depend on this default invocation.
+loadRootEnv();

--- a/discord/src/migrations/001_initial.sql
+++ b/discord/src/migrations/001_initial.sql
@@ -36,6 +36,12 @@ CREATE TABLE IF NOT EXISTS discord_subscriptions (
     -- NULLS DISTINCT treats (C, NULL, NULL) and (C, NULL, NULL) as distinct).
     -- The semantics we want: (C, NULL, NULL) collides with itself, but
     -- (C, 42, NULL) is still distinct from (C, NULL, NULL) because 42 ≠ NULL.
+    --
+    -- HARD MINIMUM: PostgreSQL 15. Older versions will reject this statement.
+    -- The dev compose stack runs PG18 (docker-compose.dev.yml). Operators
+    -- targeting a shared older cluster need either a PG upgrade OR a fork of
+    -- this migration that emulates NULLS NOT DISTINCT via a partial unique
+    -- index (CREATE UNIQUE INDEX … WHERE …) plus app-side guards.
     UNIQUE NULLS NOT DISTINCT (channel_id, game_id, creator_id)
 );
 

--- a/discord/src/migrations/001_initial.sql
+++ b/discord/src/migrations/001_initial.sql
@@ -1,0 +1,71 @@
+-- Discord bot owns these three tables. The API's EF Core DbContext does NOT model
+-- them, so EF migrations and the bot's migrations cannot collide. Tables reference
+-- games(id) / users(id) by value only — no DB-level FKs — so the bot migration is
+-- independent of which EF migration is currently applied.
+--
+-- Migration conventions for this directory:
+--   * Each .sql file runs inside a transaction (see src/migrator.ts), so a
+--     half-applied migration rolls back cleanly. Operations that REQUIRE
+--     autocommit (CREATE INDEX CONCURRENTLY, REINDEX CONCURRENTLY, VACUUM,
+--     ALTER TYPE ... ADD VALUE) must go in their own file marked with a
+--     `-- @no-transaction` directive — the migrator does not yet honour that
+--     directive, so adding one is a deliberate "extend the migrator first" gate.
+--   * snake_case names, plural-table-name + singular-column. Matches API
+--     EF conventions.
+--   * Use `timestamptz` (never bare `timestamp`); `gen_random_uuid()` (built-in
+--     since PG13, no extension); `IS NOT DISTINCT FROM` for NULL-safe equality
+--     in queries (see db.ts removeSubscription).
+
+CREATE TABLE IF NOT EXISTS discord_subscriptions (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    guild_id       text NOT NULL,
+    channel_id     text NOT NULL,
+    -- Optional filters. NULL means "no filter on this dimension". A subscription
+    -- with both NULL is the all-clips firehose for the channel.
+    -- game_id is integer because games(id) is integer (Game.cs); creator_id is uuid
+    -- because users(id) is uuid (User.cs).
+    game_id        integer NULL,
+    creator_id     uuid NULL,
+    paused         boolean NOT NULL DEFAULT false,
+    ping_role_id   text NULL,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    created_by     text NOT NULL,
+    -- One rule per (channel, game, creator) combo. NULLS NOT DISTINCT (PG15+)
+    -- is the key choice: two `/subscribe` calls with no filters on the same
+    -- channel would otherwise create two phantom firehose rows (default
+    -- NULLS DISTINCT treats (C, NULL, NULL) and (C, NULL, NULL) as distinct).
+    -- The semantics we want: (C, NULL, NULL) collides with itself, but
+    -- (C, 42, NULL) is still distinct from (C, NULL, NULL) because 42 ≠ NULL.
+    UNIQUE NULLS NOT DISTINCT (channel_id, game_id, creator_id)
+);
+
+CREATE INDEX IF NOT EXISTS discord_subscriptions_channel_idx
+    ON discord_subscriptions (channel_id);
+CREATE INDEX IF NOT EXISTS discord_subscriptions_game_idx
+    ON discord_subscriptions (game_id) WHERE game_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS discord_subscriptions_creator_idx
+    ON discord_subscriptions (creator_id) WHERE creator_id IS NOT NULL;
+
+-- Dedupe guard: a clip is posted at most once per channel. Written AFTER a
+-- successful send (see db.ts recordPost) so a crash mid-send doesn't blacklist
+-- the (channel, clip) pair — at-least-once delivery with idempotent isPosted
+-- pre-check. Grows unbounded; the posted_at_idx exists to support an eventual
+-- retention prune (DELETE WHERE posted_at < now() - interval '90 days') which
+-- isn't wired up yet (low priority until the table reaches ~1M rows).
+CREATE TABLE IF NOT EXISTS discord_post_log (
+    channel_id  text NOT NULL,
+    clip_id     uuid NOT NULL,
+    posted_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (channel_id, clip_id)
+);
+
+CREATE INDEX IF NOT EXISTS discord_post_log_posted_at_idx
+    ON discord_post_log (posted_at DESC);
+
+-- Generic key/value bag for the bot's own state. Currently holds the poller's
+-- high-water-mark (`last_clip_created_at`).
+CREATE TABLE IF NOT EXISTS discord_bot_state (
+    key         text PRIMARY KEY,
+    value       text NOT NULL,
+    updated_at  timestamptz NOT NULL DEFAULT now()
+);

--- a/discord/src/migrator.ts
+++ b/discord/src/migrator.ts
@@ -1,8 +1,19 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Sql } from 'postgres';
 
-const MIGRATIONS_DIR = new URL('./migrations/', import.meta.url).pathname;
+// fileURLToPath instead of `.pathname` because on Windows the latter yields
+// `/C:/...` which fs APIs can't open. Linux-only deploy today (Bun Alpine
+// container), but cheap cross-platform safety for dev machines.
+const MIGRATIONS_DIR = fileURLToPath(new URL('./migrations/', import.meta.url));
+
+// Arbitrary stable identifier for the discord-bot migration advisory lock.
+// Postgres docs recommend application-defined int64s here; any value works as
+// long as it's stable across boots (so two starting instances pick the same
+// lock). 32-bit signed so it stays within the single-arg pg_advisory_lock(int)
+// overload across drivers.
+const MIGRATION_LOCK_ID = 0x6766_7462; // hex 'gftb' — Gankedtv Discord Bot
 
 export async function runMigrations(sql: Sql): Promise<string[]> {
   await sql.unsafe(`
@@ -12,22 +23,32 @@ export async function runMigrations(sql: Sql): Promise<string[]> {
     )
   `);
 
-  const all = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.sql')).sort();
+  // pg_advisory_lock serialises concurrent boots so two instances can't race
+  // through the apply loop (which would otherwise double-run a migration's
+  // DDL before either gets to INSERT the filename). Session-scoped, so a
+  // crashed instance auto-releases. Lock is held only for the apply loop,
+  // not for the lifetime of the connection.
+  await sql`SELECT pg_advisory_lock(${MIGRATION_LOCK_ID})`;
+  try {
+    const all = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.sql')).sort();
 
-  const applied = await sql<{ filename: string }[]>`
-    SELECT filename FROM discord_migrations
-  `;
-  const appliedSet = new Set(applied.map((r) => r.filename));
+    const applied = await sql<{ filename: string }[]>`
+      SELECT filename FROM discord_migrations
+    `;
+    const appliedSet = new Set(applied.map((r) => r.filename));
 
-  const ranNow: string[] = [];
-  for (const filename of all) {
-    if (appliedSet.has(filename)) continue;
-    const body = await readFile(join(MIGRATIONS_DIR, filename), 'utf8');
-    await sql.begin(async (tx) => {
-      await tx.unsafe(body);
-      await tx`INSERT INTO discord_migrations (filename) VALUES (${filename})`;
-    });
-    ranNow.push(filename);
+    const ranNow: string[] = [];
+    for (const filename of all) {
+      if (appliedSet.has(filename)) continue;
+      const body = await readFile(join(MIGRATIONS_DIR, filename), 'utf8');
+      await sql.begin(async (tx) => {
+        await tx.unsafe(body);
+        await tx`INSERT INTO discord_migrations (filename) VALUES (${filename})`;
+      });
+      ranNow.push(filename);
+    }
+    return ranNow;
+  } finally {
+    await sql`SELECT pg_advisory_unlock(${MIGRATION_LOCK_ID})`;
   }
-  return ranNow;
 }

--- a/discord/src/migrator.ts
+++ b/discord/src/migrator.ts
@@ -23,32 +23,41 @@ export async function runMigrations(sql: Sql): Promise<string[]> {
     )
   `);
 
-  // pg_advisory_lock serialises concurrent boots so two instances can't race
-  // through the apply loop (which would otherwise double-run a migration's
-  // DDL before either gets to INSERT the filename). Session-scoped, so a
-  // crashed instance auto-releases. Lock is held only for the apply loop,
-  // not for the lifetime of the connection.
-  await sql`SELECT pg_advisory_lock(${MIGRATION_LOCK_ID})`;
+  // Reserve a single backend connection for the entire lock → apply → unlock
+  // sequence. PG advisory locks are session-scoped (per-backend); without
+  // sql.reserve() the three queries can land on different pooled connections
+  // and the lock provides zero protection: two concurrent boots would each
+  // acquire the lock on their own connection (PG sees them as separate
+  // sessions, both get the lock), race through the apply loop, and the
+  // INSERT INTO discord_migrations PK collision would crash one of them.
+  const conn = await sql.reserve();
   try {
-    const all = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.sql')).sort();
+    await conn`SELECT pg_advisory_lock(${MIGRATION_LOCK_ID})`;
+    try {
+      const all = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.sql')).sort();
 
-    const applied = await sql<{ filename: string }[]>`
-      SELECT filename FROM discord_migrations
-    `;
-    const appliedSet = new Set(applied.map((r) => r.filename));
+      const applied = await conn<{ filename: string }[]>`
+        SELECT filename FROM discord_migrations
+      `;
+      const appliedSet = new Set(applied.map((r) => r.filename));
 
-    const ranNow: string[] = [];
-    for (const filename of all) {
-      if (appliedSet.has(filename)) continue;
-      const body = await readFile(join(MIGRATIONS_DIR, filename), 'utf8');
-      await sql.begin(async (tx) => {
-        await tx.unsafe(body);
-        await tx`INSERT INTO discord_migrations (filename) VALUES (${filename})`;
-      });
-      ranNow.push(filename);
+      const ranNow: string[] = [];
+      for (const filename of all) {
+        if (appliedSet.has(filename)) continue;
+        const body = await readFile(join(MIGRATIONS_DIR, filename), 'utf8');
+        // begin() on the reserved connection inherits the same session, so the
+        // advisory lock held above also covers the DDL transaction.
+        await conn.begin(async (tx) => {
+          await tx.unsafe(body);
+          await tx`INSERT INTO discord_migrations (filename) VALUES (${filename})`;
+        });
+        ranNow.push(filename);
+      }
+      return ranNow;
+    } finally {
+      await conn`SELECT pg_advisory_unlock(${MIGRATION_LOCK_ID})`;
     }
-    return ranNow;
   } finally {
-    await sql`SELECT pg_advisory_unlock(${MIGRATION_LOCK_ID})`;
+    conn.release();
   }
 }

--- a/discord/src/migrator.ts
+++ b/discord/src/migrator.ts
@@ -1,0 +1,33 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Sql } from 'postgres';
+
+const MIGRATIONS_DIR = new URL('./migrations/', import.meta.url).pathname;
+
+export async function runMigrations(sql: Sql): Promise<string[]> {
+  await sql.unsafe(`
+    CREATE TABLE IF NOT EXISTS discord_migrations (
+      filename    text PRIMARY KEY,
+      applied_at  timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+
+  const all = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.sql')).sort();
+
+  const applied = await sql<{ filename: string }[]>`
+    SELECT filename FROM discord_migrations
+  `;
+  const appliedSet = new Set(applied.map((r) => r.filename));
+
+  const ranNow: string[] = [];
+  for (const filename of all) {
+    if (appliedSet.has(filename)) continue;
+    const body = await readFile(join(MIGRATIONS_DIR, filename), 'utf8');
+    await sql.begin(async (tx) => {
+      await tx.unsafe(body);
+      await tx`INSERT INTO discord_migrations (filename) VALUES (${filename})`;
+    });
+    ranNow.push(filename);
+  }
+  return ranNow;
+}

--- a/discord/src/poller.ts
+++ b/discord/src/poller.ts
@@ -1,0 +1,201 @@
+import type { ApiClient, ClipFeedItem } from './api.ts';
+import type { Db, Subscription } from './db.ts';
+import { matchingSubscriptions } from './filters.ts';
+
+// High-water-mark cursor: ISO 8601 timestamp of the most-recent clip we've seen.
+// Tracked in discord_bot_state under this key. On boot, the poller seeds it to
+// "now" so a fresh install doesn't backfill the entire history.
+const STATE_KEY = 'last_clip_created_at';
+
+export type PollerLogger = {
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+};
+
+// Per-channel post target. The poller resolves which channel + ping role each
+// clip should land on; the fanout just needs to know where to send and whether
+// to ping. Returns true on successful send, false on transient failure (the
+// poller does NOT record the post and the next round will retry).
+export type PostTarget = { channelId: string; pingRoleId: string | null };
+export type Fanout = (clip: ClipFeedItem, target: PostTarget) => Promise<boolean>;
+
+export type PollerDeps = {
+  db: Db;
+  api: ApiClient;
+  fanout: Fanout;
+  log: PollerLogger;
+  // Max items to pull per API page. The feed page caps at 100 server-side;
+  // default 50 + cursor-pagination handles bursts of >50 clips per poll round
+  // without losing the older ones (C2 from review).
+  pageSize?: number;
+  // Safety cap on cursor-driven pagination. Without this, a misconfigured
+  // cursor (e.g. lastSeen far in the past after a manual DB reset) could pull
+  // the entire history in one round. 10 × 50 = 500 clips per round is plenty;
+  // beyond that, dropping older clips on the floor is preferable to spending
+  // the whole poll interval on a single round.
+  maxPages?: number;
+};
+
+export type PollResult = {
+  fetched: number;
+  newClips: number;
+  posts: number;
+};
+
+// One poll round. Side-effect-free until it calls fanout / db writes, which
+// makes the function easy to drive from tests.
+export async function pollOnce({
+  db,
+  api,
+  fanout,
+  log,
+  pageSize = 50,
+  maxPages = 10,
+}: PollerDeps): Promise<PollResult> {
+  const lastSeenIso = await db.getState(STATE_KEY);
+  if (lastSeenIso === null) {
+    // First-ever poll: anchor to "now" so we don't backfill. The next round
+    // forward will pick up anything that lands after this timestamp.
+    await db.setState(STATE_KEY, new Date().toISOString());
+    return { fetched: 0, newClips: 0, posts: 0 };
+  }
+  const lastSeen = new Date(lastSeenIso);
+
+  // Paginate via nextCursor until a page returns at least one clip ≤ lastSeen
+  // (we've walked back past the high-water mark) or we hit maxPages. The feed
+  // is sorted DESC by (createdAt, id), so each follow-up page covers older
+  // clips. Without this loop, a burst of >pageSize clips between polls would
+  // silently drop everything older than the first pageSize newest (C2).
+  const all: ClipFeedItem[] = [];
+  let cursor: string | undefined;
+  let fetched = 0;
+  for (let pageNum = 0; pageNum < maxPages; pageNum++) {
+    const page = await api.getFeed(cursor ? { limit: pageSize, cursor } : { limit: pageSize });
+    fetched += page.items.length;
+    const lastItem = page.items[page.items.length - 1];
+    // Use >= so tied-timestamp clips at the boundary are included (C3); the
+    // post-log dedupe (isPosted) below ensures we don't double-send them.
+    const freshInPage = page.items.filter((c) => new Date(c.createdAt) >= lastSeen);
+    all.push(...freshInPage);
+    // Stop when the oldest clip in the page is ≤ lastSeen (we've walked back
+    // past the cursor) OR the page wasn't full (no more clips upstream) OR
+    // there's no next cursor.
+    const pageWalkedPastCursor = lastItem && new Date(lastItem.createdAt) < lastSeen;
+    if (pageWalkedPastCursor || page.items.length < pageSize || !page.nextCursor) break;
+    cursor = page.nextCursor;
+  }
+
+  // Sort oldest-first so Discord channel ordering matches upload order, then
+  // de-dupe by id (the same clip can appear on two pages if a new clip arrives
+  // mid-pagination — both pages then include the boundary item).
+  const seen = new Set<string>();
+  const fresh = all
+    .filter((c) => {
+      if (seen.has(c.id)) return false;
+      seen.add(c.id);
+      return true;
+    })
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+  if (fresh.length === 0) {
+    return { fetched, newClips: 0, posts: 0 };
+  }
+
+  const subs = await db.listAllSubscriptions();
+  let posts = 0;
+
+  for (const clip of fresh) {
+    const matched = matchingSubscriptions(subs, clip);
+    for (const sub of matched) {
+      const ok = await postOne(clip, sub, db, fanout, log);
+      if (ok) posts++;
+    }
+  }
+
+  // Cursor moves to the newest clip we processed. If any post failed for a
+  // (clip, sub) pair, the failure was logged but doesn't block the cursor —
+  // the post-log dedupe handles retry next round when isPosted() returns
+  // false because we never recorded.
+  const newest = fresh[fresh.length - 1];
+  if (newest) await db.setState(STATE_KEY, newest.createdAt);
+
+  log.info('poll round complete', { fetched, newClips: fresh.length, posts });
+  return { fetched, newClips: fresh.length, posts };
+}
+
+async function postOne(
+  clip: ClipFeedItem,
+  sub: Subscription,
+  db: Db,
+  fanout: Fanout,
+  log: PollerLogger,
+): Promise<boolean> {
+  // Read-only pre-check skips clips we've already posted to this channel
+  // (idempotence on restart with an un-advanced cursor, or at the tied-
+  // timestamp cursor boundary when `>=` re-includes processed clips).
+  if (await db.isPosted(sub.channelId, clip.id)) return false;
+
+  let posted: boolean;
+  try {
+    posted = await fanout(clip, { channelId: sub.channelId, pingRoleId: sub.pingRoleId });
+  } catch (err) {
+    log.error('post threw', { channelId: sub.channelId, clipId: clip.id, err: String(err) });
+    return false;
+  }
+  if (!posted) {
+    // fanout swallowed the failure (e.g. channel unavailable) and returned
+    // false — same retry semantics as a throw: skip recording, next round
+    // tries again.
+    return false;
+  }
+
+  // Record AFTER a successful send. If a crash happens between send and
+  // record, the next round will isPosted()-check, see nothing, post again
+  // → at-least-once duplicate. Inevitable without 2PC; logged here so it's
+  // greppable when investigating dupe reports.
+  try {
+    await db.recordPost(sub.channelId, clip.id);
+  } catch (err) {
+    log.warn('post recorded send but recordPost failed', {
+      channelId: sub.channelId,
+      clipId: clip.id,
+      err: String(err),
+    });
+  }
+  return true;
+}
+
+// Long-lived loop. Resolves only when stop() is called (or the abort signal
+// fires). Errors per round are logged but never crash the loop.
+export function startPoller(
+  deps: PollerDeps,
+  intervalSeconds: number,
+  signal: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const tick = async () => {
+      if (signal.aborted) return;
+      try {
+        await pollOnce(deps);
+      } catch (err) {
+        deps.log.error('poll round threw', { err: String(err) });
+      }
+    };
+
+    let running = true;
+    const handle = setInterval(() => {
+      void tick();
+    }, intervalSeconds * 1000);
+
+    signal.addEventListener('abort', () => {
+      if (!running) return;
+      running = false;
+      clearInterval(handle);
+      resolve();
+    });
+
+    // Kick off immediately so the first round doesn't wait for the interval.
+    void tick();
+  });
+}

--- a/discord/src/poller.ts
+++ b/discord/src/poller.ts
@@ -113,25 +113,46 @@ export async function pollOnce({
 
   const subs = await db.listAllSubscriptions();
   let posts = 0;
+  // Index of the first clip (in oldest-first order) that had ANY post failure.
+  // We keep processing remaining clips so we don't artificially halt newer
+  // work, but the cursor only advances to the predecessor of this clip — so
+  // the failed (clip, sub) pair is re-evaluated next round. Without this, a
+  // transient channel failure would silently drop the clip forever (cursor
+  // moved past it, post log has no row, isPosted-pre-check finds nothing,
+  // but the feed no longer returns it because lastSeen >= its createdAt).
+  let firstFailureIdx = -1;
 
-  for (const clip of fresh) {
+  for (let i = 0; i < fresh.length; i++) {
+    const clip = fresh[i]!;
     const matched = matchingSubscriptions(subs, clip);
     for (const sub of matched) {
-      const ok = await postOne(clip, sub, db, fanout, log);
-      if (ok) posts++;
+      const outcome = await postOne(clip, sub, db, fanout, log);
+      if (outcome === 'sent') posts++;
+      else if (outcome === 'failed' && firstFailureIdx === -1) firstFailureIdx = i;
     }
   }
 
-  // Cursor moves to the newest clip we processed. If any post failed for a
-  // (clip, sub) pair, the failure was logged but doesn't block the cursor —
-  // the post-log dedupe handles retry next round when isPosted() returns
-  // false because we never recorded.
-  const newest = fresh[fresh.length - 1];
-  if (newest) await db.setState(STATE_KEY, newest.createdAt);
+  // Cursor advancement:
+  //   - all clips fully done → advance to the newest clip's createdAt
+  //   - partial failure → advance only to the clip BEFORE the failure boundary
+  //     (so the failed clip is re-fetched next round; isPosted dedupes the subs
+  //     that already succeeded; only the failed sub retries)
+  //   - first clip in the round failed → don't advance at all
+  const advanceIdx = firstFailureIdx === -1 ? fresh.length - 1 : firstFailureIdx - 1;
+  if (advanceIdx >= 0) {
+    await db.setState(STATE_KEY, fresh[advanceIdx]!.createdAt);
+  }
 
-  log.info('poll round complete', { fetched, newClips: fresh.length, posts });
+  log.info('poll round complete', {
+    fetched,
+    newClips: fresh.length,
+    posts,
+    haltedAtIdx: firstFailureIdx === -1 ? null : firstFailureIdx,
+  });
   return { fetched, newClips: fresh.length, posts };
 }
+
+type PostOutcome = 'sent' | 'skipped' | 'failed';
 
 async function postOne(
   clip: ClipFeedItem,
@@ -139,24 +160,24 @@ async function postOne(
   db: Db,
   fanout: Fanout,
   log: PollerLogger,
-): Promise<boolean> {
+): Promise<PostOutcome> {
   // Read-only pre-check skips clips we've already posted to this channel
   // (idempotence on restart with an un-advanced cursor, or at the tied-
   // timestamp cursor boundary when `>=` re-includes processed clips).
-  if (await db.isPosted(sub.channelId, clip.id)) return false;
+  if (await db.isPosted(sub.channelId, clip.id)) return 'skipped';
 
   let posted: boolean;
   try {
     posted = await fanout(clip, { channelId: sub.channelId, pingRoleId: sub.pingRoleId });
   } catch (err) {
     log.error('post threw', { channelId: sub.channelId, clipId: clip.id, err: String(err) });
-    return false;
+    return 'failed';
   }
   if (!posted) {
     // fanout swallowed the failure (e.g. channel unavailable) and returned
     // false — same retry semantics as a throw: skip recording, next round
     // tries again.
-    return false;
+    return 'failed';
   }
 
   // Record AFTER a successful send. If a crash happens between send and
@@ -172,7 +193,7 @@ async function postOne(
       err: String(err),
     });
   }
-  return true;
+  return 'sent';
 }
 
 // Long-lived loop. Resolves only when stop() is called (or the abort signal

--- a/discord/src/poller.ts
+++ b/discord/src/poller.ts
@@ -60,7 +60,16 @@ export async function pollOnce({
     await db.setState(STATE_KEY, new Date().toISOString());
     return { fetched: 0, newClips: 0, posts: 0 };
   }
-  const lastSeen = new Date(lastSeenIso);
+  let lastSeen = new Date(lastSeenIso);
+  if (Number.isNaN(lastSeen.getTime())) {
+    // Garbage value in the cursor (manual DB tampering, future schema bug,
+    // truncated write). Without the guard, every clip comparison `>= lastSeen`
+    // returns false → entire feed treated as stale → silent posting outage.
+    // Re-anchor to "now" instead, log loudly, and continue.
+    log.warn('cursor value is not a valid ISO date; re-anchoring to now', { value: lastSeenIso });
+    lastSeen = new Date();
+    await db.setState(STATE_KEY, lastSeen.toISOString());
+  }
 
   // Paginate via nextCursor until a page returns at least one clip ≤ lastSeen
   // (we've walked back past the high-water mark) or we hit maxPages. The feed
@@ -174,12 +183,21 @@ export function startPoller(
   signal: AbortSignal,
 ): Promise<void> {
   return new Promise((resolve) => {
+    // Reentrancy guard: setInterval keeps firing on schedule, but a poll round
+    // can outlast `intervalSeconds` when paginating through a burst or when the
+    // API is slow. Without the guard, two overlapping ticks would re-fetch the
+    // same clips (post-log dedupe still prevents double-sends, but wastes API
+    // calls and creates avoidable DB churn).
+    let inFlight = false;
     const tick = async () => {
-      if (signal.aborted) return;
+      if (signal.aborted || inFlight) return;
+      inFlight = true;
       try {
         await pollOnce(deps);
       } catch (err) {
         deps.log.error('poll round threw', { err: String(err) });
+      } finally {
+        inFlight = false;
       }
     };
 

--- a/discord/src/posting.ts
+++ b/discord/src/posting.ts
@@ -1,0 +1,32 @@
+import type { ClipFeedItem } from './api.ts';
+import type { Subscription } from './db.ts';
+import { shareUrl } from './lib/shareUrl.ts';
+
+// Discord auto-unfurls the share URL into an embed (OG meta tags from
+// ClipsReadEndpoints.GetByShareCode). All we have to do is post a plain message
+// with the URL — no manual EmbedBuilder, no thumbnail download, no S3 round-trip.
+// If the subscription has a ping role, prepend a role mention.
+export function buildMessage(
+  clip: ClipFeedItem,
+  sub: Pick<Subscription, 'pingRoleId'>,
+  publicBase: string,
+): string {
+  const url = shareUrl(clip.shareCode, publicBase);
+  return sub.pingRoleId ? `<@&${sub.pingRoleId}> ${url}` : url;
+}
+
+// Minimal duck-typed sendable: anything with a `send` method that accepts a
+// content payload. Lets the poller pass a real discord.js TextChannel while
+// tests can pass a fake — the caller has already narrowed via isTextBased().
+export type Sendable = {
+  send(payload: {
+    content: string;
+    allowedMentions: { parse: ('roles' | 'users' | 'everyone')[] };
+  }): Promise<unknown>;
+};
+
+export async function postToChannel(channel: Sendable | null, content: string): Promise<boolean> {
+  if (!channel) return false;
+  await channel.send({ content, allowedMentions: { parse: ['roles'] } });
+  return true;
+}

--- a/discord/tests/api.test.ts
+++ b/discord/tests/api.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { createApi } from '../src/api.ts';
+
+// Builds a fake fetch that returns the given JSON body for any URL, capturing
+// every call site for assertions. Lets us cover createApi without touching the
+// network or monkey-patching global.fetch.
+function jsonFetch(body: unknown): typeof fetch & { calls: { url: string; init: RequestInit }[] } {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const f = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: input.toString(), init: init ?? {} });
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+  return Object.assign(f as unknown as typeof fetch, { calls });
+}
+
+function statusFetch(status: number): typeof fetch {
+  return mock(async () => new Response('', { status })) as unknown as typeof fetch;
+}
+
+describe('createApi.getFeed', () => {
+  test('builds the right URL with default query params dropped', async () => {
+    const fetchImpl = jsonFetch({ items: [], nextCursor: null });
+    const api = createApi('http://api.test', fetchImpl);
+    await api.getFeed();
+    expect(fetchImpl.calls).toHaveLength(1);
+    expect(fetchImpl.calls[0]!.url).toBe('http://api.test/clips/feed');
+  });
+
+  test('encodes cursor / limit / sort / window', async () => {
+    const fetchImpl = jsonFetch({ items: [], nextCursor: null });
+    const api = createApi('http://api.test', fetchImpl);
+    await api.getFeed({ cursor: 'abc', limit: 25, sort: 'trending', window: '7d' });
+    const url = new URL(fetchImpl.calls[0]!.url);
+    expect(url.searchParams.get('cursor')).toBe('abc');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('sort')).toBe('trending');
+    expect(url.searchParams.get('window')).toBe('7d');
+  });
+
+  test('handles a baseUrl with a trailing slash', async () => {
+    const fetchImpl = jsonFetch({ items: [], nextCursor: null });
+    const api = createApi('http://api.test/', fetchImpl);
+    await api.getFeed();
+    expect(fetchImpl.calls[0]!.url).toBe('http://api.test/clips/feed');
+  });
+
+  test('throws with status code in the message when the server returns non-2xx', async () => {
+    const api = createApi('http://api.test', statusFetch(503));
+    await expect(api.getFeed()).rejects.toThrow(/→ 503/);
+  });
+});
+
+describe('createApi.getClipsForGame', () => {
+  test('URL-encodes the slug', async () => {
+    const fetchImpl = jsonFetch({ items: [], nextCursor: null });
+    const api = createApi('http://api.test', fetchImpl);
+    await api.getClipsForGame('counter-strike 2');
+    expect(fetchImpl.calls[0]!.url).toBe('http://api.test/games/counter-strike%202/clips');
+  });
+
+  test('forwards an optional limit', async () => {
+    const fetchImpl = jsonFetch({ items: [], nextCursor: null });
+    const api = createApi('http://api.test', fetchImpl);
+    await api.getClipsForGame('valorant', { limit: 5 });
+    expect(new URL(fetchImpl.calls[0]!.url).searchParams.get('limit')).toBe('5');
+  });
+});
+
+describe('createApi.search', () => {
+  test("defaults type to 'clips' when omitted", async () => {
+    const fetchImpl = jsonFetch({ clips: [], games: [] });
+    const api = createApi('http://api.test', fetchImpl);
+    await api.search('flick');
+    const url = new URL(fetchImpl.calls[0]!.url);
+    expect(url.searchParams.get('q')).toBe('flick');
+    expect(url.searchParams.get('type')).toBe('clips');
+  });
+
+  test('preserves an explicit type override', async () => {
+    const fetchImpl = jsonFetch({ clips: [], games: [] });
+    const api = createApi('http://api.test', fetchImpl);
+    await api.search('flick', { type: 'games' });
+    expect(new URL(fetchImpl.calls[0]!.url).searchParams.get('type')).toBe('games');
+  });
+});
+
+describe('createApi.listGames', () => {
+  test('only emits hasClips when truthy (avoids hasClips=false in the URL)', async () => {
+    const fetchImpl = jsonFetch([]);
+    const api = createApi('http://api.test', fetchImpl);
+    await api.listGames({ hasClips: false });
+    const url = new URL(fetchImpl.calls[0]!.url);
+    expect(url.searchParams.has('hasClips')).toBe(false);
+  });
+
+  test('emits hasClips=true when requested', async () => {
+    const fetchImpl = jsonFetch([]);
+    const api = createApi('http://api.test', fetchImpl);
+    await api.listGames({ hasClips: true });
+    expect(new URL(fetchImpl.calls[0]!.url).searchParams.get('hasClips')).toBe('true');
+  });
+
+  test('drops empty-string search values', async () => {
+    const fetchImpl = jsonFetch([]);
+    const api = createApi('http://api.test', fetchImpl);
+    await api.listGames({ search: '' });
+    expect(new URL(fetchImpl.calls[0]!.url).searchParams.has('search')).toBe(false);
+  });
+});
+
+describe('createApi timeout', () => {
+  test('throws a clear timeout error when AbortSignal.timeout fires', async () => {
+    // Fake fetch that respects the AbortSignal — resolves "never" but rejects
+    // when the signal aborts. Mirrors what global fetch does internally.
+    const slowFetch: typeof fetch = ((_url: string | URL | Request, init?: RequestInit) =>
+      new Promise((_, reject) => {
+        const signal = init?.signal;
+        if (!signal) return; // hang forever
+        signal.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'TimeoutError';
+          reject(err);
+        });
+      })) as unknown as typeof fetch;
+    const api = createApi('http://api.test', slowFetch);
+    await expect(api.getFeed({ timeoutMs: 10 })).rejects.toThrow(/timed out after 10ms/);
+  });
+
+  test('honours per-call timeoutMs override (autocomplete uses this)', async () => {
+    let observedTimeout = 0;
+    const inspectFetch: typeof fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      // AbortSignal.timeout produces a signal with the abort firing after N ms.
+      // We can't read the ms directly but can fingerprint it by racing setTimeout.
+      const signal = init?.signal;
+      if (signal) {
+        const started = Date.now();
+        signal.addEventListener('abort', () => {
+          observedTimeout = Date.now() - started;
+        });
+      }
+      void url;
+      return Promise.resolve(new Response('[]', { status: 200 }));
+    }) as unknown as typeof fetch;
+    const api = createApi('http://api.test', inspectFetch);
+    await api.listGames({ timeoutMs: 2500 });
+    // Can't assert exact ms (abort never fired because we resolved fast); but
+    // the call completed without throwing — the path through the timeout
+    // option is exercised. The actual abort firing is covered by the
+    // throws-clear-timeout test above.
+    expect(observedTimeout).toBe(0);
+  });
+});

--- a/discord/tests/commands/clip.test.ts
+++ b/discord/tests/commands/clip.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+import { command } from '../../src/commands/clip.ts';
+import { commandDefinitions, dispatchChatInput, commands } from '../../src/commands/index.ts';
+import { clip } from '../factories.ts';
+import { ctx, fakeApi, fakeAutocomplete, fakeChatInput } from './helpers.ts';
+
+describe('/clip latest', () => {
+  test('posts the share URL of the latest feed clip', async () => {
+    const c = clip({ shareCode: 'top1' });
+    const c2 = clip({ shareCode: 'top2' });
+    const f = fakeChatInput({ subcommand: 'latest' });
+    const context = ctx({
+      api: fakeApi({
+        getFeed: async () => ({ items: [c, c2], nextCursor: null }),
+      }),
+    });
+
+    await command.execute(f.interaction, context);
+    expect(f.wasDeferred()).toBe(true);
+    expect(f.replies[0]?.payload).toBe('https://gankedtv.com/c/top1');
+  });
+
+  test('replies with "no clips" when feed is empty', async () => {
+    const f = fakeChatInput({ subcommand: 'latest' });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toBe('No clips found.');
+  });
+
+  test('uses /games/{slug}/clips when game filter is set', async () => {
+    const c = clip({ shareCode: 'gamed' });
+    const f = fakeChatInput({ subcommand: 'latest', strings: { game: 'valorant' } });
+    const called: { slug?: string } = {};
+    const context = ctx({
+      api: fakeApi({
+        getClipsForGame: async (slug) => {
+          called.slug = slug;
+          return { items: [c], nextCursor: null };
+        },
+      }),
+    });
+    await command.execute(f.interaction, context);
+    expect(called.slug).toBe('valorant');
+    expect(f.replies[0]?.payload).toBe('https://gankedtv.com/c/gamed');
+  });
+
+  test('/clip latest game filter with no results returns specific message', async () => {
+    const f = fakeChatInput({ subcommand: 'latest', strings: { game: 'apex' } });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toBe('No clips found for **apex**.');
+  });
+});
+
+describe('/clip top', () => {
+  test('uses trending sort with the requested window', async () => {
+    const c = clip({ shareCode: 'trnd' });
+    const f = fakeChatInput({ subcommand: 'top', strings: { window: '7d' } });
+    let captured: { sort?: string; window?: string } = {};
+    const context = ctx({
+      api: fakeApi({
+        getFeed: async (opts) => {
+          captured = { sort: opts?.sort, window: opts?.window };
+          return { items: [c], nextCursor: null };
+        },
+      }),
+    });
+    await command.execute(f.interaction, context);
+    expect(captured).toEqual({ sort: 'trending', window: '7d' });
+    expect(f.replies[0]?.payload).toBe('https://gankedtv.com/c/trnd');
+  });
+
+  test('defaults to 24h window', async () => {
+    const f = fakeChatInput({ subcommand: 'top' });
+    const captured: { window?: string } = {};
+    const context = ctx({
+      api: fakeApi({
+        getFeed: async (opts) => {
+          captured.window = opts?.window;
+          return { items: [], nextCursor: null };
+        },
+      }),
+    });
+    await command.execute(f.interaction, context);
+    expect(captured.window).toBe('24h');
+    expect(f.replies[0]?.payload).toBe('No trending clips in the last 24h.');
+  });
+});
+
+describe('/clip search', () => {
+  test('posts the top search result', async () => {
+    const c = clip({ shareCode: 'srch' });
+    const f = fakeChatInput({ subcommand: 'search', strings: { query: 'flick' } });
+    const context = ctx({
+      api: fakeApi({
+        search: async () => ({ clips: [c], games: [] }),
+      }),
+    });
+    await command.execute(f.interaction, context);
+    expect(f.replies[0]?.payload).toBe('https://gankedtv.com/c/srch');
+  });
+
+  test('search with no results returns user-facing message', async () => {
+    const f = fakeChatInput({ subcommand: 'search', strings: { query: 'xyzzy' } });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toBe('No clips matched "xyzzy".');
+  });
+});
+
+describe('/clip unknown subcommand', () => {
+  test('replies ephemerally', async () => {
+    const f = fakeChatInput({ subcommand: 'whatever' });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.phase).toBe('reply');
+  });
+});
+
+describe('/clip autocomplete', () => {
+  test('returns slug-keyed options for game field', async () => {
+    const a = fakeAutocomplete({ name: 'game', value: 'val' });
+    const context = ctx({
+      api: fakeApi({
+        listGames: async () => [
+          { id: 1, name: 'Valorant', slug: 'valorant', tag: 'val', coverUrl: null },
+        ],
+      }),
+    });
+    await command.autocomplete!(a.interaction, context);
+    expect(a.responses[0]).toEqual([{ name: 'Valorant', value: 'valorant' }]);
+  });
+
+  test('ignores autocomplete for non-game fields', async () => {
+    const a = fakeAutocomplete({ name: 'window', value: '2' });
+    await command.autocomplete!(a.interaction, ctx());
+    expect(a.responses).toHaveLength(0);
+  });
+});
+
+describe('registry', () => {
+  test('exposes /clip and /gankedtv', () => {
+    expect(Object.keys(commands).sort()).toEqual(['clip', 'gankedtv']);
+    const defs = commandDefinitions();
+    expect(defs).toHaveLength(2);
+    expect(defs.map((d) => d.name).sort()).toEqual(['clip', 'gankedtv']);
+  });
+
+  test('dispatchChatInput routes by command name', async () => {
+    const c = clip({ shareCode: 'route' });
+    const f = fakeChatInput({ subcommand: 'latest' });
+    (f.interaction as unknown as { commandName: string }).commandName = 'clip';
+    const context = ctx({
+      api: fakeApi({ getFeed: async () => ({ items: [c], nextCursor: null }) }),
+    });
+    await dispatchChatInput(f.interaction, context);
+    expect(f.replies[0]?.payload).toBe('https://gankedtv.com/c/route');
+  });
+
+  test('dispatchChatInput replies on unknown command', async () => {
+    const f = fakeChatInput({ subcommand: 'noop' });
+    (f.interaction as unknown as { commandName: string }).commandName = 'nope';
+    await dispatchChatInput(f.interaction, ctx());
+    expect(f.replies[0]?.phase).toBe('reply');
+  });
+});

--- a/discord/tests/commands/gankedtv.test.ts
+++ b/discord/tests/commands/gankedtv.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from 'bun:test';
+import { command } from '../../src/commands/gankedtv.ts';
+import { dispatchAutocomplete } from '../../src/commands/index.ts';
+import { subscription } from '../factories.ts';
+import { ctx, fakeApi, fakeAutocomplete, fakeChatInput, fakeDb } from './helpers.ts';
+
+describe('/gankedtv subscribe', () => {
+  test('mutation requires ManageChannels', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe', hasManageChannels: false });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toMatchObject({
+      content: expect.stringContaining('Manage Channels'),
+    });
+  });
+
+  test('all-filters-null subscribe records the firehose', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe' });
+    let inserted: unknown = null;
+    const db = fakeDb({
+      addSubscription: async (input) => {
+        inserted = input;
+        return subscription({ ...input });
+      },
+    });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(inserted).toMatchObject({ gameId: null, creatorId: null });
+    expect(f.replies[0]?.payload).toMatch(/Subscribed.*all clips/);
+  });
+
+  test('duplicate subscribe reports already-subscribed', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe' });
+    const db = fakeDb({ addSubscription: async () => null });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toMatch(/already subscribed/);
+  });
+
+  test('game filter resolves via search when name passed', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe', strings: { game: 'valorant' } });
+    const captured: { gameId: number | null } = { gameId: null };
+    const db = fakeDb({
+      addSubscription: async (input) => {
+        captured.gameId = input.gameId;
+        return subscription({ ...input });
+      },
+    });
+    const api = fakeApi({
+      listGames: async () => [
+        { id: 42, name: 'Valorant', slug: 'valorant', tag: 'val', coverUrl: null },
+      ],
+    });
+    await command.execute(f.interaction, ctx({ db, api }));
+    expect(captured.gameId).toBe(42);
+    expect(f.replies[0]?.payload).toMatch(/Valorant/);
+  });
+
+  test('exact slug match wins over top name match', async () => {
+    // Autocomplete returned `valorant` (slug). The API returns multiple games
+    // where the top result by name relevance is something else — the resolver
+    // should still pick the exact-slug match.
+    const f = fakeChatInput({ subcommand: 'subscribe', strings: { game: 'valorant' } });
+    const captured: { gameId: number | null } = { gameId: null };
+    const db = fakeDb({
+      addSubscription: async (input) => {
+        captured.gameId = input.gameId;
+        return subscription({ ...input });
+      },
+    });
+    const api = fakeApi({
+      listGames: async () => [
+        { id: 1, name: 'Valorant Mobile', slug: 'valorant-mobile', tag: 'valm', coverUrl: null },
+        { id: 42, name: 'Valorant', slug: 'valorant', tag: 'val', coverUrl: null },
+      ],
+    });
+    await command.execute(f.interaction, ctx({ db, api }));
+    expect(captured.gameId).toBe(42);
+  });
+
+  test('falls back to top match when no exact slug match', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe', strings: { game: 'val' } });
+    const captured: { gameId: number | null } = { gameId: null };
+    const db = fakeDb({
+      addSubscription: async (input) => {
+        captured.gameId = input.gameId;
+        return subscription({ ...input });
+      },
+    });
+    const api = fakeApi({
+      listGames: async () => [
+        { id: 1, name: 'Valorant', slug: 'valorant', tag: 'val', coverUrl: null },
+      ],
+    });
+    await command.execute(f.interaction, ctx({ db, api }));
+    expect(captured.gameId).toBe(1);
+  });
+
+  test('creator filter validates UUID format and rejects garbage', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe', strings: { creator: 'banana' } });
+    const db = fakeDb({
+      addSubscription: async () => {
+        throw new Error('should not be called');
+      },
+    });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toMatch(/must be a UUID/);
+  });
+
+  test('creator filter accepts valid UUID', async () => {
+    const uuid = '11111111-2222-3333-4444-555555555555';
+    const f = fakeChatInput({ subcommand: 'subscribe', strings: { creator: uuid } });
+    const captured: { creatorId: string | null } = { creatorId: null };
+    const db = fakeDb({
+      addSubscription: async (input) => {
+        captured.creatorId = input.creatorId;
+        return subscription({ ...input });
+      },
+    });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(captured.creatorId).toBe(uuid);
+    expect(f.replies[0]?.payload).toMatch(/creator/);
+  });
+
+  test('game filter with no matches surfaces error to user', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe', strings: { game: 'asdfzzz' } });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toMatch(/No game matched/);
+  });
+});
+
+describe('/gankedtv unsubscribe', () => {
+  test('removes when match exists', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe' });
+    const db = fakeDb({ removeSubscription: async () => 1 });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toBe('Removed 1 subscription.');
+  });
+
+  test('reports no-match when nothing removed', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe' });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toMatch(/No matching subscription/);
+  });
+
+  test('plural messaging for multi-row removal', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe' });
+    const db = fakeDb({ removeSubscription: async () => 3 });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toBe('Removed 3 subscriptions.');
+  });
+
+  test('unresolvable game filter blocks before deletion', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe', strings: { game: 'nonsense' } });
+    const db = fakeDb({
+      removeSubscription: async () => {
+        throw new Error('should not be called');
+      },
+    });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toMatch(/No game matched/);
+  });
+
+  test('invalid creator UUID is rejected before deletion', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe', strings: { creator: 'not-a-uuid' } });
+    const db = fakeDb({
+      removeSubscription: async () => {
+        throw new Error('should not be called');
+      },
+    });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toMatch(/must be a UUID/);
+  });
+});
+
+describe('/gankedtv subscriptions', () => {
+  test('empty channel returns "no subscriptions"', async () => {
+    const f = fakeChatInput({ subcommand: 'subscriptions' });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toMatch(/No subscriptions/);
+  });
+
+  test('formats subscription rows', async () => {
+    const f = fakeChatInput({ subcommand: 'subscriptions' });
+    const db = fakeDb({
+      listSubscriptionsForChannel: async () => [
+        subscription({
+          gameId: 42,
+          creatorId: '99999999-0000-0000-0000-000000000001',
+          pingRoleId: '555',
+          paused: true,
+        }),
+        subscription(),
+      ],
+    });
+    await command.execute(f.interaction, ctx({ db }));
+    const text = String(f.replies[0]?.payload);
+    expect(text).toMatch(/game=42/);
+    expect(text).toMatch(/creator=99999999/);
+    expect(text).toMatch(/ping=<@&555>/);
+    expect(text).toMatch(/paused/);
+    expect(text).toMatch(/game=any/);
+  });
+});
+
+describe('/gankedtv pause + resume', () => {
+  test('pause without subscriptions returns no-op message', async () => {
+    const f = fakeChatInput({ subcommand: 'pause' });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toMatch(/No subscriptions/);
+  });
+
+  test('pause updates and confirms count', async () => {
+    const f = fakeChatInput({ subcommand: 'pause' });
+    const db = fakeDb({ setPaused: async () => 2 });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toBe('Paused 2 subscriptions.');
+  });
+
+  test('resume confirms count', async () => {
+    const f = fakeChatInput({ subcommand: 'resume' });
+    const db = fakeDb({ setPaused: async () => 1 });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toBe('Resumed 1 subscription.');
+  });
+});
+
+describe('/gankedtv DM safety', () => {
+  test('replies ephemerally outside a guild', async () => {
+    const f = fakeChatInput({ subcommand: 'subscribe', guildId: null });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toMatchObject({
+      content: expect.stringContaining('inside a server'),
+    });
+  });
+
+  test('unknown subcommand surfaces ephemeral fallback', async () => {
+    const f = fakeChatInput({ subcommand: 'weird' });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toMatchObject({ content: 'Unknown subcommand.' });
+  });
+});
+
+describe('/gankedtv autocomplete', () => {
+  test('returns slug-keyed options (matches /clip autocomplete)', async () => {
+    const a = fakeAutocomplete({ name: 'game', value: 'val' });
+    const api = fakeApi({
+      listGames: async () => [
+        { id: 1, name: 'Valorant', slug: 'valorant', tag: 'val', coverUrl: null },
+      ],
+    });
+    await command.autocomplete!(a.interaction, ctx({ api }));
+    expect(a.responses[0]).toEqual([{ name: 'Valorant', value: 'valorant' }]);
+  });
+
+  test('skips when focused field is not "game"', async () => {
+    const a = fakeAutocomplete({ name: 'creator', value: 'x' });
+    await command.autocomplete!(a.interaction, ctx());
+    expect(a.responses).toHaveLength(0);
+  });
+
+  test('dispatchAutocomplete forwards to the right command', async () => {
+    const a = fakeAutocomplete({ name: 'game', value: '' });
+    (a.interaction as unknown as { commandName: string }).commandName = 'gankedtv';
+    const api = fakeApi({
+      listGames: async () => [{ id: 7, name: 'CS2', slug: 'cs2', tag: 'cs', coverUrl: null }],
+    });
+    await dispatchAutocomplete(a.interaction, ctx({ api }));
+    expect(a.responses[0]).toEqual([{ name: 'CS2', value: 'cs2' }]);
+  });
+
+  test('dispatchAutocomplete no-ops for unknown command', async () => {
+    const a = fakeAutocomplete({ name: 'game', value: '' });
+    (a.interaction as unknown as { commandName: string }).commandName = 'nope';
+    await dispatchAutocomplete(a.interaction, ctx());
+    expect(a.responses).toHaveLength(0);
+  });
+});

--- a/discord/tests/commands/gankedtv.test.ts
+++ b/discord/tests/commands/gankedtv.test.ts
@@ -168,6 +168,44 @@ describe('/gankedtv unsubscribe', () => {
     await command.execute(f.interaction, ctx({ db }));
     expect(f.replies[0]?.payload).toMatch(/must be a UUID/);
   });
+
+  test('all:true wipes every subscription in the channel', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe', booleans: { all: true } });
+    const db = fakeDb({ removeAllSubscriptionsForChannel: async () => 3 });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toBe('Removed all 3 subscriptions in this channel.');
+  });
+
+  test('all:true on an empty channel says nothing was removed', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe', booleans: { all: true } });
+    await command.execute(f.interaction, ctx());
+    expect(f.replies[0]?.payload).toBe('No subscriptions in this channel.');
+  });
+
+  test('all:true combined with filters is rejected', async () => {
+    const f = fakeChatInput({
+      subcommand: 'unsubscribe',
+      booleans: { all: true },
+      strings: { game: 'valorant' },
+    });
+    const db = fakeDb({
+      removeAllSubscriptionsForChannel: async () => {
+        throw new Error('should not be called');
+      },
+      removeSubscription: async () => {
+        throw new Error('should not be called');
+      },
+    });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toMatch(/Cannot combine `all:true` with/);
+  });
+
+  test('all:false falls through to filtered delete', async () => {
+    const f = fakeChatInput({ subcommand: 'unsubscribe', booleans: { all: false } });
+    const db = fakeDb({ removeSubscription: async () => 1 });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(f.replies[0]?.payload).toBe('Removed 1 subscription.');
+  });
 });
 
 describe('/gankedtv subscriptions', () => {
@@ -177,26 +215,55 @@ describe('/gankedtv subscriptions', () => {
     expect(f.replies[0]?.payload).toMatch(/No subscriptions/);
   });
 
-  test('formats subscription rows', async () => {
+  test('resolves game id to name + slug via the API', async () => {
     const f = fakeChatInput({ subcommand: 'subscriptions' });
     const db = fakeDb({
       listSubscriptionsForChannel: async () => [
+        subscription({ gameId: 42, pingRoleId: '555', paused: true }),
         subscription({
-          gameId: 42,
-          creatorId: '99999999-0000-0000-0000-000000000001',
-          pingRoleId: '555',
-          paused: true,
+          gameId: 99,
+          creatorId: '11111111-2222-3333-4444-555555555555',
         }),
-        subscription(),
+        subscription(), // firehose
       ],
     });
-    await command.execute(f.interaction, ctx({ db }));
+    const api = fakeApi({
+      listGames: async () => [
+        { id: 42, name: 'Valorant', slug: 'valorant', tag: 'val', coverUrl: null },
+        // 99 deliberately missing — exercise the unresolved-id fallback path
+      ],
+    });
+    await command.execute(f.interaction, ctx({ db, api }));
     const text = String(f.replies[0]?.payload);
-    expect(text).toMatch(/game=42/);
-    expect(text).toMatch(/creator=99999999/);
-    expect(text).toMatch(/ping=<@&555>/);
+
+    // Count header
+    expect(text).toMatch(/3 subscriptions in this channel/);
+    // Resolved game (#42)
+    expect(text).toMatch(/Valorant.*valorant/);
+    // Unresolved game (#99) falls back to id
+    expect(text).toMatch(/game id `99`/);
+    // Creator + ping + paused
+    expect(text).toMatch(/creator `11111111/);
+    expect(text).toMatch(/ping <@&555>/);
     expect(text).toMatch(/paused/);
-    expect(text).toMatch(/game=any/);
+    // Firehose row
+    expect(text).toMatch(/all clips/);
+    // Actionable hint mentions both single + bulk removal
+    expect(text).toMatch(/unsubscribe game:<slug>/);
+    expect(text).toMatch(/unsubscribe all:true/);
+  });
+
+  test('singular "1 subscription" header when only one row', async () => {
+    const f = fakeChatInput({ subcommand: 'subscriptions' });
+    const db = fakeDb({ listSubscriptionsForChannel: async () => [subscription()] });
+    await command.execute(f.interaction, ctx({ db }));
+    expect(String(f.replies[0]?.payload)).toMatch(/1 subscription in this channel/);
+  });
+
+  test('empty channel hint mentions /gankedtv subscribe', async () => {
+    const f = fakeChatInput({ subcommand: 'subscriptions' });
+    await command.execute(f.interaction, ctx());
+    expect(String(f.replies[0]?.payload)).toMatch(/Use `\/gankedtv subscribe`/);
   });
 });
 

--- a/discord/tests/commands/helpers.ts
+++ b/discord/tests/commands/helpers.ts
@@ -15,6 +15,7 @@ import type { Db, Subscription } from '../../src/db.ts';
 export type FakeChatInputOpts = {
   subcommand: string;
   strings?: Record<string, string | null>;
+  booleans?: Record<string, boolean | null>;
   roles?: Record<string, { id: string } | null>;
   guildId?: string | null;
   channelId?: string;
@@ -47,6 +48,11 @@ export function fakeChatInput(opts: FakeChatInputOpts) {
       getString: (name: string, required?: boolean) => {
         const v = opts.strings?.[name] ?? null;
         if (required && v === null) throw new Error(`required string '${name}' missing`);
+        return v;
+      },
+      getBoolean: (name: string, required?: boolean) => {
+        const v = opts.booleans?.[name] ?? null;
+        if (required && v === null) throw new Error(`required boolean '${name}' missing`);
         return v;
       },
       getRole: (name: string) => opts.roles?.[name] ?? null,
@@ -110,6 +116,9 @@ export function fakeDb(overrides: Partial<Db> = {}): Db {
       return null;
     },
     async removeSubscription() {
+      return 0;
+    },
+    async removeAllSubscriptionsForChannel() {
       return 0;
     },
     async listSubscriptionsForChannel() {

--- a/discord/tests/commands/helpers.ts
+++ b/discord/tests/commands/helpers.ts
@@ -5,13 +5,7 @@ import type {
   PermissionsBitField,
 } from 'discord.js';
 import { PermissionFlagsBits } from 'discord.js';
-import type {
-  ApiClient,
-  ClipFeedItem,
-  GameListItem,
-  SearchResponse,
-  ClipFeedResponse,
-} from '../../src/api.ts';
+import type { ApiClient, GameListItem, SearchResponse, ClipFeedResponse } from '../../src/api.ts';
 import type { CommandContext } from '../../src/commands/index.ts';
 import type { Db, Subscription } from '../../src/db.ts';
 
@@ -145,8 +139,4 @@ export function ctx(over: Partial<CommandContext> = {}): CommandContext {
     api: over.api ?? fakeApi(),
     publicBase: over.publicBase ?? 'https://gankedtv.com',
   };
-}
-
-export function asClipFeedItem(c: ClipFeedItem): ClipFeedItem {
-  return c;
 }

--- a/discord/tests/commands/helpers.ts
+++ b/discord/tests/commands/helpers.ts
@@ -1,0 +1,152 @@
+import { mock } from 'bun:test';
+import type {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  PermissionsBitField,
+} from 'discord.js';
+import { PermissionFlagsBits } from 'discord.js';
+import type {
+  ApiClient,
+  ClipFeedItem,
+  GameListItem,
+  SearchResponse,
+  ClipFeedResponse,
+} from '../../src/api.ts';
+import type { CommandContext } from '../../src/commands/index.ts';
+import type { Db, Subscription } from '../../src/db.ts';
+
+// Hand-rolled mock interaction. We mock only the surface the command handlers
+// actually touch, so a discord.js version bump that adds new methods doesn't
+// silently make these tests pass for the wrong reason.
+export type FakeChatInputOpts = {
+  subcommand: string;
+  strings?: Record<string, string | null>;
+  roles?: Record<string, { id: string } | null>;
+  guildId?: string | null;
+  channelId?: string;
+  userId?: string;
+  hasManageChannels?: boolean;
+};
+
+export function fakeChatInput(opts: FakeChatInputOpts) {
+  const replies: { phase: 'reply' | 'editReply'; payload: unknown }[] = [];
+  let deferred = false;
+
+  const memberPermissions =
+    opts.hasManageChannels === false
+      ? ({
+          has: (flag: bigint) => flag !== PermissionFlagsBits.ManageChannels,
+        } as unknown as PermissionsBitField)
+      : ({ has: () => true } as unknown as PermissionsBitField);
+
+  const interaction = {
+    commandName: 'test',
+    guildId: opts.guildId ?? 'guild-1',
+    channelId: opts.channelId ?? 'channel-1',
+    user: { id: opts.userId ?? 'user-1' },
+    memberPermissions,
+    replied: false,
+    inGuild: () => opts.guildId !== null,
+    isRepliable: () => true,
+    options: {
+      getSubcommand: () => opts.subcommand,
+      getString: (name: string, required?: boolean) => {
+        const v = opts.strings?.[name] ?? null;
+        if (required && v === null) throw new Error(`required string '${name}' missing`);
+        return v;
+      },
+      getRole: (name: string) => opts.roles?.[name] ?? null,
+    },
+    deferReply: mock(async (_opts?: unknown) => {
+      deferred = true;
+      return undefined;
+    }),
+    editReply: mock(async (payload: unknown) => {
+      replies.push({ phase: 'editReply', payload });
+      return undefined;
+    }),
+    reply: mock(async (payload: unknown) => {
+      interaction.replied = true;
+      replies.push({ phase: 'reply', payload });
+      return undefined;
+    }),
+  };
+
+  return {
+    interaction: interaction as unknown as ChatInputCommandInteraction,
+    replies,
+    wasDeferred: () => deferred,
+  };
+}
+
+export function fakeAutocomplete(focused: { name: string; value: string }) {
+  const responses: unknown[] = [];
+  const interaction = {
+    commandName: 'test',
+    options: {
+      getFocused: () => focused,
+    },
+    respond: mock(async (choices: unknown) => {
+      responses.push(choices);
+      return undefined;
+    }),
+  };
+  return {
+    interaction: interaction as unknown as AutocompleteInteraction,
+    responses,
+  };
+}
+
+export function fakeApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  const empty: ClipFeedResponse = { items: [], nextCursor: null };
+  return {
+    getFeed: async () => empty,
+    getClipsForGame: async () => empty,
+    search: async (): Promise<SearchResponse> => ({ clips: [], games: [] }),
+    listGames: async (): Promise<GameListItem[]> => [],
+    ...overrides,
+  };
+}
+
+export function fakeDb(overrides: Partial<Db> = {}): Db {
+  return {
+    sql: null as never,
+    async close() {},
+    async addSubscription() {
+      return null;
+    },
+    async removeSubscription() {
+      return 0;
+    },
+    async listSubscriptionsForChannel() {
+      return [] as Subscription[];
+    },
+    async listAllSubscriptions() {
+      return [];
+    },
+    async setPaused() {
+      return 0;
+    },
+    async isPosted() {
+      return false;
+    },
+    async recordPost() {},
+    async getState() {
+      return null;
+    },
+    async setState() {},
+    ...overrides,
+  };
+}
+
+export function ctx(over: Partial<CommandContext> = {}): CommandContext {
+  return {
+    db: over.db ?? fakeDb(),
+    api: over.api ?? fakeApi(),
+    publicBase: over.publicBase ?? 'https://gankedtv.com',
+  };
+}
+
+export function asClipFeedItem(c: ClipFeedItem): ClipFeedItem {
+  return c;
+}

--- a/discord/tests/config.test.ts
+++ b/discord/tests/config.test.ts
@@ -23,6 +23,20 @@ describe('loadConfig', () => {
     expect(cfg.enabled).toBe(true);
   });
 
+  test('disabled when token is explicitly empty (shell `VAR=` syntax)', () => {
+    // Reproduces `env DISCORD_BOT_TOKEN= bun run src/index.ts` — shells encode
+    // "unset" as an empty string. The schema must accept this and the enabled
+    // check must treat it as off, otherwise the disabled-boot contract from
+    // .env.example (which ships empty placeholders) throws ZodError at startup.
+    const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: '', DISCORD_BOT_APP_ID: '' });
+    expect(cfg.enabled).toBe(false);
+  });
+
+  test('disabled when only one of the credentials is empty', () => {
+    const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't', DISCORD_BOT_APP_ID: '' });
+    expect(cfg.enabled).toBe(false);
+  });
+
   test('poll interval defaults to 30s', () => {
     const cfg = loadConfig({ ...baseEnv });
     expect(cfg.DISCORD_POLL_INTERVAL_SECONDS).toBe(30);

--- a/discord/tests/config.test.ts
+++ b/discord/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 import { loadConfig } from '../src/config.ts';
 
 const baseEnv: NodeJS.ProcessEnv = {
@@ -14,8 +14,15 @@ describe('loadConfig', () => {
   });
 
   test('disabled when only the token is set', () => {
-    const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't' });
-    expect(cfg.enabled).toBe(false);
+    // Expected partial-config warn — silenced for output cleanliness; the warn
+    // itself is asserted in the dedicated test below.
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't' });
+      expect(cfg.enabled).toBe(false);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   test('enabled when token AND app id are present', () => {
@@ -33,8 +40,42 @@ describe('loadConfig', () => {
   });
 
   test('disabled when only one of the credentials is empty', () => {
-    const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't', DISCORD_BOT_APP_ID: '' });
-    expect(cfg.enabled).toBe(false);
+    // Silence the expected partial-config warn so it doesn't pollute test
+    // output; the warn behavior is asserted in its own test below.
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't', DISCORD_BOT_APP_ID: '' });
+      expect(cfg.enabled).toBe(false);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('emits a structured warn line when only one half of the credential pair is set', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't', DISCORD_BOT_APP_ID: '' });
+      expect(warn).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(warn.mock.calls[0]![0] as string);
+      expect(payload).toMatchObject({
+        level: 'warn',
+        hasToken: true,
+        hasAppId: false,
+      });
+      expect(payload.msg).toMatch(/partial/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('no warn line when BOTH credentials are absent (intentional off-by-default)', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      loadConfig({ ...baseEnv });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   test('poll interval defaults to 30s', () => {

--- a/discord/tests/config.test.ts
+++ b/discord/tests/config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { loadConfig } from '../src/config.ts';
+
+const baseEnv: NodeJS.ProcessEnv = {
+  DISCORD_DATABASE_URL: 'postgres://x@localhost:5432/x',
+  GANKEDTV_API_BASE: 'http://api.test',
+  GANKEDTV_PUBLIC_BASE: 'http://web.test',
+};
+
+describe('loadConfig', () => {
+  test('disabled when token/app id missing', () => {
+    const cfg = loadConfig({ ...baseEnv });
+    expect(cfg.enabled).toBe(false);
+  });
+
+  test('disabled when only the token is set', () => {
+    const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't' });
+    expect(cfg.enabled).toBe(false);
+  });
+
+  test('enabled when token AND app id are present', () => {
+    const cfg = loadConfig({ ...baseEnv, DISCORD_BOT_TOKEN: 't', DISCORD_BOT_APP_ID: 'a' });
+    expect(cfg.enabled).toBe(true);
+  });
+
+  test('poll interval defaults to 30s', () => {
+    const cfg = loadConfig({ ...baseEnv });
+    expect(cfg.DISCORD_POLL_INTERVAL_SECONDS).toBe(30);
+  });
+
+  test('poll interval reads numeric env override', () => {
+    const cfg = loadConfig({ ...baseEnv, DISCORD_POLL_INTERVAL_SECONDS: '120' });
+    expect(cfg.DISCORD_POLL_INTERVAL_SECONDS).toBe(120);
+  });
+
+  test('DISCORD_DATABASE_URL is required', () => {
+    expect(() => loadConfig({})).toThrow();
+  });
+});

--- a/discord/tests/factories.ts
+++ b/discord/tests/factories.ts
@@ -1,0 +1,45 @@
+import type { ClipFeedItem } from '../src/api.ts';
+import type { Subscription } from '../src/db.ts';
+
+let clipSeq = 0;
+let subSeq = 0;
+
+export const clip = (overrides: Partial<ClipFeedItem> = {}): ClipFeedItem => {
+  const n = ++clipSeq;
+  return {
+    id: `00000000-0000-0000-0000-${String(n).padStart(12, '0')}`,
+    shareCode: `code${String(n).padStart(4, '0')}`,
+    title: `Clip ${n}`,
+    description: null,
+    thumbnailUrl: `https://example.test/thumb/${n}.jpg`,
+    durationSecs: 30,
+    viewCount: 0,
+    likeCount: 0,
+    createdAt: new Date(2026, 0, 1, 0, 0, n).toISOString(),
+    author: {
+      id: `11111111-0000-0000-0000-${String(n).padStart(12, '0')}`,
+      username: `user${n}`,
+      avatarUrl: null,
+    },
+    game: { id: 100 + n, name: `Game ${n}`, slug: `game-${n}`, tag: `g${n}` },
+    tags: [],
+    likedByMe: false,
+    ...overrides,
+  };
+};
+
+export const subscription = (overrides: Partial<Subscription> = {}): Subscription => {
+  const n = ++subSeq;
+  return {
+    id: `22222222-0000-0000-0000-${String(n).padStart(12, '0')}`,
+    guildId: `guild-${n}`,
+    channelId: `channel-${n}`,
+    gameId: null,
+    creatorId: null,
+    paused: false,
+    pingRoleId: null,
+    createdAt: new Date(2026, 0, 1, 0, 0, n),
+    createdBy: `user-${n}`,
+    ...overrides,
+  };
+};

--- a/discord/tests/filters.test.ts
+++ b/discord/tests/filters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import { matchingSubscriptions, subscriptionMatchesClip } from '../src/filters.ts';
+import { clip, subscription } from './factories.ts';
+
+describe('subscriptionMatchesClip', () => {
+  test('no-filter subscription matches any clip', () => {
+    const sub = subscription();
+    const c = clip();
+    expect(subscriptionMatchesClip(sub, c)).toBe(true);
+  });
+
+  test('paused subscription never matches', () => {
+    const sub = subscription({ paused: true });
+    const c = clip();
+    expect(subscriptionMatchesClip(sub, c)).toBe(false);
+  });
+
+  test('game filter blocks non-matching game', () => {
+    const sub = subscription({ gameId: 999 });
+    const c = clip({ game: { id: 1, name: 'X', slug: 'x', tag: 'x' } });
+    expect(subscriptionMatchesClip(sub, c)).toBe(false);
+  });
+
+  test('game filter matches when ids align', () => {
+    const sub = subscription({ gameId: 42 });
+    const c = clip({ game: { id: 42, name: 'X', slug: 'x', tag: 'x' } });
+    expect(subscriptionMatchesClip(sub, c)).toBe(true);
+  });
+
+  test('game filter blocks clips with no game when filter is set', () => {
+    const sub = subscription({ gameId: 1 });
+    const c = clip({ game: null });
+    expect(subscriptionMatchesClip(sub, c)).toBe(false);
+  });
+
+  test('creator filter blocks non-matching creator', () => {
+    const sub = subscription({ creatorId: '33333333-0000-0000-0000-000000000001' });
+    const c = clip({
+      author: { id: '44444444-0000-0000-0000-000000000001', username: 'x', avatarUrl: null },
+    });
+    expect(subscriptionMatchesClip(sub, c)).toBe(false);
+  });
+
+  test('creator filter matches when ids align', () => {
+    const userId = '33333333-0000-0000-0000-000000000001';
+    const sub = subscription({ creatorId: userId });
+    const c = clip({ author: { id: userId, username: 'x', avatarUrl: null } });
+    expect(subscriptionMatchesClip(sub, c)).toBe(true);
+  });
+
+  test('game AND creator filters both required', () => {
+    const userId = '33333333-0000-0000-0000-000000000001';
+    const sub = subscription({ gameId: 7, creatorId: userId });
+    const matching = clip({
+      game: { id: 7, name: 'X', slug: 'x', tag: 'x' },
+      author: { id: userId, username: 'x', avatarUrl: null },
+    });
+    const wrongGame = clip({
+      game: { id: 8, name: 'X', slug: 'x', tag: 'x' },
+      author: { id: userId, username: 'x', avatarUrl: null },
+    });
+    expect(subscriptionMatchesClip(sub, matching)).toBe(true);
+    expect(subscriptionMatchesClip(sub, wrongGame)).toBe(false);
+  });
+});
+
+describe('matchingSubscriptions', () => {
+  test('returns only subscriptions whose filters allow the clip', () => {
+    const c = clip({
+      game: { id: 5, name: 'X', slug: 'x', tag: 'x' },
+      author: { id: '55555555-0000-0000-0000-000000000001', username: 'x', avatarUrl: null },
+    });
+    const subs = [
+      subscription(),
+      subscription({ gameId: 5 }),
+      subscription({ gameId: 6 }),
+      subscription({ paused: true }),
+    ];
+    const matches = matchingSubscriptions(subs, c);
+    expect(matches).toHaveLength(2);
+    expect(matches[0]).toBe(subs[0]!);
+    expect(matches[1]).toBe(subs[1]!);
+  });
+});

--- a/discord/tests/loadEnv.test.ts
+++ b/discord/tests/loadEnv.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadRootEnv, mergeFirstWins, parseEnvFile } from '../src/loadEnv.ts';
+
+describe('parseEnvFile', () => {
+  test('parses KEY=value pairs', () => {
+    expect(parseEnvFile('FOO=bar\nBAZ=qux')).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('skips blank lines and # comments', () => {
+    const text = `# a comment\n\nFOO=1\n  # indented comment\nBAR=2`;
+    expect(parseEnvFile(text)).toEqual({ FOO: '1', BAR: '2' });
+  });
+
+  test('strips surrounding double quotes', () => {
+    expect(parseEnvFile('FOO="hello world"')).toEqual({ FOO: 'hello world' });
+  });
+
+  test('strips surrounding single quotes', () => {
+    expect(parseEnvFile("FOO='hello'")).toEqual({ FOO: 'hello' });
+  });
+
+  test('trims whitespace around key and value', () => {
+    expect(parseEnvFile('  FOO  =  bar  ')).toEqual({ FOO: 'bar' });
+  });
+
+  test('skips lines with no equals sign', () => {
+    expect(parseEnvFile('FOO=bar\nbroken-line\nBAZ=qux')).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('skips lines starting with =', () => {
+    expect(parseEnvFile('=nope\nFOO=bar')).toEqual({ FOO: 'bar' });
+  });
+
+  test('preserves = inside values (only splits on first)', () => {
+    expect(parseEnvFile('CONN=Host=localhost;Port=5432')).toEqual({
+      CONN: 'Host=localhost;Port=5432',
+    });
+  });
+});
+
+describe('mergeFirstWins', () => {
+  test('sets keys that are absent from target', () => {
+    const target: Record<string, string | undefined> = { A: '1' };
+    mergeFirstWins(target, { B: '2' });
+    expect(target).toEqual({ A: '1', B: '2' });
+  });
+
+  test('does NOT overwrite existing keys (first-set wins)', () => {
+    const target: Record<string, string | undefined> = { A: 'shell' };
+    mergeFirstWins(target, { A: 'file' });
+    expect(target.A).toBe('shell');
+  });
+
+  test('treats explicit undefined as absent', () => {
+    const target: Record<string, string | undefined> = { A: undefined };
+    mergeFirstWins(target, { A: 'fallback' });
+    // 'A' is "in" the object but is undefined — we want fallback to apply here
+    // because that's how shell env behaves (unset vs set-to-empty differ).
+    // The simple `key in target` check intentionally keeps undefined as present
+    // to match Node's process.env semantics — document the choice with a test.
+    expect(target.A).toBeUndefined();
+  });
+});
+
+describe('loadRootEnv', () => {
+  test('no-ops when the file does not exist', () => {
+    const target: Record<string, string | undefined> = { FOO: 'kept' };
+    loadRootEnv('/tmp/this-file-does-not-exist-' + Math.random(), target);
+    expect(target).toEqual({ FOO: 'kept' });
+  });
+
+  test('merges a real file with first-set-wins semantics', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gktv-env-'));
+    const path = join(dir, '.env');
+    try {
+      writeFileSync(path, 'NEW_KEY=fromfile\nSHELL_KEY=shouldbeignored\n');
+      const target: Record<string, string | undefined> = { SHELL_KEY: 'shell' };
+      loadRootEnv(path, target);
+      expect(target.NEW_KEY).toBe('fromfile');
+      expect(target.SHELL_KEY).toBe('shell');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/discord/tests/loadEnv.test.ts
+++ b/discord/tests/loadEnv.test.ts
@@ -54,13 +54,14 @@ describe('mergeFirstWins', () => {
     expect(target.A).toBe('shell');
   });
 
-  test('treats explicit undefined as absent', () => {
+  test('explicit undefined counts as present (fallback does NOT override)', () => {
     const target: Record<string, string | undefined> = { A: undefined };
     mergeFirstWins(target, { A: 'fallback' });
-    // 'A' is "in" the object but is undefined — we want fallback to apply here
-    // because that's how shell env behaves (unset vs set-to-empty differ).
-    // The simple `key in target` check intentionally keeps undefined as present
-    // to match Node's process.env semantics — document the choice with a test.
+    // `'A' in target` is true even though A === undefined, so the first-set-wins
+    // check considers A "already set" and skips the fallback. Mirrors Node's
+    // process.env: setting `process.env.X = undefined` is distinct from never
+    // setting X at all (the former keeps the slot, the latter leaves it free
+    // for a downstream merge to fill).
     expect(target.A).toBeUndefined();
   });
 });

--- a/discord/tests/poller.test.ts
+++ b/discord/tests/poller.test.ts
@@ -1,0 +1,501 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { pollOnce, startPoller, type Fanout, type PollerLogger } from '../src/poller.ts';
+import type { ApiClient, ClipFeedItem, ClipFeedResponse } from '../src/api.ts';
+import type { Db, Subscription } from '../src/db.ts';
+import { clip, subscription } from './factories.ts';
+
+const silentLog: PollerLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+type StubDbState = {
+  state: Map<string, string>;
+  subs: Subscription[];
+  postLog: Set<string>;
+};
+
+function stubDb(initial: Partial<StubDbState> = {}): Db & { _state: StubDbState } {
+  const s: StubDbState = {
+    state: initial.state ?? new Map(),
+    subs: initial.subs ?? [],
+    postLog: initial.postLog ?? new Set(),
+  };
+  return {
+    _state: s,
+    sql: null as never,
+    async close() {},
+    async addSubscription() {
+      throw new Error('not used in poller tests');
+    },
+    async removeSubscription() {
+      return 0;
+    },
+    async listSubscriptionsForChannel() {
+      return [];
+    },
+    async listAllSubscriptions() {
+      return s.subs.filter((sub) => !sub.paused);
+    },
+    async setPaused() {
+      return 0;
+    },
+    async isPosted(channelId, clipId) {
+      return s.postLog.has(`${channelId}:${clipId}`);
+    },
+    async recordPost(channelId, clipId) {
+      s.postLog.add(`${channelId}:${clipId}`);
+    },
+    async getState(key) {
+      return s.state.get(key) ?? null;
+    },
+    async setState(key, value) {
+      s.state.set(key, value);
+    },
+  };
+}
+
+// Default API returns a single page with no nextCursor — covers the no-
+// pagination tests. Pagination tests use stubPagedApi below.
+function stubApi(items: ClipFeedItem[]): ApiClient {
+  return {
+    async getFeed(): Promise<ClipFeedResponse> {
+      return { items, nextCursor: null };
+    },
+    async getClipsForGame() {
+      return { items: [], nextCursor: null };
+    },
+    async search() {
+      return { clips: [], games: [] };
+    },
+    async listGames() {
+      return [];
+    },
+  };
+}
+
+// Pagination stub: hand it N pages keyed by cursor (empty-string cursor =
+// initial fetch). Each page has its own nextCursor so the poller walks the
+// chain. Tracks how many pages were actually requested for assertions.
+function stubPagedApi(
+  pages: Map<string, ClipFeedResponse>,
+): ApiClient & { callCount: () => number } {
+  let calls = 0;
+  return {
+    callCount: () => calls,
+    async getFeed(opts) {
+      calls++;
+      const key = opts?.cursor ?? '';
+      const page = pages.get(key);
+      if (!page) throw new Error(`stub: no page for cursor=${key}`);
+      return page;
+    },
+    async getClipsForGame() {
+      return { items: [], nextCursor: null };
+    },
+    async search() {
+      return { clips: [], games: [] };
+    },
+    async listGames() {
+      return [];
+    },
+  };
+}
+
+// Fanout that always succeeds; tracks calls for assertions.
+function okFanout(): Fanout & {
+  calls: { clipId: string; channelId: string; pingRoleId: string | null }[];
+} {
+  const calls: { clipId: string; channelId: string; pingRoleId: string | null }[] = [];
+  const f: Fanout = async (clip, target) => {
+    calls.push({ clipId: clip.id, channelId: target.channelId, pingRoleId: target.pingRoleId });
+    return true;
+  };
+  return Object.assign(f, { calls });
+}
+
+describe('pollOnce', () => {
+  test('first-ever poll seeds the cursor and does not fan out', async () => {
+    const db = stubDb();
+    const fanout = okFanout();
+    const res = await pollOnce({ db, api: stubApi([clip(), clip()]), fanout, log: silentLog });
+    expect(res).toEqual({ fetched: 0, newClips: 0, posts: 0 });
+    expect(fanout.calls).toHaveLength(0);
+    expect(db._state.state.get('last_clip_created_at')).toBeDefined();
+  });
+
+  test('fanout is called per-channel, records post log on success, advances cursor', async () => {
+    const c1 = clip();
+    const c2 = clip();
+    const c3 = clip();
+    const sub = subscription({ channelId: 'C1', pingRoleId: '555' });
+    const db = stubDb({ state: new Map([['last_clip_created_at', c2.createdAt]]), subs: [sub] });
+    // Cursor at c2: with the new `>=` filter, both c2 and c3 are fresh, but c2
+    // ties the cursor exactly. The post log starts empty, so both fan out.
+    const fanout = okFanout();
+
+    const res = await pollOnce({ db, api: stubApi([c3, c2, c1]), fanout, log: silentLog });
+
+    expect(res).toMatchObject({ fetched: 3, newClips: 2, posts: 2 });
+    expect(fanout.calls).toHaveLength(2);
+    // Calls are in chronological order (oldest first) so Discord matches upload order.
+    expect(fanout.calls[0]).toMatchObject({ clipId: c2.id, channelId: 'C1', pingRoleId: '555' });
+    expect(fanout.calls[1]).toMatchObject({ clipId: c3.id, channelId: 'C1', pingRoleId: '555' });
+    expect(db._state.postLog.has(`C1:${c2.id}`)).toBe(true);
+    expect(db._state.postLog.has(`C1:${c3.id}`)).toBe(true);
+    expect(db._state.state.get('last_clip_created_at')).toBe(c3.createdAt);
+  });
+
+  test('isPosted pre-check skips clips already in post log', async () => {
+    const c1 = clip();
+    const c2 = clip();
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [sub],
+      // Pre-existing entry (crashed-mid-fanout restart): isPosted returns true,
+      // so fanout is NOT called and recordPost is NOT re-issued. Cursor still
+      // advances because the clip has been "evaluated".
+      postLog: new Set([`C1:${c2.id}`]),
+    });
+    const fanout = okFanout();
+
+    const res = await pollOnce({ db, api: stubApi([c2]), fanout, log: silentLog });
+    expect(res.posts).toBe(0);
+    expect(fanout.calls).toHaveLength(0);
+    expect(db._state.state.get('last_clip_created_at')).toBe(c2.createdAt);
+  });
+
+  test('fanout returning false does NOT record the post (retry next round)', async () => {
+    const c1 = clip();
+    const c2 = clip();
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [sub],
+    });
+    const fanout: Fanout = async () => false;
+
+    const res = await pollOnce({ db, api: stubApi([c2]), fanout, log: silentLog });
+    expect(res.posts).toBe(0);
+    expect(db._state.postLog.has(`C1:${c2.id}`)).toBe(false);
+    // Cursor still advances — failed sends are retried via isPosted next round
+    // (which will still return false because we never recorded).
+    expect(db._state.state.get('last_clip_created_at')).toBe(c2.createdAt);
+  });
+
+  test('fanout throwing is caught, logged, and treated as a failed send', async () => {
+    const c1 = clip();
+    const c2 = clip();
+    const sub = subscription({ channelId: 'C1' });
+    const errLog = mock(() => {});
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [sub],
+    });
+    const fanout: Fanout = async () => {
+      throw new Error('discord 502');
+    };
+
+    const res = await pollOnce({
+      db,
+      api: stubApi([c2]),
+      fanout,
+      log: { info: () => {}, warn: () => {}, error: errLog },
+    });
+    expect(res.posts).toBe(0);
+    expect(errLog).toHaveBeenCalled();
+    expect(db._state.postLog.has(`C1:${c2.id}`)).toBe(false);
+  });
+
+  test('clips matching no subscription advance the cursor without fanout', async () => {
+    const c1 = clip();
+    const c2 = clip({ game: { id: 999, name: 'X', slug: 'x', tag: 'x' } });
+    const sub = subscription({ channelId: 'C1', gameId: 7 });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [sub],
+    });
+    const fanout = okFanout();
+
+    const res = await pollOnce({ db, api: stubApi([c2]), fanout, log: silentLog });
+    expect(res.newClips).toBe(1);
+    expect(res.posts).toBe(0);
+    expect(fanout.calls).toHaveLength(0);
+    expect(db._state.state.get('last_clip_created_at')).toBe(c2.createdAt);
+  });
+
+  test('zero-fresh-after-cursor poll exits early without consulting subscriptions', async () => {
+    // Cursor anchored AFTER the only feed item; nothing is `>=` lastSeen.
+    const c1 = clip();
+    const cursorAhead = new Date(new Date(c1.createdAt).getTime() + 60_000).toISOString();
+    const listSubsSpy = mock(async () => [] as Subscription[]);
+    const db = stubDb({ state: new Map([['last_clip_created_at', cursorAhead]]) });
+    db.listAllSubscriptions = listSubsSpy;
+
+    const res = await pollOnce({
+      db,
+      api: stubApi([c1]),
+      fanout: okFanout(),
+      log: silentLog,
+    });
+    expect(res).toMatchObject({ fetched: 1, newClips: 0, posts: 0 });
+    expect(listSubsSpy).not.toHaveBeenCalled();
+  });
+
+  test('multiple subscriptions on different channels: one fanout call per (clip, sub)', async () => {
+    const c1 = clip();
+    const c2 = clip();
+    const subA = subscription({ channelId: 'A' });
+    const subB = subscription({ channelId: 'B' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [subA, subB],
+    });
+    const fanout = okFanout();
+
+    const res = await pollOnce({ db, api: stubApi([c2]), fanout, log: silentLog });
+    expect(res.posts).toBe(2);
+    expect(fanout.calls).toHaveLength(2);
+    expect(fanout.calls.map((c) => c.channelId).sort()).toEqual(['A', 'B']);
+  });
+
+  test('recordPost failure after a successful send is logged but does not throw', async () => {
+    // Simulates a DB write hiccup AFTER Discord accepted the message. The send
+    // succeeded so we count the post, but we log a warning because the next
+    // round will see no log entry, isPosted-check will return false, and the
+    // bot will double-post. This is the at-least-once tradeoff being exercised.
+    const c1 = clip();
+    const c2 = clip();
+    const sub = subscription({ channelId: 'C1' });
+    const warnLog = mock(() => {});
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [sub],
+    });
+    db.recordPost = async () => {
+      throw new Error('db write blip');
+    };
+    const fanout = okFanout();
+
+    const res = await pollOnce({
+      db,
+      api: stubApi([c2]),
+      fanout,
+      log: { info: () => {}, warn: warnLog, error: () => {} },
+    });
+    expect(res.posts).toBe(1); // send succeeded → counts
+    expect(warnLog).toHaveBeenCalled();
+  });
+
+  test('partial failure: one sub succeeds, another fails — only the success is recorded', async () => {
+    const c1 = clip();
+    const c2 = clip();
+    const subA = subscription({ channelId: 'A' });
+    const subB = subscription({ channelId: 'B' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [subA, subB],
+    });
+    // Fail the first call (channel A), succeed the second (channel B).
+    let n = 0;
+    const fanout: Fanout = async () => {
+      n++;
+      return n !== 1;
+    };
+
+    const res = await pollOnce({ db, api: stubApi([c2]), fanout, log: silentLog });
+    expect(res.posts).toBe(1);
+    expect(db._state.postLog.has(`A:${c2.id}`)).toBe(false);
+    expect(db._state.postLog.has(`B:${c2.id}`)).toBe(true);
+    // Cursor advances — A will be retried next round (isPosted returns false).
+    expect(db._state.state.get('last_clip_created_at')).toBe(c2.createdAt);
+  });
+});
+
+describe('pollOnce cursor + dedupe boundary cases', () => {
+  test('tied-timestamp clip at the cursor boundary is reprocessed but dedupe blocks the post', async () => {
+    // c1 has the exact same timestamp as the cursor; isPosted returns true
+    // because we already recorded it last round. The `>=` filter brings it
+    // back into `fresh`, but postOne's isPosted check short-circuits.
+    const c1 = clip();
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      subs: [sub],
+      postLog: new Set([`C1:${c1.id}`]),
+    });
+    const fanout = okFanout();
+
+    const res = await pollOnce({ db, api: stubApi([c1]), fanout, log: silentLog });
+    expect(res.posts).toBe(0);
+    expect(fanout.calls).toHaveLength(0);
+  });
+});
+
+describe('pollOnce pagination', () => {
+  test('walks nextCursor when first page is full and all items are fresh', async () => {
+    // Cursor in the distant past — every clip in the feed is fresh.
+    const old = clip();
+    // Page 1: pageSize=2, all fresh, nextCursor='p2'.
+    const a = clip();
+    const b = clip();
+    // Page 2: pageSize=2, mixed (one fresh, one older than cursor) → poller
+    // stops here because the page contains an item ≤ lastSeen.
+    const c = clip();
+    const d = clip(); // older than cursor (simulated by setting cursor to between c and d)
+
+    // Place cursor between c and d so d is the boundary stop.
+    const cursorTs = new Date(
+      (new Date(c.createdAt).getTime() + new Date(d.createdAt).getTime()) / 2,
+    ).toISOString();
+    // Actually: c was created last, so c.createdAt > d.createdAt? No — clip()
+    // increments seq, so later clips have LATER timestamps. Order:
+    // old < a < b < c < d (chronological). Feed is DESC, so first page returns
+    // newest first: [d, c]. Set the cursor so c < cursor < d → only d is fresh.
+    void old;
+    const lastSeen = new Date(
+      (new Date(c.createdAt).getTime() + new Date(d.createdAt).getTime()) / 2,
+    ).toISOString();
+    void cursorTs;
+
+    const pages = new Map<string, ClipFeedResponse>([
+      // Initial fetch: 2 items, both newer than cursor's reference clip 'a'
+      ['', { items: [d, c], nextCursor: 'p2' }],
+      ['p2', { items: [b, a], nextCursor: null }],
+    ]);
+    const api = stubPagedApi(pages);
+    const sub = subscription({ channelId: 'C1' });
+    // Anchor cursor far back so a, b, c are ALL fresh; d is fresh too.
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', new Date(0).toISOString()]]),
+      subs: [sub],
+    });
+    void lastSeen;
+    const fanout = okFanout();
+
+    const res = await pollOnce({
+      db,
+      api,
+      fanout,
+      log: silentLog,
+      pageSize: 2,
+    });
+
+    // 4 fanouts in chronological order: a, b, c, d.
+    expect(res.posts).toBe(4);
+    expect(api.callCount()).toBe(2);
+    expect(fanout.calls.map((c) => c.clipId)).toEqual([a.id, b.id, c.id, d.id]);
+  });
+
+  test('stops paginating when a page contains an item older than the cursor', async () => {
+    const old = clip(); // will be older than cursor
+    const a = clip();
+    const b = clip();
+    const c = clip();
+    const cursor = new Date(
+      (new Date(old.createdAt).getTime() + new Date(a.createdAt).getTime()) / 2,
+    ).toISOString();
+    const pages = new Map<string, ClipFeedResponse>([
+      ['', { items: [c, b], nextCursor: 'p2' }],
+      // Second page contains `old` which is < cursor → poller stops, doesn't
+      // request a third page even if nextCursor is present.
+      ['p2', { items: [a, old], nextCursor: 'p3' }],
+    ]);
+    const api = stubPagedApi(pages);
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', cursor]]),
+      subs: [sub],
+    });
+    const fanout = okFanout();
+
+    const res = await pollOnce({ db, api, fanout, log: silentLog, pageSize: 2 });
+    expect(api.callCount()).toBe(2);
+    expect(res.posts).toBe(3); // a, b, c — not old
+    expect(fanout.calls.map((c) => c.clipId)).toEqual([a.id, b.id, c.id]);
+  });
+
+  test('respects maxPages safety cap', async () => {
+    // Every page is full of fresh items; without the cap the poller would loop
+    // forever. maxPages=2 stops after the second fetch.
+    const a = clip();
+    const b = clip();
+    const c = clip();
+    const d = clip();
+    const pages = new Map<string, ClipFeedResponse>([
+      ['', { items: [d, c], nextCursor: 'p2' }],
+      ['p2', { items: [b, a], nextCursor: 'p3' }],
+      // p3 would be requested without the cap.
+    ]);
+    const api = stubPagedApi(pages);
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', new Date(0).toISOString()]]),
+      subs: [sub],
+    });
+    const fanout = okFanout();
+
+    await pollOnce({ db, api, fanout, log: silentLog, pageSize: 2, maxPages: 2 });
+    expect(api.callCount()).toBe(2);
+  });
+
+  test('de-dupes items that appear on two pages (mid-pagination insert)', async () => {
+    // If a new clip arrives between page-1 and page-2 fetches, the boundary
+    // item can shift onto both pages. We de-dupe by clip id.
+    const a = clip();
+    const b = clip();
+    const pages = new Map<string, ClipFeedResponse>([
+      ['', { items: [b, a], nextCursor: 'p2' }],
+      // a appears again on page 2 (shifted due to mid-fetch insert).
+      ['p2', { items: [a], nextCursor: null }],
+    ]);
+    const api = stubPagedApi(pages);
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', new Date(0).toISOString()]]),
+      subs: [sub],
+    });
+    const fanout = okFanout();
+
+    const res = await pollOnce({ db, api, fanout, log: silentLog, pageSize: 2 });
+    expect(res.posts).toBe(2);
+    expect(fanout.calls.map((c) => c.clipId)).toEqual([a.id, b.id]);
+  });
+});
+
+describe('startPoller', () => {
+  test('runs immediately, then resolves on abort', async () => {
+    const c1 = clip();
+    const db = stubDb({ state: new Map([['last_clip_created_at', c1.createdAt]]) });
+    const fanout = okFanout();
+    const abort = new AbortController();
+    const loopDone = startPoller(
+      { db, api: stubApi([c1]), fanout, log: silentLog },
+      3600,
+      abort.signal,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    abort.abort();
+    await loopDone;
+  });
+
+  test('catches errors thrown by pollOnce so the loop survives', async () => {
+    const errLog = mock(() => {});
+    const log: PollerLogger = { info: () => {}, warn: () => {}, error: errLog };
+    const brokenDb = stubDb();
+    brokenDb.getState = async () => {
+      throw new Error('db blew up');
+    };
+    const abort = new AbortController();
+    const loopDone = startPoller(
+      { db: brokenDb, api: stubApi([]), fanout: okFanout(), log },
+      3600,
+      abort.signal,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    abort.abort();
+    await loopDone;
+
+    expect(errLog).toHaveBeenCalled();
+  });
+});

--- a/discord/tests/poller.test.ts
+++ b/discord/tests/poller.test.ts
@@ -177,33 +177,28 @@ describe('pollOnce', () => {
     expect(db._state.state.get('last_clip_created_at')).toBe(c2.createdAt);
   });
 
-  test('fanout returning false does NOT record the post (retry next round)', async () => {
+  test('fanout returning false does NOT record the post AND halts cursor (M2 from review)', async () => {
+    // The only fresh clip failed → cursor must stay at its predecessor (c1)
+    // so the next round re-evaluates c2. Without the halt, the cursor would
+    // jump past c2 and the failed post would be lost forever.
     const c1 = clip();
     const c2 = clip();
     const sub = subscription({ channelId: 'C1' });
-    const db = stubDb({
-      cursor: c1.createdAt,
-      subs: [sub],
-    });
+    const db = stubDb({ cursor: c1.createdAt, subs: [sub] });
     const fanout: Fanout = async () => false;
 
     const res = await pollOnce({ db, api: stubApi([c2]), fanout, log: silentLog });
     expect(res.posts).toBe(0);
     expect(db._state.postLog.has(`C1:${c2.id}`)).toBe(false);
-    // Cursor still advances — failed sends are retried via isPosted next round
-    // (which will still return false because we never recorded).
-    expect(db._state.state.get('last_clip_created_at')).toBe(c2.createdAt);
+    expect(db._state.state.get('last_clip_created_at')).toBe(c1.createdAt);
   });
 
-  test('fanout throwing is caught, logged, and treated as a failed send', async () => {
+  test('fanout throwing halts the cursor too (same retry semantics as returning false)', async () => {
     const c1 = clip();
     const c2 = clip();
     const sub = subscription({ channelId: 'C1' });
     const errLog = mock(() => {});
-    const db = stubDb({
-      cursor: c1.createdAt,
-      subs: [sub],
-    });
+    const db = stubDb({ cursor: c1.createdAt, subs: [sub] });
     const fanout: Fanout = async () => {
       throw new Error('discord 502');
     };
@@ -217,6 +212,42 @@ describe('pollOnce', () => {
     expect(res.posts).toBe(0);
     expect(errLog).toHaveBeenCalled();
     expect(db._state.postLog.has(`C1:${c2.id}`)).toBe(false);
+    expect(db._state.state.get('last_clip_created_at')).toBe(c1.createdAt);
+  });
+
+  test('partial-failure mid-round: cursor halts at predecessor, later clips still processed', async () => {
+    // Three clips: c1 (succeeds), c2 (fails), c3 (succeeds).
+    // Cursor must halt at c1 so c2 re-runs next round; c3 is still processed
+    // and recorded so we don't artificially drop newer work.
+    const cursor = new Date(0).toISOString();
+    const c1 = clip();
+    const c2 = clip();
+    const c3 = clip();
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({ cursor, subs: [sub] });
+
+    const fanout: Fanout = async (clip) => clip.id !== c2.id;
+
+    const res = await pollOnce({ db, api: stubApi([c3, c2, c1]), fanout, log: silentLog });
+
+    expect(res.posts).toBe(2); // c1 + c3 sent
+    expect(db._state.postLog.has(`C1:${c1.id}`)).toBe(true);
+    expect(db._state.postLog.has(`C1:${c2.id}`)).toBe(false);
+    expect(db._state.postLog.has(`C1:${c3.id}`)).toBe(true);
+    // Cursor moves to c1 only — c2 will be re-evaluated next round; c3's
+    // isPosted check then short-circuits because we recorded it above.
+    expect(db._state.state.get('last_clip_created_at')).toBe(c1.createdAt);
+  });
+
+  test('failure on the very first clip: cursor does NOT advance at all', async () => {
+    const cursor = new Date(0).toISOString();
+    const c1 = clip();
+    const sub = subscription({ channelId: 'C1' });
+    const db = stubDb({ cursor, subs: [sub] });
+    const fanout: Fanout = async () => false;
+
+    await pollOnce({ db, api: stubApi([c1]), fanout, log: silentLog });
+    expect(db._state.state.get('last_clip_created_at')).toBe(cursor);
   });
 
   test('clips matching no subscription advance the cursor without fanout', async () => {
@@ -299,15 +330,12 @@ describe('pollOnce', () => {
     expect(warnLog).toHaveBeenCalled();
   });
 
-  test('partial failure: one sub succeeds, another fails — only the success is recorded', async () => {
+  test('partial failure across subs for the same clip: success recorded, cursor halts', async () => {
     const c1 = clip();
     const c2 = clip();
     const subA = subscription({ channelId: 'A' });
     const subB = subscription({ channelId: 'B' });
-    const db = stubDb({
-      cursor: c1.createdAt,
-      subs: [subA, subB],
-    });
+    const db = stubDb({ cursor: c1.createdAt, subs: [subA, subB] });
     // Fail the first call (channel A), succeed the second (channel B).
     let n = 0;
     const fanout: Fanout = async () => {
@@ -319,8 +347,9 @@ describe('pollOnce', () => {
     expect(res.posts).toBe(1);
     expect(db._state.postLog.has(`A:${c2.id}`)).toBe(false);
     expect(db._state.postLog.has(`B:${c2.id}`)).toBe(true);
-    // Cursor advances — A will be retried next round (isPosted returns false).
-    expect(db._state.state.get('last_clip_created_at')).toBe(c2.createdAt);
+    // Cursor stays at c1 so c2 is re-evaluated next round; B's isPosted check
+    // will short-circuit (already recorded), only A retries.
+    expect(db._state.state.get('last_clip_created_at')).toBe(c1.createdAt);
   });
 });
 

--- a/discord/tests/poller.test.ts
+++ b/discord/tests/poller.test.ts
@@ -310,6 +310,31 @@ describe('pollOnce', () => {
   });
 });
 
+describe('pollOnce cursor sanity', () => {
+  test('garbage cursor value re-anchors to a valid ISO date and logs a warning', async () => {
+    // Without the guard, `new Date('not-a-date')` is Invalid Date and every
+    // `c.createdAt >= lastSeen` returns false → entire feed treated as stale
+    // → silent posting outage. The fix logs and re-anchors instead.
+    const warnLog = mock(() => {});
+    const db = stubDb({
+      state: new Map([['last_clip_created_at', 'not-a-date']]),
+      subs: [subscription({ channelId: 'C1' })],
+    });
+
+    await pollOnce({
+      db,
+      api: stubApi([clip()]),
+      fanout: okFanout(),
+      log: { info: () => {}, warn: warnLog, error: () => {} },
+    });
+
+    expect(warnLog).toHaveBeenCalled();
+    const newCursor = db._state.state.get('last_clip_created_at');
+    expect(newCursor).toBeDefined();
+    expect(Number.isNaN(new Date(newCursor!).getTime())).toBe(false);
+  });
+});
+
 describe('pollOnce cursor + dedupe boundary cases', () => {
   test('tied-timestamp clip at the cursor boundary is reprocessed but dedupe blocks the post', async () => {
     // c1 has the exact same timestamp as the cursor; isPosted returns true
@@ -332,43 +357,26 @@ describe('pollOnce cursor + dedupe boundary cases', () => {
 
 describe('pollOnce pagination', () => {
   test('walks nextCursor when first page is full and all items are fresh', async () => {
-    // Cursor in the distant past — every clip in the feed is fresh.
-    const old = clip();
-    // Page 1: pageSize=2, all fresh, nextCursor='p2'.
+    // clip() increments a seq, so a..d have strictly increasing timestamps.
+    // The cursor is anchored at epoch so EVERY clip is fresh — the poller
+    // should walk both pages until it sees a non-full page (page 2 returns 2
+    // items but nextCursor=null, so the loop terminates after page 2).
     const a = clip();
     const b = clip();
-    // Page 2: pageSize=2, mixed (one fresh, one older than cursor) → poller
-    // stops here because the page contains an item ≤ lastSeen.
     const c = clip();
-    const d = clip(); // older than cursor (simulated by setting cursor to between c and d)
-
-    // Place cursor between c and d so d is the boundary stop.
-    const cursorTs = new Date(
-      (new Date(c.createdAt).getTime() + new Date(d.createdAt).getTime()) / 2,
-    ).toISOString();
-    // Actually: c was created last, so c.createdAt > d.createdAt? No — clip()
-    // increments seq, so later clips have LATER timestamps. Order:
-    // old < a < b < c < d (chronological). Feed is DESC, so first page returns
-    // newest first: [d, c]. Set the cursor so c < cursor < d → only d is fresh.
-    void old;
-    const lastSeen = new Date(
-      (new Date(c.createdAt).getTime() + new Date(d.createdAt).getTime()) / 2,
-    ).toISOString();
-    void cursorTs;
+    const d = clip();
 
     const pages = new Map<string, ClipFeedResponse>([
-      // Initial fetch: 2 items, both newer than cursor's reference clip 'a'
+      // Feed sort is DESC, so the newest clips appear on page 1.
       ['', { items: [d, c], nextCursor: 'p2' }],
       ['p2', { items: [b, a], nextCursor: null }],
     ]);
     const api = stubPagedApi(pages);
     const sub = subscription({ channelId: 'C1' });
-    // Anchor cursor far back so a, b, c are ALL fresh; d is fresh too.
     const db = stubDb({
       state: new Map([['last_clip_created_at', new Date(0).toISOString()]]),
       subs: [sub],
     });
-    void lastSeen;
     const fanout = okFanout();
 
     const res = await pollOnce({

--- a/discord/tests/poller.test.ts
+++ b/discord/tests/poller.test.ts
@@ -12,9 +12,20 @@ type StubDbState = {
   postLog: Set<string>;
 };
 
-function stubDb(initial: Partial<StubDbState> = {}): Db & { _state: StubDbState } {
+// `cursor` is sugar: every poller test needs to anchor the
+// `last_clip_created_at` key, and writing the full Map literal each time made
+// the intent of each test hard to spot. Passes through to `state` if both are
+// supplied (explicit `state` wins so a test can still set arbitrary keys).
+type StubDbInit = Partial<StubDbState> & { cursor?: string };
+
+function stubDb(initial: StubDbInit = {}): Db & { _state: StubDbState } {
+  const state =
+    initial.state ??
+    (initial.cursor !== undefined
+      ? new Map([['last_clip_created_at', initial.cursor]])
+      : new Map());
   const s: StubDbState = {
-    state: initial.state ?? new Map(),
+    state,
     subs: initial.subs ?? [],
     postLog: initial.postLog ?? new Set(),
   };
@@ -129,7 +140,7 @@ describe('pollOnce', () => {
     const c2 = clip();
     const c3 = clip();
     const sub = subscription({ channelId: 'C1', pingRoleId: '555' });
-    const db = stubDb({ state: new Map([['last_clip_created_at', c2.createdAt]]), subs: [sub] });
+    const db = stubDb({ cursor: c2.createdAt, subs: [sub] });
     // Cursor at c2: with the new `>=` filter, both c2 and c3 are fresh, but c2
     // ties the cursor exactly. The post log starts empty, so both fan out.
     const fanout = okFanout();
@@ -151,7 +162,7 @@ describe('pollOnce', () => {
     const c2 = clip();
     const sub = subscription({ channelId: 'C1' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [sub],
       // Pre-existing entry (crashed-mid-fanout restart): isPosted returns true,
       // so fanout is NOT called and recordPost is NOT re-issued. Cursor still
@@ -171,7 +182,7 @@ describe('pollOnce', () => {
     const c2 = clip();
     const sub = subscription({ channelId: 'C1' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [sub],
     });
     const fanout: Fanout = async () => false;
@@ -190,7 +201,7 @@ describe('pollOnce', () => {
     const sub = subscription({ channelId: 'C1' });
     const errLog = mock(() => {});
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [sub],
     });
     const fanout: Fanout = async () => {
@@ -213,7 +224,7 @@ describe('pollOnce', () => {
     const c2 = clip({ game: { id: 999, name: 'X', slug: 'x', tag: 'x' } });
     const sub = subscription({ channelId: 'C1', gameId: 7 });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [sub],
     });
     const fanout = okFanout();
@@ -230,7 +241,7 @@ describe('pollOnce', () => {
     const c1 = clip();
     const cursorAhead = new Date(new Date(c1.createdAt).getTime() + 60_000).toISOString();
     const listSubsSpy = mock(async () => [] as Subscription[]);
-    const db = stubDb({ state: new Map([['last_clip_created_at', cursorAhead]]) });
+    const db = stubDb({ cursor: cursorAhead });
     db.listAllSubscriptions = listSubsSpy;
 
     const res = await pollOnce({
@@ -249,7 +260,7 @@ describe('pollOnce', () => {
     const subA = subscription({ channelId: 'A' });
     const subB = subscription({ channelId: 'B' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [subA, subB],
     });
     const fanout = okFanout();
@@ -270,7 +281,7 @@ describe('pollOnce', () => {
     const sub = subscription({ channelId: 'C1' });
     const warnLog = mock(() => {});
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [sub],
     });
     db.recordPost = async () => {
@@ -294,7 +305,7 @@ describe('pollOnce', () => {
     const subA = subscription({ channelId: 'A' });
     const subB = subscription({ channelId: 'B' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [subA, subB],
     });
     // Fail the first call (channel A), succeed the second (channel B).
@@ -320,7 +331,7 @@ describe('pollOnce cursor sanity', () => {
     // → silent posting outage. The fix logs and re-anchors instead.
     const warnLog = mock(() => {});
     const db = stubDb({
-      state: new Map([['last_clip_created_at', 'not-a-date']]),
+      cursor: 'not-a-date',
       subs: [subscription({ channelId: 'C1' })],
     });
 
@@ -346,7 +357,7 @@ describe('pollOnce cursor + dedupe boundary cases', () => {
     const c1 = clip();
     const sub = subscription({ channelId: 'C1' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', c1.createdAt]]),
+      cursor: c1.createdAt,
       subs: [sub],
       postLog: new Set([`C1:${c1.id}`]),
     });
@@ -377,7 +388,7 @@ describe('pollOnce pagination', () => {
     const api = stubPagedApi(pages);
     const sub = subscription({ channelId: 'C1' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', new Date(0).toISOString()]]),
+      cursor: new Date(0).toISOString(),
       subs: [sub],
     });
     const fanout = okFanout();
@@ -413,7 +424,7 @@ describe('pollOnce pagination', () => {
     const api = stubPagedApi(pages);
     const sub = subscription({ channelId: 'C1' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', cursor]]),
+      cursor: cursor,
       subs: [sub],
     });
     const fanout = okFanout();
@@ -439,7 +450,7 @@ describe('pollOnce pagination', () => {
     const api = stubPagedApi(pages);
     const sub = subscription({ channelId: 'C1' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', new Date(0).toISOString()]]),
+      cursor: new Date(0).toISOString(),
       subs: [sub],
     });
     const fanout = okFanout();
@@ -461,7 +472,7 @@ describe('pollOnce pagination', () => {
     const api = stubPagedApi(pages);
     const sub = subscription({ channelId: 'C1' });
     const db = stubDb({
-      state: new Map([['last_clip_created_at', new Date(0).toISOString()]]),
+      cursor: new Date(0).toISOString(),
       subs: [sub],
     });
     const fanout = okFanout();
@@ -475,7 +486,7 @@ describe('pollOnce pagination', () => {
 describe('startPoller', () => {
   test('runs immediately, then resolves on abort', async () => {
     const c1 = clip();
-    const db = stubDb({ state: new Map([['last_clip_created_at', c1.createdAt]]) });
+    const db = stubDb({ cursor: c1.createdAt });
     const fanout = okFanout();
     const abort = new AbortController();
     const loopDone = startPoller(

--- a/discord/tests/poller.test.ts
+++ b/discord/tests/poller.test.ts
@@ -28,6 +28,9 @@ function stubDb(initial: Partial<StubDbState> = {}): Db & { _state: StubDbState 
     async removeSubscription() {
       return 0;
     },
+    async removeAllSubscriptionsForChannel() {
+      return 0;
+    },
     async listSubscriptionsForChannel() {
       return [];
     },

--- a/discord/tests/posting.test.ts
+++ b/discord/tests/posting.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { buildMessage, postToChannel, type Sendable } from '../src/posting.ts';
+import { clip } from './factories.ts';
+
+describe('buildMessage', () => {
+  test('no ping role → bare share URL', () => {
+    const c = clip({ shareCode: 'abcd1234' });
+    expect(buildMessage(c, { pingRoleId: null }, 'https://gankedtv.com')).toBe(
+      'https://gankedtv.com/c/abcd1234',
+    );
+  });
+
+  test('with ping role → role mention prefix', () => {
+    const c = clip({ shareCode: 'abcd1234' });
+    expect(buildMessage(c, { pingRoleId: '987' }, 'https://gankedtv.com')).toBe(
+      '<@&987> https://gankedtv.com/c/abcd1234',
+    );
+  });
+});
+
+describe('postToChannel', () => {
+  test('returns false and does nothing when channel is null', async () => {
+    expect(await postToChannel(null, 'hello')).toBe(false);
+  });
+
+  test('forwards to channel.send with role-only allowed mentions', async () => {
+    const send = mock(async (_payload: unknown) => undefined);
+    const fake: Sendable = { send };
+    const ok = await postToChannel(fake, 'hi');
+    expect(ok).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    const arg = send.mock.calls[0]![0] as { content: string; allowedMentions: { parse: string[] } };
+    expect(arg.content).toBe('hi');
+    expect(arg.allowedMentions.parse).toEqual(['roles']);
+  });
+});

--- a/discord/tests/shareUrl.test.ts
+++ b/discord/tests/shareUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { shareUrl } from '../src/lib/shareUrl.ts';
+
+describe('shareUrl', () => {
+  test('builds the canonical /c/{code} URL', () => {
+    expect(shareUrl('abc12345', 'https://gankedtv.com')).toBe('https://gankedtv.com/c/abc12345');
+  });
+
+  test('strips a trailing slash from the base', () => {
+    expect(shareUrl('abc12345', 'https://gankedtv.com/')).toBe('https://gankedtv.com/c/abc12345');
+  });
+
+  test('supports custom dev hosts', () => {
+    expect(shareUrl('xyz', 'http://localhost:5173')).toBe('http://localhost:5173/c/xyz');
+  });
+});

--- a/discord/tsconfig.json
+++ b/discord/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2024"],
+    "types": ["bun"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,40 @@ services:
       timeout: 5s
       retries: 5
 
+  # Discord bot — off-by-default. Gated behind the `discord` compose profile so
+  # `make up` (plain dev) doesn't build the Bun image until you opt in with
+  # `make up-discord`. Without DISCORD_BOT_TOKEN the container still no-ops
+  # cleanly — the profile gate is purely a build-time skip.
+  discord:
+    profiles: ["discord"]
+    build:
+      context: ./discord
+      dockerfile: Dockerfile
+    environment:
+      # Distinct from the API's DATABASE_URL because the API uses dotnet
+      # semicolon form, which porsager's `postgres` driver can't parse.
+      DISCORD_DATABASE_URL: postgres://gankedtv:gankedtv_dev@postgres:5432/gankedtv
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_BOT_APP_ID: ${DISCORD_BOT_APP_ID:-}
+      DISCORD_BOT_GUILD_ID: ${DISCORD_BOT_GUILD_ID:-}
+      DISCORD_POLL_INTERVAL_SECONDS: ${DISCORD_POLL_INTERVAL_SECONDS:-30}
+      # Inside the docker network the API is reachable via host.docker.internal
+      # (since the API runs on the host via `dotnet watch`, not in compose).
+      # `bun dev` from the discord/ directory uses a local .env to talk to
+      # http://localhost:5050 directly.
+      GANKEDTV_API_BASE: ${GANKEDTV_API_BASE:-http://host.docker.internal:5050}
+      GANKEDTV_PUBLIC_BASE: ${GANKEDTV_PUBLIC_BASE:-http://localhost:5173}
+    # Native Linux Docker doesn't auto-resolve host.docker.internal (only Docker
+    # Desktop / WSL2 do); the host-gateway alias is the cross-platform way to
+    # let the container reach the host-running API. Without this the in-container
+    # bot can't hit GANKEDTV_API_BASE in dev on Linux.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   minio_data:

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -144,10 +144,17 @@ MINIO_CONSOLE_HOST_PORT=${s3c}
 ASPNETCORE_URLS=http://localhost:${api}
 VITE_PORT=${vite}
 
-# cross-process wiring (Program.cs:48,56-66 + web/src/api/client.ts:2 already read these)
+# cross-process wiring (Program.cs:48,56-66 + web/src/api/client.ts:2 +
+# discord/src/loadEnv.ts already read these)
 DATABASE_URL=Host=localhost;Port=${pg};Database=gankedtv;Username=gankedtv;Password=gankedtv_dev
 S3_ENDPOINT=http://localhost:${s3}
 VITE_API_BASE_URL=http://localhost:${api}
+# discord bot uses the standard libpq URL shape, not the dotnet semicolon form.
+# Both refer to the same Postgres; duplicated because the bot's `postgres` driver
+# can't parse the dotnet variant.
+DISCORD_DATABASE_URL=postgres://gankedtv:gankedtv_dev@localhost:${pg}/gankedtv
+GANKEDTV_API_BASE=http://localhost:${api}
+GANKEDTV_PUBLIC_BASE=http://localhost:${vite}
 
 # CORS + OAuth redirect target. Program.cs always allows WEB_ORIGIN through CORS,
 # so the worktree's web (port ${vite}) needs this set or browser→api requests get
@@ -203,6 +210,7 @@ echo "→ bootstrapping stack (this mirrors 'make setup' minus the destructive c
   make wait-minio
   make server-install
   make web-install
+  make discord-install
   make migrate
   make seed
 )


### PR DESCRIPTION
## Summary

Implements the Phase 4 Discord bot from #107 as a sibling `discord/` package (TypeScript + Bun + discord.js 14.26). The bot polls `/clips/feed` every 30s, fans new public+ready clips out to subscribed Discord channels, and exposes slash commands for subscription management and on-demand clip pulls. Off by default — boots and exits cleanly without `DISCORD_BOT_TOKEN`, matching the `IgdbSyncHostedService` contract.

## What's here

- **New `discord/` package** ([discord/src/](discord/src/)) — boot + config + db layer + poller + per-channel fanout + slash commands. 99.81% line / 98.72% function coverage, gate enforced by [discord/scripts/check-coverage.ts](discord/scripts/check-coverage.ts) (Bun's `coverageThreshold` is documentation-only on 1.3.13, so we parse `coverage/lcov.info` ourselves).
- **Three bot-owned tables** in the shared Postgres ([discord/src/migrations/001_initial.sql](discord/src/migrations/001_initial.sql)): `discord_subscriptions`, `discord_post_log`, `discord_bot_state`. EF Core doesn't model them — bot applies its own SQL migrations on boot via [discord/src/migrator.ts](discord/src/migrator.ts). `UNIQUE NULLS NOT DISTINCT` on the subscriptions key prevents phantom firehose duplicates.
- **Polling-based detection** ([discord/src/poller.ts](discord/src/poller.ts)) — high-water-mark cursor by `createdAt`, walks `nextCursor` to absorb bursts > `pageSize`, per-`(channel, clip)` post-log row as the at-least-once dedupe guard (post first, record on success). Future upgrade to push-based delivery only swaps the poller's entry-point.
- **Slash commands**: `/gankedtv subscribe|unsubscribe|subscriptions|pause|resume` (channel-scoped, gated to `ManageChannels`) and `/clip latest|top|search` (open in any guild, even without a subscription). Game autocomplete returns slugs uniformly across both namespaces.
- **Compose service** ([docker-compose.dev.yml](docker-compose.dev.yml)) — gated behind the `discord` profile so `make up` still spins only Postgres + MinIO. `extra_hosts: host.docker.internal:host-gateway` keeps the container reachable from the host-running API on native Linux Docker.
- **Repo wiring**: [Makefile](Makefile) (`make discord`, `make discord-install`, `make discord-test`, `make discord-lint`, `make ci-discord`, threaded into `make ci`), [.githooks/pre-push](.githooks/pre-push) (third scoped subset for `discord/` changes), [.github/workflows/discord.yml](.github/workflows/discord.yml) (build → format/lint → test+coverage with markdown summary in `$GITHUB_STEP_SUMMARY`), [scripts/new-worktree.sh](scripts/new-worktree.sh) (`make discord-install` + per-worktree `DISCORD_DATABASE_URL` in libpq form).
- **Env loading** ([discord/src/loadEnv.ts](discord/src/loadEnv.ts)) — reads the repo-root `.env` first, then layers `discord/.env`, then shell env (first-set-wins). Mirrors web's `envDir: '../'` convention. `DISCORD_DATABASE_URL` is a distinct env var from the API's `DATABASE_URL` because the API stores its connection string in dotnet semicolon form, which porsager's `postgres` driver can't parse.

Closes #107

## How to test manually

Per the original issue's manual-test checklist:

1. `make up && make migrate && make seed` to get the dev stack running.
2. Set `DISCORD_BOT_TOKEN`, `DISCORD_BOT_APP_ID`, and `DISCORD_BOT_GUILD_ID` in your root `.env` (the bot/app pair from https://discord.com/developers/applications; the guild id makes slash-command registration instant). Add `DISCORD_DATABASE_URL=postgres://gankedtv:gankedtv_dev@localhost:5435/gankedtv`.
3. `make discord` to start the bot (or `cd discord && bun run dev`). Should log `Discord client ready` and `Starting poller`.
4. Invite the bot to a test guild, run `/gankedtv subscribe` in a channel.
5. Upload a public clip via the web app (`make web`) → within one poll interval (30s default) the bot posts `https://gankedtv.com/c/<code>` and Discord unfurls the OG embed.
6. Subscribe with `game=valorant`; upload a Valorant clip + a non-Valorant clip; confirm only the Valorant one posts.
7. Restart the bot mid-poll → previously-logged clips don't double-post (post-log dedupe guard).
8. `/gankedtv unsubscribe` → no further posts.
9. Run `/clip latest`, `/clip top window:7d`, `/clip search query:flick` → bot posts the corresponding share URL.
10. Restart with `DISCORD_BOT_TOKEN` unset → logs `Discord bot disabled (...); exiting` and the process exits cleanly.

Also confirms the `enhancement` checklist from #107:

- [x] Subscribing a channel + a new public clip → exactly one message posted, embed renders
- [x] Game/creator filter respected
- [x] No duplicate posts for the same clip in the same channel
- [x] Bot no-ops when `DISCORD_BOT_TOKEN` is unset
- [x] Unsubscribe stops posts

## Checklist

- [x] Verified manually against a real Discord guild
- [x] Smoke-tested boot with no token (returns "disabled; exiting" and exits 0)
- [x] `make ci-discord` green locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Discord bot with slash commands (`/gankedtv`, `/clip`) for subscribing to and viewing clips
  * Automated clip feed polling with filtering by game and creator
  * Optional role mention notifications on new clip posts
  * Game autocomplete in subscription commands

* **Configuration**
  * Added Discord bot environment variables and Docker profile support
  * New development commands for Discord bot setup and testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->