### PR TITLE
[server][infra] Redis: hot-feed/trending cache + cluster-wide rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ S3_SECRET_KEY=minioadmin
 # Leave unset in pure-local dev — presigned GET URLs will use S3_ENDPOINT.
 S3_PUBLIC_URL=
 
+# Redis — OPTIONAL in development. Backs the hot-feed/trending cache and cluster-wide rate
+# limiting. Leave unset to run without Redis: the API falls back to an in-process cache and
+# per-instance rate limiters (fine for local/single-pod dev). Format: redis://[:password@]host:port
+# (use rediss:// for TLS). `make up` starts a local redis on 6379.
+REDIS_URL=redis://localhost:6379
+
 # API
 API_PORT=5050
 ASPNETCORE_ENVIRONMENT=Development

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 POSTGRES_HOST_PORT ?= 5435
 MINIO_API_HOST_PORT ?= 9000
 MINIO_CONSOLE_HOST_PORT ?= 9001
+REDIS_HOST_PORT ?= 6379
 ASPNETCORE_URLS ?= http://localhost:5050
 VITE_PORT ?= 5173
 
@@ -81,6 +82,7 @@ wait-minio:
 ports:
 	@printf "postgres   localhost:%s\n" "$(POSTGRES_HOST_PORT)"
 	@printf "minio      localhost:%s  (console: localhost:%s)\n" "$(MINIO_API_HOST_PORT)" "$(MINIO_CONSOLE_HOST_PORT)"
+	@printf "redis      localhost:%s\n" "$(REDIS_HOST_PORT)"
 	@printf "api        %s\n" "$(ASPNETCORE_URLS)"
 	@printf "web        http://localhost:%s\n" "$(VITE_PORT)"
 	@test -z "$(COMPOSE_PROJECT_NAME)" || printf "project    %s\n" "$(COMPOSE_PROJECT_NAME)"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "${MINIO_API_HOST_PORT:-9000}:9000"
       - "${MINIO_CONSOLE_HOST_PORT:-9001}:9001"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -79,6 +79,19 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  redis:
+    image: redis:7
+    ports:
+      - "${REDIS_HOST_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   postgres_data:
   minio_data:
+  redis_data:

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -73,6 +73,7 @@ s3=$((9000 + offset))
 s3c=$((9001 + offset))
 api=$((5050 + offset))
 vite=$((5173 + offset))
+redis=$((6379 + offset))
 
 if [[ -e "$dir" ]]; then
   echo "error: $dir already exists — remove it first with ./scripts/remove-worktree.sh $issue" >&2
@@ -85,7 +86,7 @@ fi
 # message if anything is already listening — better than a confusing compose
 # port-bind error mid-bootstrap.
 ports_in_use=()
-for p in "$pg" "$s3" "$s3c" "$api" "$vite"; do
+for p in "$pg" "$s3" "$s3c" "$api" "$vite" "$redis"; do
   if (echo >"/dev/tcp/127.0.0.1/$p") >/dev/null 2>&1; then
     ports_in_use+=("$p")
   fi
@@ -139,6 +140,7 @@ COMPOSE_PROJECT_NAME=gankedtv-issue-${issue}
 POSTGRES_HOST_PORT=${pg}
 MINIO_API_HOST_PORT=${s3}
 MINIO_CONSOLE_HOST_PORT=${s3c}
+REDIS_HOST_PORT=${redis}
 
 # host-side process bindings
 ASPNETCORE_URLS=http://localhost:${api}
@@ -148,6 +150,7 @@ VITE_PORT=${vite}
 # discord/src/loadEnv.ts already read these)
 DATABASE_URL=Host=localhost;Port=${pg};Database=gankedtv;Username=gankedtv;Password=gankedtv_dev
 S3_ENDPOINT=http://localhost:${s3}
+REDIS_URL=redis://localhost:${redis}
 VITE_API_BASE_URL=http://localhost:${api}
 # discord bot uses the standard libpq URL shape, not the dotnet semicolon form.
 # Both refer to the same Postgres; duplicated because the bot's `postgres` driver
@@ -193,7 +196,7 @@ fi
 
 echo ""
 echo "✓ worktree created: ${rel_dir} (branch $branch)"
-echo "  postgres :${pg}   minio :${s3}/:${s3c}   api :${api}   web :${vite}"
+echo "  postgres :${pg}   minio :${s3}/:${s3c}   redis :${redis}   api :${api}   web :${vite}"
 
 if [[ "${NEW_WORKTREE_SKIP_BOOTSTRAP:-0}" == "1" ]]; then
   echo ""

--- a/server/src/GankedTV.Api/Auth/AuthRateLimiting.cs
+++ b/server/src/GankedTV.Api/Auth/AuthRateLimiting.cs
@@ -1,5 +1,7 @@
 using System.Threading.RateLimiting;
+using GankedTV.Api.Services.Caching;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GankedTV.Api.Auth;
 
@@ -11,9 +13,10 @@ public static class AuthRateLimiting
 {
     public const string CredentialsPolicy = "auth-credentials";
 
-    // 5 attempts per minute per remote IP. Fixed window (not sliding) — keeps the bucket
-    // arithmetic in-process with no extra state. Returns 429 when exceeded; the SPA
-    // surfaces this inline below the form. No queueing — failed limit checks short-circuit.
+    // 5 attempts per minute per remote IP. Fixed window (not sliding). Enforced cluster-wide
+    // via RedisRateLimiterFactory when REDIS_URL is set; otherwise per-pod in-process. Returns
+    // 429 when exceeded; the SPA surfaces this inline below the form. No queueing — failed limit
+    // checks short-circuit.
     public const int CredentialsPermitLimit = 5;
     public static readonly TimeSpan CredentialsWindow = TimeSpan.FromMinutes(1);
 
@@ -33,14 +36,8 @@ public static class AuthRateLimiting
             // unrecognised proxies). Without a fallback, those callers would partition
             // by null and bypass the limit entirely.
             var key = ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-            return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
-            {
-                AutoReplenishment = true,
-                PermitLimit = CredentialsPermitLimit,
-                Window = CredentialsWindow,
-                QueueLimit = 0,
-                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-            });
+            var factory = ctx.RequestServices.GetRequiredService<RedisRateLimiterFactory>();
+            return RateLimitPartition.Get(key, _ => factory.Create(CredentialsPolicy, key, CredentialsPermitLimit, CredentialsWindow));
         });
         return options;
     }

--- a/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
+++ b/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
@@ -58,8 +58,14 @@ public static class ClipsRateLimiting
         {
             if (ctx.Lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfter))
             {
+                // Round up to whole seconds, floored at 1. The in-process FixedWindowRateLimiter
+                // fallback reports the *remaining* window as a sub-second TimeSpan, so a plain
+                // (int) cast would emit `Retry-After: 0` late in a window — and RFC 7231 lets
+                // clients retry immediately on 0, defeating the limiter. (The Redis path already
+                // rounds up, so this is a no-op there.)
+                var seconds = Math.Max(1, (int)Math.Ceiling(retryAfter.TotalSeconds));
                 ctx.HttpContext.Response.Headers.RetryAfter =
-                    ((int)retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+                    seconds.ToString(CultureInfo.InvariantCulture);
             }
             return new ValueTask(ProblemResults.TooManyRequests(RateLimitedCode)
                 .ExecuteAsync(ctx.HttpContext));

--- a/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
+++ b/server/src/GankedTV.Api/Clips/ClipsRateLimiting.cs
@@ -3,7 +3,9 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.RateLimiting;
 using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Caching;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GankedTV.Api.Clips;
 
@@ -25,9 +27,10 @@ public static class ClipsRateLimiting
     // A happy-path upload burns 3 (create + upload-url + complete), so the floor is ~10 clips/min
     // per user before the bucket exhausts. Pinned by ClipsRateLimitTests.MixedWrites_ShareBucket.
     //
-    // SCALING CAVEAT: this is in-process, per-instance state. Once the API runs on more than
-    // one pod the effective limit becomes 30 × pod_count per user. Phase 4 (issue #74 out-of-scope)
-    // moves to a Redis-backed limiter for cluster-wide enforcement.
+    // Enforced cluster-wide via RedisRateLimiterFactory when REDIS_URL is set — all pods share
+    // one Redis bucket per partition key, so the 30/min ceiling holds regardless of pod count.
+    // Without Redis (or during a Redis outage) it degrades to the original in-process fixed
+    // window, which is per-pod — fine for single-instance dev.
     public const int WritePermitLimit = 30;
     public static readonly TimeSpan WriteWindow = TimeSpan.FromMinutes(1);
 
@@ -63,14 +66,14 @@ public static class ClipsRateLimiting
         };
 
         options.AddPolicy<string>(ClipsWritePolicy, ctx =>
-            RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(ctx), _ => new FixedWindowRateLimiterOptions
-            {
-                AutoReplenishment = true,
-                PermitLimit = WritePermitLimit,
-                Window = WriteWindow,
-                QueueLimit = 0,
-                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-            }));
+        {
+            // RedisRateLimiterFactory returns a Redis-backed limiter (shared across pods) when
+            // REDIS_URL is configured, else the in-process fixed window. The framework caches
+            // the returned limiter per partition key, so the factory runs once per bucket.
+            var key = ResolvePartitionKey(ctx);
+            var factory = ctx.RequestServices.GetRequiredService<RedisRateLimiterFactory>();
+            return RateLimitPartition.Get(key, _ => factory.Create(ClipsWritePolicy, key, WritePermitLimit, WriteWindow));
+        });
         return options;
     }
 

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -5,6 +5,7 @@ using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.Maintenance;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Services.Tags;
@@ -44,6 +45,7 @@ public static class ClipsMutateEndpoints
         ITagsResolver tagsResolver,
         IOptions<S3Options> s3,
         IOptions<ClipValidationOptions> validation,
+        IFeedCache feedCache,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -142,6 +144,10 @@ public static class ClipsMutateEndpoints
         clip.UpdatedAt = DateTimeOffset.UtcNow;
         await db.SaveChangesAsync(ct);
 
+        // An edit can change anything shown in a feed item (title, thumbnail, game, tags) or move
+        // the clip in/out of the public feed (visibility), so drop the cached pages.
+        await feedCache.InvalidateFeedsAsync(ct);
+
         var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
         var videoUrl = storage.GetPresignedGetUrl(s3.Value.ClipsBucket, clip.VideoKey, VideoUrlLifetime);
         var thumbnailUrl = ClipsReadEndpoints.BuildThumbnailUrl(
@@ -159,6 +165,7 @@ public static class ClipsMutateEndpoints
         IObjectStorageService storage,
         IOptions<S3Options> s3,
         ILoggerFactory loggerFactory,
+        IFeedCache feedCache,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -179,6 +186,9 @@ public static class ClipsMutateEndpoints
 
         db.Clips.Remove(clip);
         await db.SaveChangesAsync(ct);
+
+        // A deleted clip may have been on a cached feed page; drop them so it stops being served.
+        await feedCache.InvalidateFeedsAsync(ct);
 
         // S3 cleanup is best-effort: the DB row is already gone, so a cleanup failure must not
         // surface as 500 (that would mislead the client into retrying a non-existent row).

--- a/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsMutateEndpoints.cs
@@ -46,6 +46,7 @@ public static class ClipsMutateEndpoints
         IOptions<S3Options> s3,
         IOptions<ClipValidationOptions> validation,
         IFeedCache feedCache,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))
@@ -146,7 +147,7 @@ public static class ClipsMutateEndpoints
 
         // An edit can change anything shown in a feed item (title, thumbnail, game, tags) or move
         // the clip in/out of the public feed (visibility), so drop the cached pages.
-        await feedCache.InvalidateFeedsAsync(ct);
+        await InvalidateFeedsBestEffortAsync(feedCache, loggerFactory, ct);
 
         var expiresAt = DateTimeOffset.UtcNow.Add(VideoUrlLifetime);
         var videoUrl = storage.GetPresignedGetUrl(s3.Value.ClipsBucket, clip.VideoKey, VideoUrlLifetime);
@@ -188,7 +189,7 @@ public static class ClipsMutateEndpoints
         await db.SaveChangesAsync(ct);
 
         // A deleted clip may have been on a cached feed page; drop them so it stops being served.
-        await feedCache.InvalidateFeedsAsync(ct);
+        await InvalidateFeedsBestEffortAsync(feedCache, loggerFactory, ct);
 
         // S3 cleanup is best-effort: the DB row is already gone, so a cleanup failure must not
         // surface as 500 (that would mislead the client into retrying a non-existent row).
@@ -200,6 +201,23 @@ public static class ClipsMutateEndpoints
             ct);
 
         return Results.NoContent();
+    }
+
+    // The DB write has already committed by the time we invalidate, so a cache failure (e.g. Redis
+    // down) must not turn a successful mutation into a 500. Swallow + log; the short TTL self-heals
+    // if invalidation is missed. Mirrors the best-effort pattern in MediaJobHostedService.
+    private static async Task InvalidateFeedsBestEffortAsync(
+        IFeedCache feedCache, ILoggerFactory loggerFactory, CancellationToken ct)
+    {
+        try
+        {
+            await feedCache.InvalidateFeedsAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            loggerFactory.CreateLogger(LogCategory).LogWarning(ex,
+                "Feed cache invalidation failed after a clip mutation; entries will expire via TTL.");
+        }
     }
 
     private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -9,6 +9,7 @@ using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Pagination;
 using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.Media;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
@@ -101,6 +102,7 @@ public static class ClipsReadEndpoints
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
+        IFeedCache feedCache,
         CancellationToken ct)
     {
         var baseQuery = db.Clips.AsNoTracking()
@@ -109,7 +111,8 @@ public static class ClipsReadEndpoints
         // `source` is treated leniently: only the literal "following" switches behaviour;
         // anything else (null, "public", garbage) falls through to the global feed. Matches
         // the same forgive-and-fall-back spirit as the cursor decoder.
-        if (string.Equals(source, "following", StringComparison.OrdinalIgnoreCase))
+        var isFollowing = string.Equals(source, "following", StringComparison.OrdinalIgnoreCase);
+        if (isFollowing)
         {
             if (!TryGetUserId(principal, out var me))
             {
@@ -140,8 +143,36 @@ public static class ClipsReadEndpoints
                 return ProblemResults.BadRequest("invalid_window");
             }
 
-            var response = await BuildTrendingFeedAsync(baseQuery, since, limit, principal, db, storage, s3, ct);
-            return Results.Ok(response);
+            // The personalised "following + trending" combination filters baseQuery per user,
+            // so it must never hit the shared cache; only the global trending feed is cached.
+            if (isFollowing)
+            {
+                var personalised = await BuildTrendingFeedAsync(baseQuery, since, limit, principal, db, storage, s3, ct);
+                return Results.Ok(personalised);
+            }
+
+            var trendingLimit = Math.Clamp(limit ?? FeedDefaultLimit, 1, TrendingMaxLimit);
+            var cachedTrending = await feedCache.GetOrCreateTrendingAsync(
+                $"feed:trending:{window}:{trendingLimit}",
+                c => new ValueTask<CachedFeedPage>(
+                    BuildAnonymousTrendingFeedAsync(baseQuery, since, limit, db, storage, s3, c)),
+                ct);
+            var trendingItems = await ApplyLikedByMeAsync(cachedTrending.Items, principal, db, ct);
+            return Results.Ok(new ClipFeedResponse(trendingItems, cachedTrending.NextCursor));
+        }
+
+        // Cache only the global latest first page (no cursor, not personalised). Cursor pages
+        // and following feeds bypass the cache and query Postgres directly.
+        if (cursor is null && !isFollowing)
+        {
+            var feedLimit = Math.Clamp(limit ?? FeedDefaultLimit, 1, FeedMaxLimit);
+            var cached = await feedCache.GetOrCreateFeedAsync(
+                $"feed:latest:{feedLimit}",
+                c => new ValueTask<CachedFeedPage>(
+                    BuildAnonymousFeedPageAsync(baseQuery, null, limit, storage, s3, c)),
+                ct);
+            var items = await ApplyLikedByMeAsync(cached.Items, principal, db, ct);
+            return Results.Ok(new ClipFeedResponse(items, cached.NextCursor));
         }
 
         var latest = await BuildFeedPageAsync(baseQuery, cursor, limit, principal, db, storage, s3, ct);
@@ -186,6 +217,24 @@ public static class ClipsReadEndpoints
         IOptions<S3Options> s3,
         CancellationToken ct)
     {
+        var page = await BuildAnonymousTrendingFeedAsync(baseQuery, since, limit, db, storage, s3, ct);
+        var items = await ApplyLikedByMeAsync(page.Items, principal, db, ct);
+        return new ClipFeedResponse(items, page.NextCursor);
+    }
+
+    // Caller-independent half of BuildTrendingFeedAsync — the scoring + rehydration + anonymous
+    // projection that FeedCache stores. The window-relative ranking is inherently approximate and
+    // self-healing, so caching it behind a short TTL (rather than invalidating on every like/view)
+    // is sufficient: a cache entry just freezes `since`/scores for one TTL.
+    internal static async Task<CachedFeedPage> BuildAnonymousTrendingFeedAsync(
+        IQueryable<Clip> baseQuery,
+        DateTimeOffset since,
+        int? limit,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
         var clampedLimit = Math.Clamp(limit ?? FeedDefaultLimit, 1, TrendingMaxLimit);
 
         var candidates = await baseQuery
@@ -215,7 +264,7 @@ public static class ClipsReadEndpoints
 
         if (topIds.Count == 0)
         {
-            return new ClipFeedResponse([], NextCursor: null);
+            return new CachedFeedPage([], NextCursor: null);
         }
 
         // Re-hydrate with feed Includes (the candidate Select dropped them) and preserve
@@ -243,8 +292,8 @@ public static class ClipsReadEndpoints
             }
         }
 
-        var items = await ProjectFeedItemsAsync(ranked, principal, db, storage, s3, ct);
-        return new ClipFeedResponse(items, NextCursor: null);
+        var items = ProjectAnonymousFeedItems(ranked, storage, s3);
+        return new CachedFeedPage(items, NextCursor: null);
     }
 
     // Shared cursor-paginated feed builder. Callers pass a pre-filtered IQueryable<Clip>
@@ -256,6 +305,23 @@ public static class ClipsReadEndpoints
         int? limit,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        var page = await BuildAnonymousFeedPageAsync(baseQuery, cursor, limit, storage, s3, ct);
+        var items = await ApplyLikedByMeAsync(page.Items, principal, db, ct);
+        return new ClipFeedResponse(items, page.NextCursor);
+    }
+
+    // Caller-independent half of BuildFeedPageAsync: runs the keyset query + ordering + includes
+    // + thumbnail signing into an anonymous page (no likedByMe). This is what FeedCache stores,
+    // so the cached entry never holds personalised data. No ClaimsPrincipal/DbContext needed
+    // for the likes lookup — that happens after the cache, per caller, in ApplyLikedByMeAsync.
+    internal static async Task<CachedFeedPage> BuildAnonymousFeedPageAsync(
+        IQueryable<Clip> baseQuery,
+        string? cursor,
+        int? limit,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
         CancellationToken ct)
@@ -288,10 +354,10 @@ public static class ClipsReadEndpoints
         var hasMore = rows.Count > clampedLimit;
         var page = hasMore ? rows.GetRange(0, clampedLimit) : rows;
 
-        var items = await ProjectFeedItemsAsync(page, principal, db, storage, s3, ct);
+        var items = ProjectAnonymousFeedItems(page, storage, s3);
         var nextCursor = hasMore ? KeysetCursor.Build(page[^1].CreatedAt, page[^1].Id) : null;
 
-        return new ClipFeedResponse(items, nextCursor);
+        return new CachedFeedPage(items, nextCursor);
     }
 
     // Shared DTO projector for any pre-ordered, pre-included Clip list. Splits out the
@@ -305,16 +371,50 @@ public static class ClipsReadEndpoints
         IOptions<S3Options> s3,
         CancellationToken ct)
     {
+        var anonymous = ProjectAnonymousFeedItems(clips, storage, s3);
+        return await ApplyLikedByMeAsync(anonymous, principal, db, ct);
+    }
+
+    // Caller-independent projection: thumbnail signing only, LikedByMe left false. This is the
+    // shape the feed cache stores — never personalised — so one user's likes can't leak to
+    // another via a shared cache entry. likedByMe is re-stamped per request by ApplyLikedByMeAsync.
+    internal static List<ClipFeedItem> ProjectAnonymousFeedItems(
+        IReadOnlyList<Clip> clips,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3)
+    {
         if (clips.Count == 0)
         {
             return [];
         }
 
-        var likedIds = await LoadLikedClipIdsAsync(db, principal, clips.Select(c => c.Id), ct);
         var thumbnailsBucket = s3.Value.ThumbnailsBucket;
         return [.. clips.Select(c => c.ToFeedItem(
             BuildThumbnailUrl(storage, thumbnailsBucket, c.ThumbnailKey),
-            likedIds.Contains(c.Id)))];
+            likedByMe: false))];
+    }
+
+    // Re-stamps the per-caller LikedByMe flag onto an anonymous (possibly cached) item list.
+    // Anonymous callers and callers with no likes among these clips get the list back unchanged
+    // (items already carry LikedByMe=false), so the only cost is one indexed Likes lookup.
+    internal static async Task<List<ClipFeedItem>> ApplyLikedByMeAsync(
+        IReadOnlyList<ClipFeedItem> items,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (items.Count == 0)
+        {
+            return [.. items];
+        }
+
+        var likedIds = await LoadLikedClipIdsAsync(db, principal, items.Select(i => i.Id), ct);
+        if (likedIds.Count == 0)
+        {
+            return [.. items];
+        }
+
+        return [.. items.Select(i => likedIds.Contains(i.Id) ? i with { LikedByMe = true } : i)];
     }
 
     // Public Ready clips always have a thumbnail (the worker is the only path to Ready

--- a/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
@@ -1,7 +1,9 @@
 using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Contracts.Games;
 using GankedTV.Api.Data;
 using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -27,10 +29,29 @@ public static class GamesEndpoints
         int? limit,
         bool? hasClips,
         GankedTvDbContext db,
+        IGamesCache gamesCache,
         CancellationToken ct)
     {
         var clampedLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
 
+        // Only the browse list (no search) is cached — search strings are high-cardinality and
+        // the upload picker's queries don't repeat, so caching them would just churn keys.
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            return Results.Ok(await QueryGamesAsync(db, hasClips, search, clampedLimit, ct));
+        }
+
+        var key = $"games:list:hasClips={hasClips == true}:{clampedLimit}";
+        var cached = await gamesCache.GetOrCreateListAsync(
+            key,
+            async c => await QueryGamesAsync(db, hasClips, search: null, clampedLimit, c),
+            ct);
+        return Results.Ok(cached);
+    }
+
+    private static async Task<IReadOnlyList<GameListItem>> QueryGamesAsync(
+        GankedTvDbContext db, bool? hasClips, string? search, int clampedLimit, CancellationToken ct)
+    {
         var query = db.Games.AsNoTracking().AsQueryable();
 
         // The games *page* (GamesView) passes hasClips=true so it only lists games people can
@@ -56,19 +77,31 @@ public static class GamesEndpoints
                 || EF.Functions.ILike(g.Slug, pattern, @"\"));
         }
 
-        var rows = await query
+        return await query
             .OrderBy(g => g.Name)
             .Take(clampedLimit)
             .Select(g => new GameListItem(g.Id, g.Name, g.Slug, g.Tag, g.CoverUrl))
             .ToListAsync(ct);
-
-        return Results.Ok(rows);
     }
 
     private static async Task<IResult> GetBySlug(
         string slug,
         GankedTvDbContext db,
+        IGamesCache gamesCache,
         CancellationToken ct)
+    {
+        var detail = await gamesCache.GetOrCreateDetailAsync(
+            $"games:detail:{slug}",
+            async c => await QueryGameDetailAsync(db, slug, c),
+            ct);
+
+        return detail is null
+            ? ProblemResults.NotFound("not_found")
+            : Results.Ok(detail);
+    }
+
+    private static async Task<GameDetail?> QueryGameDetailAsync(
+        GankedTvDbContext db, string slug, CancellationToken ct)
     {
         // One round-trip: project the entity together with a correlated COUNT scoped
         // to the same visibility/status filter the clips list uses, so the header
@@ -83,9 +116,7 @@ public static class GamesEndpoints
             })
             .FirstOrDefaultAsync(ct);
 
-        return row is null
-            ? ProblemResults.NotFound("not_found")
-            : Results.Ok(row.Game.ToDetail(row.ClipCount));
+        return row?.Game.ToDetail(row.ClipCount);
     }
 
     private static async Task<IResult> GetClipsForGame(
@@ -96,6 +127,7 @@ public static class GamesEndpoints
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
+        IFeedCache feedCache,
         CancellationToken ct)
     {
         // Distinguish "no such game" (404) from "game exists but has no clips" (200, empty page)
@@ -110,6 +142,19 @@ public static class GamesEndpoints
 
         var baseQuery = db.Clips.AsNoTracking()
             .Where(c => c.GameId == gameId && c.Visibility == "public" && c.Status == "ready");
+
+        // Cache only the first page per game (no cursor). Cursor pages bypass the cache.
+        if (cursor is null)
+        {
+            var feedLimit = Math.Clamp(limit ?? ClipsReadEndpoints.FeedDefaultLimit, 1, ClipsReadEndpoints.FeedMaxLimit);
+            var cached = await feedCache.GetOrCreateFeedAsync(
+                $"feed:game:{slug}:{feedLimit}",
+                c => new ValueTask<CachedFeedPage>(
+                    ClipsReadEndpoints.BuildAnonymousFeedPageAsync(baseQuery, null, limit, storage, s3, c)),
+                ct);
+            var items = await ClipsReadEndpoints.ApplyLikedByMeAsync(cached.Items, principal, db, ct);
+            return Results.Ok(new ClipFeedResponse(items, cached.NextCursor));
+        }
 
         var response = await ClipsReadEndpoints.BuildFeedPageAsync(
             baseQuery, cursor, limit, principal, db, storage, s3, ct);

--- a/server/src/GankedTV.Api/Endpoints/TagsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/TagsEndpoints.cs
@@ -1,7 +1,9 @@
 using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
 using GankedTV.Api.Contracts.Tags;
 using GankedTV.Api.Data;
 using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Services.Tags;
 using Microsoft.EntityFrameworkCore;
@@ -107,6 +109,7 @@ public static class TagsEndpoints
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
+        IFeedCache feedCache,
         CancellationToken ct)
     {
         // Distinguish "no such tag" (404) from "tag exists but has no clips" (200, empty page)
@@ -124,6 +127,21 @@ public static class TagsEndpoints
             .Where(c => c.ClipTags.Any(ct => ct.TagId == resolvedTagId)
                 && c.Visibility == "public"
                 && c.Status == "ready");
+
+        // Cache only the first page per tag (no cursor). Cursor pages bypass. Same pattern as
+        // GamesEndpoints.GetClipsForGame — the entry rides the shared clips-feed tag, so any clip
+        // create/ready/delete/visibility/tag change invalidates it.
+        if (cursor is null)
+        {
+            var feedLimit = Math.Clamp(limit ?? ClipsReadEndpoints.FeedDefaultLimit, 1, ClipsReadEndpoints.FeedMaxLimit);
+            var cached = await feedCache.GetOrCreateFeedAsync(
+                $"feed:tag:{slug}:{feedLimit}",
+                c => new ValueTask<CachedFeedPage>(
+                    ClipsReadEndpoints.BuildAnonymousFeedPageAsync(baseQuery, null, limit, storage, s3, c)),
+                ct);
+            var items = await ClipsReadEndpoints.ApplyLikedByMeAsync(cached.Items, principal, db, ct);
+            return Results.Ok(new ClipFeedResponse(items, cached.NextCursor));
+        }
 
         var response = await ClipsReadEndpoints.BuildFeedPageAsync(
             baseQuery, cursor, limit, principal, db, storage, s3, ct);

--- a/server/src/GankedTV.Api/GankedTV.Api.csproj
+++ b/server/src/GankedTV.Api/GankedTV.Api.csproj
@@ -23,7 +23,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
   </ItemGroup>
 

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -11,6 +11,7 @@ using GankedTV.Api.Data;
 using GankedTV.Api.Endpoints;
 using GankedTV.Api.Middleware;
 using GankedTV.Api.Notifications;
+using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.Clips;
 using GankedTV.Api.Services.Igdb;
 using GankedTV.Api.Services.Maintenance;
@@ -307,6 +308,17 @@ builder.Services.AddSingleton<IPasswordHasher, Argon2idPasswordHasher>();
 builder.Services.AddScoped<IRefreshTokenService, RefreshTokenService>();
 builder.Services.AddScoped<UserUpsertService>();
 builder.Services.AddScoped<CredentialAuthService>();
+
+// Redis-backed shared cache (hot feeds + trending) + cluster-wide rate limiting. OPTIONAL:
+// AddGankedCaching falls back to an in-process cache + per-instance limiters when REDIS_URL
+// is unset/malformed, so local dev needs no Redis. Config binding only — logic lives in the
+// Services/Caching/* services to stay inside the coverage denominator.
+var redisOptions = new RedisOptions
+{
+    Url = Environment.GetEnvironmentVariable("REDIS_URL") ?? builder.Configuration["Redis:Url"],
+};
+builder.Services.AddSingleton(redisOptions);
+builder.Services.AddGankedCaching(redisOptions);
 
 builder.Services.AddRateLimiter(opts => opts
     .AddCredentialsPolicy()

--- a/server/src/GankedTV.Api/Services/Caching/FeedCache.cs
+++ b/server/src/GankedTV.Api/Services/Caching/FeedCache.cs
@@ -1,0 +1,81 @@
+using GankedTV.Api.Contracts.Clips;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace GankedTV.Api.Services.Caching;
+
+/// <summary>
+/// Anonymous projection of a feed page held in the cache: the per-caller <c>LikedByMe</c>
+/// flag is deliberately left <c>false</c> here and re-stamped per request after a cache hit,
+/// so one user's likes never leak to another via the shared cache.
+/// </summary>
+public sealed record CachedFeedPage(IReadOnlyList<ClipFeedItem> Items, string? NextCursor);
+
+/// <summary>
+/// Hot read-path cache for feeds + trending. The interface lets write paths depend on (and
+/// tests verify) cache behaviour without binding to HybridCache directly.
+/// </summary>
+public interface IFeedCache
+{
+    /// <summary>Cache a feed page (latest or per-game) under the shared feed tag.</summary>
+    ValueTask<CachedFeedPage> GetOrCreateFeedAsync(
+        string key, Func<CancellationToken, ValueTask<CachedFeedPage>> factory, CancellationToken ct);
+
+    /// <summary>Cache a trending page (TTL-governed; not invalidated on writes).</summary>
+    ValueTask<CachedFeedPage> GetOrCreateTrendingAsync(
+        string key, Func<CancellationToken, ValueTask<CachedFeedPage>> factory, CancellationToken ct);
+
+    /// <summary>Drop every cached feed page (called best-effort on clip mutations).</summary>
+    ValueTask InvalidateFeedsAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Thin wrapper over <see cref="HybridCache"/> for the hot read paths (latest feed, per-game
+/// feed, trending). HybridCache is L1 in-memory + optional L2 Redis (wired in
+/// <see cref="RedisRegistration"/>): with Redis it's shared cluster-wide; without it the API
+/// still works off L1 alone. Centralises the short TTL + tag conventions so feed and trending
+/// stay DRY and invalidation has a single source of truth.
+/// </summary>
+public sealed class FeedCache(HybridCache cache) : IFeedCache
+{
+    /// <summary>Tag on every feed page (latest + per-game). One invalidation clears them all.</summary>
+    public const string FeedTag = "clips-feed";
+
+    /// <summary>Tag on trending pages. Self-heals via TTL (ranking is time-windowed/approximate),
+    /// so it's not invalidated on writes — only the short expiration governs freshness.</summary>
+    public const string TrendingTag = "trending";
+
+    // Short TTL with write-time invalidation. L1 (LocalCacheExpiration) is intentionally
+    // shorter than L2 (Expiration): with no cross-pod L1 backplane, RemoveByTagAsync clears
+    // L2 immediately but a sibling pod's L1 can serve stale until its local copy lapses —
+    // bounded to LocalCacheExpiration. Acceptable for a 30-60s hot-feed cache.
+    private static readonly HybridCacheEntryOptions Entry = new()
+    {
+        Expiration = TimeSpan.FromSeconds(60),
+        LocalCacheExpiration = TimeSpan.FromSeconds(30),
+    };
+
+    private static readonly string[] FeedTags = [FeedTag];
+    private static readonly string[] TrendingTags = [TrendingTag];
+
+    /// <summary>Cache a feed page (latest or per-game) under the <see cref="FeedTag"/>.</summary>
+    public ValueTask<CachedFeedPage> GetOrCreateFeedAsync(
+        string key,
+        Func<CancellationToken, ValueTask<CachedFeedPage>> factory,
+        CancellationToken ct) =>
+        cache.GetOrCreateAsync(key, factory, Entry, FeedTags, ct);
+
+    /// <summary>Cache a trending page under the <see cref="TrendingTag"/> (TTL-governed).</summary>
+    public ValueTask<CachedFeedPage> GetOrCreateTrendingAsync(
+        string key,
+        Func<CancellationToken, ValueTask<CachedFeedPage>> factory,
+        CancellationToken ct) =>
+        cache.GetOrCreateAsync(key, factory, Entry, TrendingTags, ct);
+
+    /// <summary>
+    /// Drop every cached feed page. Called best-effort on clip create/complete/delete and on
+    /// visibility/game changes — any of which can alter the global latest page, so we clear the
+    /// whole <see cref="FeedTag"/> rather than reason about which specific pages changed.
+    /// </summary>
+    public ValueTask InvalidateFeedsAsync(CancellationToken ct) =>
+        cache.RemoveByTagAsync(FeedTag, ct);
+}

--- a/server/src/GankedTV.Api/Services/Caching/FeedCache.cs
+++ b/server/src/GankedTV.Api/Services/Caching/FeedCache.cs
@@ -75,6 +75,12 @@ public sealed class FeedCache(HybridCache cache) : IFeedCache
     /// Drop every cached feed page. Called best-effort on clip create/complete/delete and on
     /// visibility/game changes — any of which can alter the global latest page, so we clear the
     /// whole <see cref="FeedTag"/> rather than reason about which specific pages changed.
+    /// <para>
+    /// Deliberately NOT called on like/unlike: a cached card's <c>LikeCount</c> is therefore
+    /// TTL-bounded-stale (≤ the entry's expiration), the same accepted tradeoff as trending.
+    /// Likes are high-frequency, so invalidating on each would defeat the cache; the clip detail
+    /// view and like button reflect the true count immediately.
+    /// </para>
     /// </summary>
     public ValueTask InvalidateFeedsAsync(CancellationToken ct) =>
         cache.RemoveByTagAsync(FeedTag, ct);

--- a/server/src/GankedTV.Api/Services/Caching/GamesCache.cs
+++ b/server/src/GankedTV.Api/Services/Caching/GamesCache.cs
@@ -1,0 +1,45 @@
+using GankedTV.Api.Contracts.Games;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace GankedTV.Api.Services.Caching;
+
+/// <summary>
+/// Caches the games catalog read paths (browse list + per-game detail). Separate from
+/// <see cref="IFeedCache"/> because the payloads aren't feed pages and the freshness model
+/// differs: catalog rows (name/slug/cover) change only via the IGDB importer, while
+/// <c>clipCount</c>/<c>hasClips</c> track the clip lifecycle. Rather than couple this to clip
+/// writes, it is TTL-only (like trending) — a short entry self-heals, so a new game appears in
+/// the browse list and an updated clipCount lands within the TTL.
+/// </summary>
+public interface IGamesCache
+{
+    ValueTask<IReadOnlyList<GameListItem>> GetOrCreateListAsync(
+        string key, Func<CancellationToken, ValueTask<IReadOnlyList<GameListItem>>> factory, CancellationToken ct);
+
+    ValueTask<GameDetail?> GetOrCreateDetailAsync(
+        string key, Func<CancellationToken, ValueTask<GameDetail?>> factory, CancellationToken ct);
+}
+
+/// <inheritdoc cref="IGamesCache"/>
+public sealed class GamesCache(HybridCache cache) : IGamesCache
+{
+    public const string GamesTag = "games";
+
+    // Same short window as the feed cache; clipCount / hasClips membership may lag by up to the
+    // TTL, which is acceptable for a browse catalog and self-heals without write-time coupling.
+    private static readonly HybridCacheEntryOptions Entry = new()
+    {
+        Expiration = TimeSpan.FromSeconds(60),
+        LocalCacheExpiration = TimeSpan.FromSeconds(30),
+    };
+
+    private static readonly string[] Tags = [GamesTag];
+
+    public ValueTask<IReadOnlyList<GameListItem>> GetOrCreateListAsync(
+        string key, Func<CancellationToken, ValueTask<IReadOnlyList<GameListItem>>> factory, CancellationToken ct) =>
+        cache.GetOrCreateAsync(key, factory, Entry, Tags, ct);
+
+    public ValueTask<GameDetail?> GetOrCreateDetailAsync(
+        string key, Func<CancellationToken, ValueTask<GameDetail?>> factory, CancellationToken ct) =>
+        cache.GetOrCreateAsync(key, factory, Entry, Tags, ct);
+}

--- a/server/src/GankedTV.Api/Services/Caching/RedisOptions.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisOptions.cs
@@ -47,12 +47,24 @@ public sealed class RedisOptions
         configuration.EndPoints.Add(uri.Host, port);
         configuration.Ssl = isTls;
 
-        // userinfo carries the password: redis://:pw@host or redis://user:pw@host. Redis AUTH
-        // is password-only (the username is the ACL user, optional). Take the password half.
+        // userinfo carries credentials: redis://:pw@host (password only) or redis://user:pw@host
+        // (ACL username + password). Preserve both so Redis 6+ ACL auth works, not just the
+        // legacy password-only AUTH.
         if (!string.IsNullOrEmpty(uri.UserInfo))
         {
             var parts = uri.UserInfo.Split(':', 2);
-            configuration.Password = Uri.UnescapeDataString(parts.Length == 2 ? parts[1] : parts[0]);
+            if (parts.Length == 2)
+            {
+                if (parts[0].Length > 0)
+                {
+                    configuration.User = Uri.UnescapeDataString(parts[0]);
+                }
+                configuration.Password = Uri.UnescapeDataString(parts[1]);
+            }
+            else
+            {
+                configuration.Password = Uri.UnescapeDataString(parts[0]);
+            }
         }
 
         return true;

--- a/server/src/GankedTV.Api/Services/Caching/RedisOptions.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisOptions.cs
@@ -1,0 +1,60 @@
+using StackExchange.Redis;
+
+namespace GankedTV.Api.Services.Caching;
+
+/// <summary>
+/// Redis connection config for the shared cache (hot feeds + trending) and cluster-wide
+/// rate limiting. Bound in Program.cs from the <c>REDIS_URL</c> env var. OPTIONAL: when
+/// <see cref="Url"/> is unset the API runs without Redis — an in-process L1 cache and
+/// per-instance rate limiters take over (mirrors the IGDB-optional pattern). Never 500s
+/// on a missing/unreachable Redis.
+/// </summary>
+public sealed class RedisOptions
+{
+    /// <summary>
+    /// Connection string in URL form: <c>redis://[:password@]host:port</c> (or
+    /// <c>rediss://</c> for TLS). StackExchange.Redis doesn't parse this scheme natively,
+    /// so <see cref="TryBuildConfiguration"/> translates it.
+    /// </summary>
+    public string? Url { get; set; }
+
+    /// <summary>Whether Redis-backed features are wired (vs. the in-process fallback).</summary>
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(Url);
+
+    /// <summary>
+    /// Translate <see cref="Url"/> into StackExchange.Redis <see cref="ConfigurationOptions"/>.
+    /// Returns false (rather than throwing) on a malformed URL so a typo degrades to the
+    /// in-process fallback instead of crashing startup. <c>AbortOnConnectFail = false</c> so
+    /// a Redis that's down at boot never hangs/throws — the multiplexer reconnects in the
+    /// background and the cache/limiter degrade gracefully until it does.
+    /// </summary>
+    public bool TryBuildConfiguration(out ConfigurationOptions configuration)
+    {
+        configuration = new ConfigurationOptions { AbortOnConnectFail = false };
+
+        if (!IsConfigured || !Uri.TryCreate(Url, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        var isTls = string.Equals(uri.Scheme, "rediss", StringComparison.OrdinalIgnoreCase);
+        if (!isTls && !string.Equals(uri.Scheme, "redis", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var port = uri.Port > 0 ? uri.Port : 6379;
+        configuration.EndPoints.Add(uri.Host, port);
+        configuration.Ssl = isTls;
+
+        // userinfo carries the password: redis://:pw@host or redis://user:pw@host. Redis AUTH
+        // is password-only (the username is the ACL user, optional). Take the password half.
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            var parts = uri.UserInfo.Split(':', 2);
+            configuration.Password = Uri.UnescapeDataString(parts.Length == 2 ? parts[1] : parts[0]);
+        }
+
+        return true;
+    }
+}

--- a/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
@@ -78,6 +78,7 @@ internal sealed class RedisFixedWindowRateLimiter : RateLimiter
     private readonly Lazy<FixedWindowRateLimiter> _fallback;
     private readonly ILogger<RedisFixedWindowRateLimiter> _logger;
     private int _degradedLogged;
+    private long _lastActivityTicks = Environment.TickCount64;
 
     public RedisFixedWindowRateLimiter(
         IConnectionMultiplexer multiplexer,
@@ -95,12 +96,17 @@ internal sealed class RedisFixedWindowRateLimiter : RateLimiter
         _logger = logger;
     }
 
-    public override TimeSpan? IdleDuration => null;
+    // Report idle time since the last acquire so the partitioned limiter's reaper can evict
+    // stale per-user / per-IP limiters — returning null (the default) would pin every partition
+    // key ever seen in memory for the life of the process.
+    public override TimeSpan? IdleDuration =>
+        TimeSpan.FromMilliseconds(Environment.TickCount64 - Interlocked.Read(ref _lastActivityTicks));
 
     public override RateLimiterStatistics? GetStatistics() => null;
 
     protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
     {
+        Interlocked.Exchange(ref _lastActivityTicks, Environment.TickCount64);
         try
         {
             var db = _multiplexer.GetDatabase();
@@ -119,6 +125,7 @@ internal sealed class RedisFixedWindowRateLimiter : RateLimiter
 
     protected override RateLimitLease AttemptAcquireCore(int permitCount)
     {
+        Interlocked.Exchange(ref _lastActivityTicks, Environment.TickCount64);
         try
         {
             var db = _multiplexer.GetDatabase();

--- a/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
@@ -1,0 +1,206 @@
+using System.Threading.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+
+namespace GankedTV.Api.Services.Caching;
+
+/// <summary>
+/// Builds the per-partition rate limiter used by the clip-write and credentials policies.
+/// When a shared <see cref="IConnectionMultiplexer"/> is registered (i.e. <c>REDIS_URL</c> is
+/// set) it returns a Redis fixed-window limiter so the limit is enforced cluster-wide across
+/// pods; otherwise it returns the in-process <see cref="FixedWindowRateLimiter"/> — identical
+/// to the pre-Redis behaviour. Resolved once per partition by the policy callbacks in
+/// ClipsRateLimiting / AuthRateLimiting (the framework caches limiter instances per key).
+/// </summary>
+public sealed class RedisRateLimiterFactory(IServiceProvider services, ILoggerFactory loggerFactory)
+{
+    /// <param name="policy">Namespaces the Redis key so the two policies never share a bucket.</param>
+    /// <param name="partitionKey">The caller bucket (e.g. <c>u:{userId}</c> / <c>ip:{ip}</c>).</param>
+    public RateLimiter Create(string policy, string partitionKey, int permitLimit, TimeSpan window)
+    {
+        var multiplexer = services.GetService<IConnectionMultiplexer>();
+        if (multiplexer is null)
+        {
+            return CreateLocal(permitLimit, window);
+        }
+
+        return new RedisFixedWindowRateLimiter(
+            multiplexer,
+            $"rl:{policy}:{partitionKey}",
+            permitLimit,
+            window,
+            () => CreateLocal(permitLimit, window),
+            loggerFactory.CreateLogger<RedisFixedWindowRateLimiter>());
+    }
+
+    internal static FixedWindowRateLimiter CreateLocal(int permitLimit, TimeSpan window) =>
+        new(new FixedWindowRateLimiterOptions
+        {
+            AutoReplenishment = true,
+            PermitLimit = permitLimit,
+            Window = window,
+            QueueLimit = 0,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+        });
+}
+
+/// <summary>
+/// Cluster-wide fixed-window limiter backed by an atomic Redis INCRBY+PEXPIRE script. On any
+/// Redis failure it transparently delegates to a lazily-created in-process limiter — so a Redis
+/// outage degrades to per-pod limiting (never unlimited, never a 500). The same partition's
+/// limiter instance is reused by the framework, so the local fallback's window state persists.
+/// </summary>
+internal sealed class RedisFixedWindowRateLimiter : RateLimiter
+{
+    // Fixed window via a single round trip. INCRBY creates the key at 0 implicitly; the first
+    // increment in a window (or any key that somehow lost its TTL) gets PEXPIRE so the window
+    // always expires. Returns {count, ttlMs} — the caller compares count to the permit limit
+    // and derives Retry-After from the remaining TTL.
+    //
+    // Note: the INCRBY runs before the limit check, so a rejected request still counts toward the
+    // window. That makes this marginally stricter than the in-process FixedWindowRateLimiter
+    // (which doesn't consume on rejection) — never looser — which is the safe direction for a
+    // limiter and the conventional Redis fixed-window tradeoff (no decrement race on rejection).
+    private const string Script = """
+        local current = redis.call('INCRBY', KEYS[1], ARGV[1])
+        local ttl = redis.call('PTTL', KEYS[1])
+        if ttl < 0 then
+          redis.call('PEXPIRE', KEYS[1], ARGV[2])
+          ttl = tonumber(ARGV[2])
+        end
+        return {current, ttl}
+        """;
+
+    private readonly IConnectionMultiplexer _multiplexer;
+    private readonly RedisKey _key;
+    private readonly int _permitLimit;
+    private readonly long _windowMs;
+    private readonly Lazy<FixedWindowRateLimiter> _fallback;
+    private readonly ILogger<RedisFixedWindowRateLimiter> _logger;
+    private int _degradedLogged;
+
+    public RedisFixedWindowRateLimiter(
+        IConnectionMultiplexer multiplexer,
+        string key,
+        int permitLimit,
+        TimeSpan window,
+        Func<FixedWindowRateLimiter> fallbackFactory,
+        ILogger<RedisFixedWindowRateLimiter> logger)
+    {
+        _multiplexer = multiplexer;
+        _key = key;
+        _permitLimit = permitLimit;
+        _windowMs = (long)window.TotalMilliseconds;
+        _fallback = new Lazy<FixedWindowRateLimiter>(fallbackFactory);
+        _logger = logger;
+    }
+
+    public override TimeSpan? IdleDuration => null;
+
+    public override RateLimiterStatistics? GetStatistics() => null;
+
+    protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var db = _multiplexer.GetDatabase();
+            var result = await db.ScriptEvaluateAsync(
+                Script,
+                [_key],
+                [permitCount, _windowMs]).ConfigureAwait(false);
+            return Evaluate(result);
+        }
+        catch (Exception ex) when (ex is RedisException or RedisTimeoutException)
+        {
+            LogDegraded(ex);
+            return await _fallback.Value.AcquireAsync(permitCount, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    protected override RateLimitLease AttemptAcquireCore(int permitCount)
+    {
+        try
+        {
+            var db = _multiplexer.GetDatabase();
+            var result = db.ScriptEvaluate(Script, [_key], [permitCount, _windowMs]);
+            return Evaluate(result);
+        }
+        catch (Exception ex) when (ex is RedisException or RedisTimeoutException)
+        {
+            LogDegraded(ex);
+            return _fallback.Value.AttemptAcquire(permitCount);
+        }
+    }
+
+    private RateLimitLease Evaluate(RedisResult result)
+    {
+        var values = (RedisResult[])result!;
+        var current = (long)values[0];
+        var ttlMs = (long)values[1];
+        if (current <= _permitLimit)
+        {
+            return RedisRateLimitLease.Acquired;
+        }
+
+        // Whole seconds, rounded up, per RFC 6585 Retry-After. A sub-second remainder still
+        // costs the client a full second of back-off — never advise retrying before the window
+        // actually rolls over.
+        var retryAfter = TimeSpan.FromSeconds(Math.Ceiling(Math.Max(0, ttlMs) / 1000.0));
+        return new RedisRateLimitLease(retryAfter);
+    }
+
+    private void LogDegraded(Exception ex)
+    {
+        if (Interlocked.Exchange(ref _degradedLogged, 1) == 0)
+        {
+            _logger.LogWarning(ex,
+                "Redis rate limiter unavailable for {Key}; degrading to in-process limiting until it recovers.",
+                (string?)_key);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _fallback.IsValueCreated)
+        {
+            _fallback.Value.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}
+
+/// <summary>
+/// Minimal lease for the Redis limiter: granted leases carry no metadata; rejected leases carry
+/// the <c>Retry-After</c> the shared OnRejected handler stamps onto the 429.
+/// </summary>
+internal sealed class RedisRateLimitLease : RateLimitLease
+{
+    private static readonly string[] RetryAfterMetadata = [MetadataName.RetryAfter.Name];
+
+    /// <summary>Shared granted lease — acquired leases are stateless, so one instance suffices.</summary>
+    public static readonly RedisRateLimitLease Acquired = new();
+
+    private readonly TimeSpan? _retryAfter;
+
+    private RedisRateLimitLease() => _retryAfter = null;
+
+    public RedisRateLimitLease(TimeSpan retryAfter) => _retryAfter = retryAfter;
+
+    public override bool IsAcquired => _retryAfter is null;
+
+    public override IEnumerable<string> MetadataNames =>
+        _retryAfter is null ? Array.Empty<string>() : RetryAfterMetadata;
+
+    public override bool TryGetMetadata(string metadataName, out object? metadata)
+    {
+        if (_retryAfter is { } value && metadataName == MetadataName.RetryAfter.Name)
+        {
+            metadata = value;
+            return true;
+        }
+
+        metadata = null;
+        return false;
+    }
+}

--- a/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
@@ -203,7 +203,11 @@ internal sealed class RedisRateLimitLease : RateLimitLease
 {
     private static readonly string[] RetryAfterMetadata = [MetadataName.RetryAfter.Name];
 
-    /// <summary>Shared granted lease — acquired leases are stateless, so one instance suffices.</summary>
+    /// <summary>
+    /// Shared granted lease — acquired leases are stateless and carry no metadata, so one instance
+    /// suffices. Safe only because the base <see cref="RateLimitLease.Dispose(bool)"/> is a no-op
+    /// (this type adds no disposable state); if that ever changes, switch to a per-acquire instance.
+    /// </summary>
     public static readonly RedisRateLimitLease Acquired = new();
 
     private readonly TimeSpan? _retryAfter;

--- a/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisRateLimiterFactory.cs
@@ -16,6 +16,11 @@ public sealed class RedisRateLimiterFactory(IServiceProvider services, ILoggerFa
 {
     /// <param name="policy">Namespaces the Redis key so the two policies never share a bucket.</param>
     /// <param name="partitionKey">The caller bucket (e.g. <c>u:{userId}</c> / <c>ip:{ip}</c>).</param>
+    /// <remarks>
+    /// Callers must acquire with <c>permitCount &lt;= permitLimit</c>. The Redis path increments
+    /// before checking, so a single over-limit acquisition would poison the window for its whole
+    /// duration. Every current caller acquires exactly 1 permit, well under both policies' limits.
+    /// </remarks>
     public RateLimiter Create(string policy, string partitionKey, int permitLimit, TimeSpan window)
     {
         var multiplexer = services.GetService<IConnectionMultiplexer>();
@@ -110,13 +115,15 @@ internal sealed class RedisFixedWindowRateLimiter : RateLimiter
         try
         {
             var db = _multiplexer.GetDatabase();
-            var result = await db.ScriptEvaluateAsync(
-                Script,
-                [_key],
-                [permitCount, _windowMs]).ConfigureAwait(false);
+            // ScriptEvaluateAsync has no CancellationToken overload, so WaitAsync releases the
+            // request when the client aborts (e.g. a stuck Redis) instead of pinning it until
+            // AsyncTimeout. OperationCanceledException then propagates — deliberately not caught.
+            var result = await db.ScriptEvaluateAsync(Script, [_key], [permitCount, _windowMs])
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
             return Evaluate(result);
         }
-        catch (Exception ex) when (ex is RedisException or RedisTimeoutException)
+        catch (Exception ex) when (IsRedisFailure(ex))
         {
             LogDegraded(ex);
             return await _fallback.Value.AcquireAsync(permitCount, cancellationToken).ConfigureAwait(false);
@@ -132,15 +139,26 @@ internal sealed class RedisFixedWindowRateLimiter : RateLimiter
             var result = db.ScriptEvaluate(Script, [_key], [permitCount, _windowMs]);
             return Evaluate(result);
         }
-        catch (Exception ex) when (ex is RedisException or RedisTimeoutException)
+        catch (Exception ex) when (IsRedisFailure(ex))
         {
             LogDegraded(ex);
             return _fallback.Value.AttemptAcquire(permitCount);
         }
     }
 
+    // Any infra-level failure must degrade to the in-process limiter rather than 500. Besides the
+    // Redis exception types, GetDatabase() throws ObjectDisposedException when the multiplexer is
+    // torn down during a graceful-shutdown / test-teardown race. Cancellation is NOT a failure —
+    // it must propagate so an aborted request stops promptly.
+    private static bool IsRedisFailure(Exception ex) =>
+        ex is RedisException or RedisTimeoutException or ObjectDisposedException or TimeoutException;
+
     private RateLimitLease Evaluate(RedisResult result)
     {
+        // A successful round trip means Redis is back; re-arm the degraded warning so a later
+        // outage logs again (otherwise a flapping Redis logs only once for the life of the pod).
+        Interlocked.Exchange(ref _degradedLogged, 0);
+
         var values = (RedisResult[])result!;
         var current = (long)values[0];
         var ttlMs = (long)values[1];

--- a/server/src/GankedTV.Api/Services/Caching/RedisRegistration.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisRegistration.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 
 namespace GankedTV.Api.Services.Caching;
@@ -26,13 +28,17 @@ public static class RedisRegistration
 
         if (options.TryBuildConfiguration(out var configuration))
         {
-            // AbortOnConnectFail=false (set in TryBuildConfiguration) means Connect returns a
-            // multiplexer immediately even if Redis is down at boot; it reconnects in the
-            // background. A single shared multiplexer backs both the L2 cache and the limiter.
-            var multiplexer = ConnectionMultiplexer.Connect(configuration);
-            services.AddSingleton<IConnectionMultiplexer>(multiplexer);
-            services.AddStackExchangeRedisCache(o =>
-                o.ConnectionMultiplexerFactory = () => Task.FromResult<IConnectionMultiplexer>(multiplexer));
+            // Lazy, container-owned singleton: Connect runs on first resolve (first cache op or
+            // rate-limited request), not at boot — so a slow/unreachable Redis never delays
+            // startup (AbortOnConnectFail=false also keeps it non-throwing). Registering the
+            // factory (not a pre-built instance) lets the DI container dispose it on shutdown,
+            // giving Redis a clean QUIT instead of a dropped TCP connection. Both the L2 cache and
+            // the limiter resolve this same instance, so there's still exactly one connection.
+            services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(configuration));
+            services.AddStackExchangeRedisCache(_ => { });
+            services.AddOptions<RedisCacheOptions>().Configure<IServiceProvider>((cacheOptions, sp) =>
+                cacheOptions.ConnectionMultiplexerFactory =
+                    () => Task.FromResult(sp.GetRequiredService<IConnectionMultiplexer>()));
         }
 
         return services;

--- a/server/src/GankedTV.Api/Services/Caching/RedisRegistration.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisRegistration.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Caching.Hybrid;
+using StackExchange.Redis;
+
+namespace GankedTV.Api.Services.Caching;
+
+/// <summary>
+/// Wires the caching + cluster-coordination stack, gated on whether Redis is configured.
+/// Lives in a service (not Program.cs) so the conditional logic stays inside the coverage
+/// denominator per CLAUDE.md.
+///
+/// Always registers <see cref="HybridCache"/>, <see cref="FeedCache"/>, and
+/// <see cref="RedisRateLimiterFactory"/>. When <c>REDIS_URL</c> is set and parses, also
+/// registers a shared <see cref="IConnectionMultiplexer"/> and attaches Redis as HybridCache's
+/// L2 (the <c>IDistributedCache</c>) — so the same connection backs both caching and the
+/// rate limiter. When it's unset/malformed, HybridCache runs L1-only and the limiter falls
+/// back to in-process: local dev needs no Redis.
+/// </summary>
+public static class RedisRegistration
+{
+    public static IServiceCollection AddGankedCaching(this IServiceCollection services, RedisOptions options)
+    {
+        services.AddHybridCache();
+        services.AddSingleton<IFeedCache, FeedCache>();
+        services.AddSingleton<IGamesCache, GamesCache>();
+        services.AddSingleton<RedisRateLimiterFactory>();
+
+        if (options.TryBuildConfiguration(out var configuration))
+        {
+            // AbortOnConnectFail=false (set in TryBuildConfiguration) means Connect returns a
+            // multiplexer immediately even if Redis is down at boot; it reconnects in the
+            // background. A single shared multiplexer backs both the L2 cache and the limiter.
+            var multiplexer = ConnectionMultiplexer.Connect(configuration);
+            services.AddSingleton<IConnectionMultiplexer>(multiplexer);
+            services.AddStackExchangeRedisCache(o =>
+                o.ConnectionMultiplexerFactory = () => Task.FromResult<IConnectionMultiplexer>(multiplexer));
+        }
+
+        return services;
+    }
+}

--- a/server/src/GankedTV.Api/Services/Media/ClipStageWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/ClipStageWorker.cs
@@ -1,3 +1,4 @@
+using GankedTV.Api.Services.Caching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -30,4 +31,21 @@ public abstract class ClipStageWorker : MediaStageWorker<ClaimedMediaJob>
 
     protected override Task FailAsync(IServiceProvider scope, ClaimedMediaJob job, CancellationToken ct) =>
         scope.GetRequiredService<IClipMediaJobStore>().MarkFailedAsync(job.ClipId, job.AttemptNumber, ClaimStatus, ct);
+
+    // Drop cached feed pages once a clip becomes feed-visible (reaches 'ready'). Best-effort: the
+    // status transition has already committed, so a cache failure (e.g. Redis down) must NOT bubble
+    // up — that would trip the stage's failure/retry path on an already-ready clip. Resolved from
+    // the scope to avoid widening worker constructors; the short TTL self-heals if a hit is missed.
+    protected static async Task InvalidateFeedsBestEffortAsync(IServiceProvider scope, CancellationToken ct)
+    {
+        try
+        {
+            await scope.GetRequiredService<IFeedCache>().InvalidateFeedsAsync(ct);
+        }
+        catch (Exception ex) when (!ct.IsCancellationRequested)
+        {
+            scope.GetService<ILoggerFactory>()?.CreateLogger(typeof(ClipStageWorker).FullName!)
+                .LogWarning(ex, "Feed cache invalidation failed after a clip reached ready; entries will expire via TTL.");
+        }
+    }
 }

--- a/server/src/GankedTV.Api/Services/Media/CompressWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/CompressWorker.cs
@@ -39,6 +39,9 @@ public sealed class CompressWorker : ClipStageWorker
         var result = await compressor.CompressAsync(job, ct);
         await store.CompleteCompressionAsync(job.ClipId, job.AttemptNumber, result.VideoKey, result.VideoCodec, ct);
 
+        // The clip is now 'ready' (feed-visible) — drop cached feed pages so it appears promptly.
+        await InvalidateFeedsBestEffortAsync(scope, ct);
+
         // Delete the original only now that the row points at the compressed master. The clip
         // is already 'ready', so a delete failure must NOT bubble up: that would log a bogus
         // "compress failed" and trigger a pointless retry on a row that's no longer claimable.

--- a/server/src/GankedTV.Api/Services/Media/ThumbnailWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/ThumbnailWorker.cs
@@ -37,5 +37,12 @@ public sealed class ThumbnailWorker : ClipStageWorker
         // otherwise the thumbnail is the last step and the clip is ready (stores the upload).
         var toStatus = opts.TranscodeEnabled ? ClipStatuses.Transcoding : ClipStatuses.Ready;
         await store.AdvanceThumbnailAsync(job.ClipId, job.AttemptNumber, result, toStatus, ct);
+
+        // Only the thumbnail-is-final path makes the clip feed-visible; when it hands off to the
+        // compress stage, CompressWorker invalidates once it reaches 'ready'.
+        if (toStatus == ClipStatuses.Ready)
+        {
+            await InvalidateFeedsBestEffortAsync(scope, ct);
+        }
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsMutateEndpointsTests.cs
@@ -1,13 +1,17 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
 
 namespace GankedTV.Api.Tests.Integration.Endpoints;
@@ -85,6 +89,35 @@ public class ClipsMutateEndpointsTests : IAsyncLifetime
     }
 
     // ---- PATCH /clips/{id} ----
+
+    [Fact]
+    public async Task Patch_FeedCacheInvalidationThrows_StillReturns200()
+    {
+        // Codifies the spec's "Redis unavailable → no 500s": the DB write has committed, so a
+        // throwing best-effort invalidation must not surface as a 500. Overrides IFeedCache with
+        // a substitute that throws on InvalidateFeedsAsync.
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedClipAsync(userId, title: "before");
+
+        var throwingCache = Substitute.For<IFeedCache>();
+        throwingCache.When(c => c.InvalidateFeedsAsync(Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("redis down"));
+        using var factory = _factory!.WithWebHostBuilder(b => b.ConfigureServices(s =>
+        {
+            s.RemoveAll<IFeedCache>();
+            s.AddSingleton(throwingCache);
+        }));
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var resp = await client.PatchAsJsonAsync($"/clips/{clipId}", new { title = "after" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var db = _fx.CreateContext();
+        (await db.Clips.AsNoTracking().Where(c => c.Id == clipId).Select(c => c.Title).FirstAsync())
+            .Should().Be("after"); // the write persisted despite the cache failure
+    }
 
     [Fact]
     public async Task Patch_NoBearer_Returns401()

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -378,6 +378,40 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Feed_CachedFirstPage_LikedByMeStaysPerCaller()
+    {
+        // The first-page anonymous projection is cached and shared; likedByMe must be re-stamped
+        // per caller so one user's like never leaks to another through the cache.
+        await _fx.ResetAsync();
+        var (likerId, likerToken) = await SeedUserAndIssueTokenAsync("liker");
+        var (authorId, _) = await SeedUserAndIssueTokenAsync("author2");
+        var (clipId, _) = await SeedClipAsync(authorId, DateTimeOffset.UtcNow);
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = likerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await db.SaveChangesAsync();
+        }
+
+        // Anonymous request first → populates the shared cache entry with likedByMe=false.
+        using (var anon = _factory!.CreateClient())
+        {
+            var anonBody = await (await anon.GetAsync("/clips/feed")).Content.ReadFromJsonAsync<JsonElement>();
+            anonBody.GetProperty("items").EnumerateArray()
+                .Select(e => e.GetProperty("likedByMe").GetBoolean())
+                .Should().OnlyContain(l => l == false);
+        }
+
+        // The liker hits the same cached page within TTL but must still see likedByMe=true.
+        using (var likerClient = ClientWithBearer(likerToken))
+        {
+            var likerBody = await (await likerClient.GetAsync("/clips/feed")).Content.ReadFromJsonAsync<JsonElement>();
+            likerBody.GetProperty("items").EnumerateArray()
+                .Single(e => e.GetProperty("id").GetGuid() == clipId)
+                .GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+        }
+    }
+
+    [Fact]
     public async Task Feed_FeedItemShape_ContainsAuthorAndThumbnailUrl()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -412,6 +412,40 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Feed_CachedFirstPage_FilledByAuthedUser_DoesNotLeakToAnother()
+    {
+        // Symmetric to the test above, guarding the riskier direction: an *authenticated* caller
+        // (who liked the clip) warms the cache, then a different user reads the same entry. Because
+        // only the anonymous projection is cached, the filler's likedByMe must never leak — a future
+        // refactor routing an authed caller through a non-anonymous factory would trip this.
+        await _fx.ResetAsync();
+        var (likerId, likerToken) = await SeedUserAndIssueTokenAsync("liker-fills");
+        var (_, otherToken) = await SeedUserAndIssueTokenAsync("other-reads");
+        var (clipId, _) = await SeedClipAsync(likerId, DateTimeOffset.UtcNow);
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = likerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await db.SaveChangesAsync();
+        }
+
+        // Liker warms the cache via the authenticated path → sees their own like.
+        using (var likerClient = ClientWithBearer(likerToken))
+        {
+            var body = await (await likerClient.GetAsync("/clips/feed")).Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("items").EnumerateArray().Single(e => e.GetProperty("id").GetGuid() == clipId)
+                .GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+        }
+
+        // A different user reads the same cached page and must NOT inherit the liker's flag.
+        using (var otherClient = ClientWithBearer(otherToken))
+        {
+            var body = await (await otherClient.GetAsync("/clips/feed")).Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("items").EnumerateArray().Single(e => e.GetProperty("id").GetGuid() == clipId)
+                .GetProperty("likedByMe").GetBoolean().Should().BeFalse();
+        }
+    }
+
+    [Fact]
     public async Task Feed_FeedItemShape_ContainsAuthorAndThumbnailUrl()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/TagsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/TagsEndpointsTests.cs
@@ -215,6 +215,39 @@ public class TagsEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetClipsForTag_CachedFirstPage_LikedByMeStaysPerCaller()
+    {
+        // The tag-clips first page is cached as an anonymous projection (same as latest/game feeds);
+        // likedByMe must be re-stamped per caller so a like never leaks across users via the cache.
+        await _fx.ResetAsync();
+        var (likerId, likerToken) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "tag-liker");
+        var (clipId, _) = await SeedClipAsync(likerId, DateTimeOffset.UtcNow, tagSlugs: new[] { "clutch" });
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = likerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow });
+            await db.SaveChangesAsync();
+        }
+
+        // Anonymous request first → populates the shared cache entry with likedByMe=false.
+        using (var anon = _factory!.CreateClient())
+        {
+            var anonBody = await (await anon.GetAsync("/tags/clutch/clips")).Content.ReadFromJsonAsync<JsonElement>();
+            anonBody.GetProperty("items").EnumerateArray()
+                .Select(e => e.GetProperty("likedByMe").GetBoolean())
+                .Should().OnlyContain(l => l == false);
+        }
+
+        // The liker hits the same cached page within TTL but must still see likedByMe=true.
+        using (var likerClient = AuthTestHelpers.CreateBearerClient(_factory!, likerToken))
+        {
+            var likerBody = await (await likerClient.GetAsync("/tags/clutch/clips")).Content.ReadFromJsonAsync<JsonElement>();
+            likerBody.GetProperty("items").EnumerateArray()
+                .Single(e => e.GetProperty("id").GetGuid() == clipId)
+                .GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+        }
+    }
+
+    [Fact]
     public async Task GetClipsForTag_UnknownSlug_Returns404()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/CachedFeedPageSerializationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/CachedFeedPageSerializationTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Contracts.Tags;
+using GankedTV.Api.Services.Caching;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Services.Caching;
+
+// The unit/integration tests run HybridCache L1-only, where values are stored by reference and
+// never serialized — so a CachedFeedPage that fails to round-trip through the Redis L2 would only
+// surface in production. HybridCache serializes objects with System.Text.Json by default, so this
+// asserts the cached payload (a positional record with nested records + a collection) survives a
+// default STJ round-trip — the failure mode being a type STJ can't reconstruct.
+public class CachedFeedPageSerializationTests
+{
+    [Fact]
+    public void CachedFeedPage_RoundTripsThroughSystemTextJson()
+    {
+        var page = new CachedFeedPage(
+            [
+                new ClipFeedItem(
+                    Id: Guid.NewGuid(),
+                    ShareCode: "abc123",
+                    Title: "Clutch 1v5",
+                    Description: "ace on Ascent",
+                    ThumbnailUrl: "https://cdn.example/thumb.jpg?sig=xyz",
+                    DurationSecs: 42,
+                    ViewCount: 1234,
+                    LikeCount: 56,
+                    CreatedAt: DateTimeOffset.UtcNow,
+                    Author: new AuthorSummary(Guid.NewGuid(), "player1", "https://cdn.example/avatar.png"),
+                    Game: new GameSummary(7, "Valorant", "valorant", "VAL"),
+                    Tags: [new TagSummary(1, "ace", "Ace", 99)],
+                    LikedByMe: false),
+                // A second item with the nullable fields null, to cover those branches too.
+                new ClipFeedItem(
+                    Id: Guid.NewGuid(),
+                    ShareCode: "def456",
+                    Title: "No game tag",
+                    Description: null,
+                    ThumbnailUrl: "https://cdn.example/thumb2.jpg",
+                    DurationSecs: null,
+                    ViewCount: 0,
+                    LikeCount: 0,
+                    CreatedAt: DateTimeOffset.UtcNow.AddMinutes(-5),
+                    Author: new AuthorSummary(Guid.NewGuid(), "player2", null),
+                    Game: null,
+                    Tags: [],
+                    LikedByMe: false),
+            ],
+            NextCursor: "cursor-token");
+
+        var json = JsonSerializer.Serialize(page);
+        var roundTripped = JsonSerializer.Deserialize<CachedFeedPage>(json);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.NextCursor.Should().Be("cursor-token");
+        roundTripped.Items.Should().BeEquivalentTo(page.Items); // every nested field must survive
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/FeedCacheTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/FeedCacheTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using GankedTV.Api.Services.Caching;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Services.Caching;
+
+// Exercises FeedCache against a real HybridCache (L1-only — no Redis registered, mirroring local
+// dev / a Redis outage). Verifies the cache-hit, tag-invalidation, and tag-isolation behaviour the
+// endpoints rely on.
+public class FeedCacheTests
+{
+    private static (FeedCache cache, ServiceProvider sp) Build()
+    {
+        var services = new ServiceCollection();
+        services.AddHybridCache();
+        var sp = services.BuildServiceProvider();
+        return (new FeedCache(sp.GetRequiredService<HybridCache>()), sp);
+    }
+
+    private static CachedFeedPage Page(string? cursor = null) => new([], cursor);
+
+    [Fact]
+    public async Task GetOrCreateFeedAsync_SecondCall_ServedFromCache()
+    {
+        var (cache, sp) = Build();
+        await using var _ = sp;
+        var calls = 0;
+
+        ValueTask<CachedFeedPage> Factory(CancellationToken _)
+        {
+            calls++;
+            return new ValueTask<CachedFeedPage>(Page("c1"));
+        }
+
+        var first = await cache.GetOrCreateFeedAsync("feed:latest:20", Factory, default);
+        var second = await cache.GetOrCreateFeedAsync("feed:latest:20", Factory, default);
+
+        calls.Should().Be(1, "the second call must hit the cache, not the factory");
+        first.NextCursor.Should().Be("c1");
+        second.NextCursor.Should().Be("c1");
+    }
+
+    [Fact]
+    public async Task InvalidateFeedsAsync_ForcesFactoryToRunAgain()
+    {
+        var (cache, sp) = Build();
+        await using var _ = sp;
+        var calls = 0;
+        ValueTask<CachedFeedPage> Factory(CancellationToken _)
+        {
+            calls++;
+            return new ValueTask<CachedFeedPage>(Page());
+        }
+
+        await cache.GetOrCreateFeedAsync("feed:latest:20", Factory, default);
+        await cache.InvalidateFeedsAsync(default);
+        await cache.GetOrCreateFeedAsync("feed:latest:20", Factory, default);
+
+        calls.Should().Be(2, "invalidation must drop the entry so the next read re-queries");
+    }
+
+    [Fact]
+    public async Task InvalidateFeedsAsync_DoesNotEvictTrending()
+    {
+        // Trending lives under its own tag and is TTL-governed; a feed invalidation must leave it.
+        var (cache, sp) = Build();
+        await using var _ = sp;
+        var trendingCalls = 0;
+        ValueTask<CachedFeedPage> Trending(CancellationToken _)
+        {
+            trendingCalls++;
+            return new ValueTask<CachedFeedPage>(Page());
+        }
+
+        await cache.GetOrCreateTrendingAsync("feed:trending:24h:20", Trending, default);
+        await cache.InvalidateFeedsAsync(default);
+        await cache.GetOrCreateTrendingAsync("feed:trending:24h:20", Trending, default);
+
+        trendingCalls.Should().Be(1, "the feed tag must not evict trending entries");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/GamesCacheTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/GamesCacheTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Services.Caching;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Services.Caching;
+
+// Exercises GamesCache against a real HybridCache (L1-only — no Redis). Verifies the cache-hit
+// behaviour the games endpoints rely on, plus that the cached payloads survive the System.Text.Json
+// round-trip the Redis L2 performs (L1-only tests store by reference and wouldn't catch that).
+public class GamesCacheTests
+{
+    private static (GamesCache cache, ServiceProvider sp) Build()
+    {
+        var services = new ServiceCollection();
+        services.AddHybridCache();
+        var sp = services.BuildServiceProvider();
+        return (new GamesCache(sp.GetRequiredService<HybridCache>()), sp);
+    }
+
+    [Fact]
+    public async Task GetOrCreateListAsync_SecondCall_ServedFromCache()
+    {
+        var (cache, sp) = Build();
+        await using var _ = sp;
+        var calls = 0;
+        ValueTask<IReadOnlyList<GameListItem>> Factory(CancellationToken _)
+        {
+            calls++;
+            return new ValueTask<IReadOnlyList<GameListItem>>(
+                new List<GameListItem> { new(1, "Valorant", "valorant", "VAL", null) });
+        }
+
+        var first = await cache.GetOrCreateListAsync("games:list:hasClips=true:20", Factory, default);
+        var second = await cache.GetOrCreateListAsync("games:list:hasClips=true:20", Factory, default);
+
+        calls.Should().Be(1);
+        first.Should().ContainSingle();
+        second[0].Slug.Should().Be("valorant");
+    }
+
+    [Fact]
+    public async Task GetOrCreateDetailAsync_SecondCall_ServedFromCache()
+    {
+        var (cache, sp) = Build();
+        await using var _ = sp;
+        var calls = 0;
+        ValueTask<GameDetail?> Factory(CancellationToken _)
+        {
+            calls++;
+            return new ValueTask<GameDetail?>(new GameDetail(7, "Counter-Strike 2", "cs2", "CS2", "http://x/cs2.jpg", 42));
+        }
+
+        var first = await cache.GetOrCreateDetailAsync("games:detail:cs2", Factory, default);
+        var second = await cache.GetOrCreateDetailAsync("games:detail:cs2", Factory, default);
+
+        calls.Should().Be(1);
+        first!.ClipCount.Should().Be(42);
+        second!.Slug.Should().Be("cs2");
+    }
+
+    [Fact]
+    public void GamesCatalogDtos_RoundTripThroughSystemTextJson()
+    {
+        // HybridCache serializes L2 entries with System.Text.Json; confirm the cached payloads
+        // (records, one with a null CoverUrl) reconstruct faithfully.
+        var list = new List<GameListItem>
+        {
+            new(1, "Valorant", "valorant", "VAL", "http://cdn/val.jpg"),
+            new(2, "Dota 2", "dota-2", "DOTA2", null),
+        };
+        var detail = new GameDetail(3, "Apex Legends", "apex-legends", "APEX", null, 99);
+
+        JsonSerializer.Deserialize<List<GameListItem>>(JsonSerializer.Serialize(list))
+            .Should().BeEquivalentTo(list);
+        JsonSerializer.Deserialize<GameDetail>(JsonSerializer.Serialize(detail))
+            .Should().BeEquivalentTo(detail);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/RedisOptionsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/RedisOptionsTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using GankedTV.Api.Services.Caching;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Services.Caching;
+
+public class RedisOptionsTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("redis://localhost:6379", true)]
+    public void IsConfigured_TracksUrlPresence(string? url, bool expected)
+    {
+        new RedisOptions { Url = url }.IsConfigured.Should().Be(expected);
+    }
+
+    [Fact]
+    public void TryBuildConfiguration_ParsesHostAndPort()
+    {
+        var ok = new RedisOptions { Url = "redis://localhost:6380" }.TryBuildConfiguration(out var config);
+
+        ok.Should().BeTrue();
+        config.EndPoints.Should().ContainSingle();
+        config.EndPoints[0].ToString().Should().Contain("localhost").And.Contain("6380");
+        config.Ssl.Should().BeFalse();
+        // AbortOnConnectFail must stay false so a down-at-boot Redis never hangs/throws startup.
+        config.AbortOnConnectFail.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryBuildConfiguration_DefaultsPortWhenOmitted()
+    {
+        new RedisOptions { Url = "redis://cache.internal" }.TryBuildConfiguration(out var config);
+
+        config.EndPoints[0].ToString().Should().Contain("6379");
+    }
+
+    [Fact]
+    public void TryBuildConfiguration_RedissEnablesTls()
+    {
+        var ok = new RedisOptions { Url = "rediss://secure-host:6380" }.TryBuildConfiguration(out var config);
+
+        ok.Should().BeTrue();
+        config.Ssl.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryBuildConfiguration_ExtractsPasswordFromUserInfo()
+    {
+        // redis://:password@host and redis://user:password@host both carry the password second.
+        new RedisOptions { Url = "redis://:s3cr3t@host:6379" }.TryBuildConfiguration(out var withColon);
+        withColon.Password.Should().Be("s3cr3t");
+
+        new RedisOptions { Url = "redis://aclu:p%40ss@host:6379" }.TryBuildConfiguration(out var withUser);
+        withUser.Password.Should().Be("p@ss"); // %40 decoded
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not a url")]
+    [InlineData("http://localhost:6379")] // wrong scheme
+    public void TryBuildConfiguration_ReturnsFalse_ForMalformedOrWrongScheme(string? url)
+    {
+        // A bad URL must degrade to the in-process fallback, never crash startup.
+        new RedisOptions { Url = url }.TryBuildConfiguration(out _).Should().BeFalse();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/RedisOptionsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/RedisOptionsTests.cs
@@ -49,11 +49,14 @@ public class RedisOptionsTests
     [Fact]
     public void TryBuildConfiguration_ExtractsPasswordFromUserInfo()
     {
-        // redis://:password@host and redis://user:password@host both carry the password second.
+        // redis://:password@host → password only, no ACL user.
         new RedisOptions { Url = "redis://:s3cr3t@host:6379" }.TryBuildConfiguration(out var withColon);
         withColon.Password.Should().Be("s3cr3t");
+        withColon.User.Should().BeNull();
 
+        // redis://user:password@host → ACL username preserved alongside the password.
         new RedisOptions { Url = "redis://aclu:p%40ss@host:6379" }.TryBuildConfiguration(out var withUser);
+        withUser.User.Should().Be("aclu");
         withUser.Password.Should().Be("p@ss"); // %40 decoded
     }
 

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRateLimiterFactoryTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRateLimiterFactoryTests.cs
@@ -1,0 +1,114 @@
+using System.Threading.RateLimiting;
+using FluentAssertions;
+using GankedTV.Api.Services.Caching;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Services.Caching;
+
+public class RedisRateLimiterFactoryTests
+{
+    private static RedisRateLimiterFactory FactoryWith(IConnectionMultiplexer? multiplexer)
+    {
+        var services = new ServiceCollection();
+        if (multiplexer is not null)
+        {
+            services.AddSingleton(multiplexer);
+        }
+        var sp = services.BuildServiceProvider();
+        return new RedisRateLimiterFactory(sp, NullLoggerFactory.Instance);
+    }
+
+    // {current, ttlMs} multi-bulk reply, matching the Lua script's return shape.
+    private static RedisResult ScriptReply(long current, long ttlMs) =>
+        RedisResult.Create(new RedisValue[] { current, ttlMs });
+
+    private static (IConnectionMultiplexer mux, IDatabase db) MuxReturning(RedisResult reply)
+    {
+        var db = Substitute.For<IDatabase>();
+        db.ScriptEvaluateAsync(Arg.Any<string>(), Arg.Any<RedisKey[]>(), Arg.Any<RedisValue[]>(), Arg.Any<CommandFlags>())
+            .Returns(reply);
+        db.ScriptEvaluate(Arg.Any<string>(), Arg.Any<RedisKey[]>(), Arg.Any<RedisValue[]>(), Arg.Any<CommandFlags>())
+            .Returns(reply);
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        mux.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(db);
+        return (mux, db);
+    }
+
+    [Fact]
+    public async Task NoMultiplexer_EnforcesLimitInProcess()
+    {
+        var limiter = FactoryWith(null).Create("clips-write", "u:1", permitLimit: 2, TimeSpan.FromMinutes(1));
+
+        (await limiter.AcquireAsync(1)).IsAcquired.Should().BeTrue();
+        (await limiter.AcquireAsync(1)).IsAcquired.Should().BeTrue();
+        using var rejected = await limiter.AcquireAsync(1);
+        rejected.IsAcquired.Should().BeFalse("the third acquire exceeds the local fixed window of 2");
+    }
+
+    [Fact]
+    public async Task Redis_WithinLimit_IsAcquired()
+    {
+        var (mux, _) = MuxReturning(ScriptReply(current: 1, ttlMs: 60_000));
+        var limiter = FactoryWith(mux).Create("clips-write", "u:1", permitLimit: 30, TimeSpan.FromMinutes(1));
+
+        using var lease = await limiter.AcquireAsync(1);
+
+        lease.IsAcquired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Redis_OverLimit_RejectsWithRetryAfterFromTtl()
+    {
+        // count 31 > limit 30, 1500ms remaining → Retry-After rounds up to 2 seconds.
+        var (mux, _) = MuxReturning(ScriptReply(current: 31, ttlMs: 1500));
+        var limiter = FactoryWith(mux).Create("clips-write", "u:1", permitLimit: 30, TimeSpan.FromMinutes(1));
+
+        using var lease = await limiter.AcquireAsync(1);
+
+        lease.IsAcquired.Should().BeFalse();
+        lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter).Should().BeTrue();
+        retryAfter.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task Redis_Throws_FallsBackToInProcessLimiter()
+    {
+        var db = Substitute.For<IDatabase>();
+        db.ScriptEvaluateAsync(Arg.Any<string>(), Arg.Any<RedisKey[]>(), Arg.Any<RedisValue[]>(), Arg.Any<CommandFlags>())
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "down"));
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        mux.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(db);
+
+        var limiter = FactoryWith(mux).Create("clips-write", "u:1", permitLimit: 1, TimeSpan.FromMinutes(1));
+
+        // First acquire degrades to the in-process limiter and is granted; the second exceeds
+        // the local limit of 1 — proving the fallback enforces (degraded, not fail-open).
+        (await limiter.AcquireAsync(1)).IsAcquired.Should().BeTrue();
+        using var rejected = await limiter.AcquireAsync(1);
+        rejected.IsAcquired.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Redis_SyncAttemptAcquire_Works()
+    {
+        var (mux, _) = MuxReturning(ScriptReply(current: 1, ttlMs: 60_000));
+        var limiter = FactoryWith(mux).Create("auth-credentials", "ip:1.2.3.4", permitLimit: 5, TimeSpan.FromMinutes(1));
+
+        using var lease = limiter.AttemptAcquire(1);
+
+        lease.IsAcquired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AcquiredLease_ExposesNoRetryAfterMetadata()
+    {
+        RedisRateLimitLease.Acquired.IsAcquired.Should().BeTrue();
+        RedisRateLimitLease.Acquired.MetadataNames.Should().BeEmpty();
+        RedisRateLimitLease.Acquired.TryGetMetadata(MetadataName.RetryAfter, out _).Should().BeFalse();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRateLimiterFactoryTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRateLimiterFactoryTests.cs
@@ -53,12 +53,19 @@ public class RedisRateLimiterFactoryTests
     [Fact]
     public async Task Redis_WithinLimit_IsAcquired()
     {
-        var (mux, _) = MuxReturning(ScriptReply(current: 1, ttlMs: 60_000));
+        var (mux, db) = MuxReturning(ScriptReply(current: 1, ttlMs: 60_000));
         var limiter = FactoryWith(mux).Create("clips-write", "u:1", permitLimit: 30, TimeSpan.FromMinutes(1));
 
         using var lease = await limiter.AcquireAsync(1);
 
         lease.IsAcquired.Should().BeTrue();
+        // Pin the Lua contract: a regression that swaps INCRBY/PEXPIRE, reorders KEYS/ARGV, or
+        // reshapes the call would otherwise slip past the lease-only assertions.
+        await db.Received(1).ScriptEvaluateAsync(
+            Arg.Is<string>(s => s.Contains("INCRBY") && s.Contains("PEXPIRE")),
+            Arg.Is<RedisKey[]>(k => k.Length == 1 && k[0] == "rl:clips-write:u:1"),
+            Arg.Is<RedisValue[]>(v => v.Length == 2 && (long)v[0] == 1 && (long)v[1] == 60_000),
+            Arg.Any<CommandFlags>());
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Services/Media/MediaStageWorkerTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Media/MediaStageWorkerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.Media;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.Extensions.DependencyInjection;
@@ -252,6 +253,43 @@ public class MediaStageWorkerTests
 
         await store.Received(1).CompleteCompressionAsync(job.ClipId, 1, "u/clip.cmp.mp4", "av1", Arg.Any<CancellationToken>());
         await storage.Received(1).DeleteObjectAsync("clips", "u/clip.mp4", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Compress_FeedCacheInvalidationThrows_StillCompletesAndDoesNotFail()
+    {
+        // Codifies the "Redis unavailable → no failure" guarantee for the ready transition: the
+        // best-effort feed invalidation runs after the clip is already 'ready', so a throwing
+        // IFeedCache must be swallowed — never tripping the stage's MarkFailed/ReleaseLease path.
+        var store = Substitute.For<IClipMediaJobStore>();
+        var compressor = Substitute.For<ICompressJobService>();
+        var storage = Substitute.For<IObjectStorageService>();
+        var s3 = Substitute.For<IOptionsMonitor<S3Options>>();
+        s3.CurrentValue.Returns(new S3Options { ClipsBucket = "clips" });
+        var feedCache = Substitute.For<IFeedCache>();
+        feedCache.When(c => c.InvalidateFeedsAsync(Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("redis down"));
+        var sp = Scope(s =>
+        {
+            s.AddScoped(_ => store);
+            s.AddScoped(_ => compressor);
+            s.AddScoped(_ => storage);
+            s.AddScoped(_ => s3);
+            s.AddScoped(_ => feedCache);
+        });
+        var svc = new CompressWorker(
+            sp.GetRequiredService<IServiceScopeFactory>(), Ffmpeg(),
+            Monitor(new MediaJobOptions { MaxAttempts = 3 }), NullLogger<CompressWorker>.Instance);
+        var job = ClipJob();
+        store.ClaimNextAsync(ClipStatuses.Transcoding, Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(job);
+        compressor.CompressAsync(job, Arg.Any<CancellationToken>())
+            .Returns(new CompressionResult("same.mp4", "h264", "same.mp4"));
+
+        (await svc.TryProcessOneAsync(CancellationToken.None)).Should().BeTrue();
+
+        await store.Received(1).CompleteCompressionAsync(job.ClipId, 1, "same.mp4", "h264", Arg.Any<CancellationToken>());
+        await store.DidNotReceive().MarkFailedAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().ReleaseLeaseAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Introduces Redis as Phase 4's shared cache + cross-instance coordination layer. The API previously had no caching and per-pod rate limiters; this adds an optional **HybridCache** (in-memory L1 + Redis L2) over the hot read paths and a **cluster-wide Redis fixed-window rate limiter**. Everything degrades gracefully to in-process when Redis is absent, so local dev needs no Redis and a Redis outage never 500s.

## What's here

- **Infra:** `redis:7` service in `docker-compose.dev.yml`, `REDIS_HOST_PORT` default + `make ports` line, per-issue worktree offset in `new-worktree.sh`, and `REDIS_URL` in `.env.example`. Main checkout resolves to `6379`; worktrees get their offset port (verified `docker compose config` both ways).
- **Hot-feed cache** behind `IFeedCache` (HybridCache + optional Redis L2): caches the anonymous first page of the latest / per-game / per-tag feeds and trending, with a short TTL and tag-based write-time invalidation. Cursor pages and `source=following` bypass.
- **Personalization safety:** only the anonymous projection is cached; `likedByMe` is re-stamped per caller after the cache read, so a like never leaks across users.
- **Games catalog cache** (`IGamesCache`): browse list + per-game detail, TTL-only; `search` queries bypass (high-cardinality).
- **Cluster-wide rate limiting:** a shared Redis fixed-window limiter for the `clips-write` and `auth-credentials` policies — same partition keys (`u:{id}` / `ip:{ip}`) and 429 + `Retry-After` envelope — falling back to the in-process limiter on any Redis error (degraded, never fail-open).
- **Trending:** #87 shipped trending *uncached*, so this adds Redis caching to it via the same abstraction (rather than migrating an in-process cache that didn't exist).

Closes #101

## How to test manually

```bash
make up                                   # now also starts redis (healthcheck: redis-cli ping)
make ports                                # shows the redis port
# Hot-feed cache
curl -s 'http://localhost:5050/clips/feed' >/dev/null
redis-cli -u "$REDIS_URL" keys 'feed:*'   # feed:latest:20 present (also game/tag/trending after hitting those)
redis-cli -u "$REDIS_URL" keys 'games:*'  # games:list:* / games:detail:* after hitting /games
# Cluster-wide rate limit
#   fire >30 authed clip-writes/min  -> 429 + Retry-After; rl:clips-write:u:{id} key appears
# Graceful degradation
docker compose -f docker-compose.dev.yml stop redis
curl -s 'http://localhost:5050/clips/feed' | jq '.items | length'   # still 200, in-process fallback
```

## Checklist

- [x] Feed / game / tag / trending first page served from Redis within TTL; cursor pages bypass
- [x] Cache invalidated on clip ready / delete / visibility change
- [x] `likedByMe` never leaks across users via the shared cache
- [x] Rate limit shared across instances via Redis; falls back in-process when Redis is down
- [x] Redis unavailable -> in-process fallback, no 500s (smoke-tested with redis stopped)
- [x] Coverage gate passes (94% line / 86% branch)
- [x] Rebase onto latest `main` before merge (currently 1 behind — Notifications #110)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Redis support for distributed caching and cluster-wide rate limiting. Feeds and game catalogs are now cached for faster load times.
  
* **Configuration**
  * Added optional `REDIS_URL` environment variable. When configured, enables Redis-backed caching and rate limiting across instances. System gracefully falls back to in-process caching when Redis is unavailable.

* **Tests**
  * Added comprehensive tests for caching and rate limiting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Known limitations (scale-up)

- **Cross-pod cache stampede:** `HybridCache.GetOrCreateAsync` single-flights *within* a pod only. After a `RemoveByTagAsync` clears L2, N pods can each run the feed factory once on the next request (a brief thundering herd, not a correctness issue). Acceptable for v1; revisit with a backplane/lock if feed-factory cost becomes material at scale.
