### PR TITLE
[server][web] Game leaderboards: most-liked per game per week + /leaderboards

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Leaderboards/GameLeaderboardResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/GameLeaderboardResponse.cs
@@ -1,0 +1,8 @@
+using GankedTV.Api.Contracts.Games;
+
+namespace GankedTV.Api.Contracts.Leaderboards;
+
+public sealed record GameLeaderboardResponse(
+    string Window,
+    GameSummary Game,
+    IReadOnlyList<LeaderboardEntry> Entries);

--- a/server/src/GankedTV.Api/Contracts/Leaderboards/GlobalLeaderboardResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/GlobalLeaderboardResponse.cs
@@ -1,0 +1,6 @@
+namespace GankedTV.Api.Contracts.Leaderboards;
+
+public sealed record GlobalLeaderboardResponse(
+    string Window,
+    IReadOnlyList<LeaderboardEntry> TopClips,
+    IReadOnlyList<TopGameEntry> TopGames);

--- a/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardEntry.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardEntry.cs
@@ -1,0 +1,5 @@
+using GankedTV.Api.Contracts.Clips;
+
+namespace GankedTV.Api.Contracts.Leaderboards;
+
+public sealed record LeaderboardEntry(int Rank, int WindowLikes, ClipFeedItem Clip);

--- a/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardMappings.cs
@@ -1,0 +1,13 @@
+using GankedTV.Api.Contracts.Clips;
+
+namespace GankedTV.Api.Contracts.Leaderboards;
+
+public static class LeaderboardMappings
+{
+    // `rank` and `windowLikes` are computed by the caller (post-query) because they're
+    // a function of result position, not a property of the clip itself. The ClipFeedItem
+    // is reused verbatim so the web layer can render the same ClipCard component used
+    // on every other feed.
+    public static LeaderboardEntry ToEntry(this ClipFeedItem clip, int rank, int windowLikes) =>
+        new(rank, windowLikes, clip);
+}

--- a/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardWindow.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardWindow.cs
@@ -1,0 +1,35 @@
+namespace GankedTV.Api.Contracts.Leaderboards;
+
+// Leaderboards intentionally use coarser windows than trending (week/month/all vs 24h/7d):
+// "most liked this hour" is too noisy to rank, and "all-time" is a meaningful question for
+// boards but never for trending. Kept separate from TryParseTrendingWindow so the two
+// endpoints can evolve their window vocabularies independently.
+public static class LeaderboardWindow
+{
+    public const string Week = "week";
+    public const string Month = "month";
+    public const string All = "all";
+    public const string Default = Week;
+
+    // `since` for `all` is DateTimeOffset.MinValue so the same `l.CreatedAt >= since`
+    // filter covers every window with no branching at the query layer.
+    public static bool TryParse(string? window, out DateTimeOffset since)
+    {
+        var now = DateTimeOffset.UtcNow;
+        switch (window)
+        {
+            case Week:
+                since = now.AddDays(-7);
+                return true;
+            case Month:
+                since = now.AddDays(-30);
+                return true;
+            case All:
+                since = DateTimeOffset.MinValue;
+                return true;
+            default:
+                since = default;
+                return false;
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardWindow.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardWindow.cs
@@ -12,7 +12,10 @@ public static class LeaderboardWindow
     public const string Default = Week;
 
     // `since` for `all` is DateTimeOffset.MinValue so the same `l.CreatedAt >= since`
-    // filter covers every window with no branching at the query layer.
+    // filter covers every window with no branching at the query layer. Note the inclusive
+    // `>=`: trending uses strict `>` (see TryParseTrendingWindow) — inconsequential at
+    // second precision, but called out so a future reader copy-pasting between the two
+    // endpoints doesn't assume the boundary semantics are interchangeable.
     public static bool TryParse(string? window, out DateTimeOffset since)
     {
         var now = DateTimeOffset.UtcNow;
@@ -22,6 +25,10 @@ public static class LeaderboardWindow
                 since = now.AddDays(-7);
                 return true;
             case Month:
+                // Deliberately a rolling 30 days, not a calendar month — the web label
+                // ("This Month") is a simplification. A clip liked 31 days ago drops out
+                // of the window even mid-calendar-month. Renaming the key to `30d` would
+                // be more honest, but `month` matches the user-facing label.
                 since = now.AddDays(-30);
                 return true;
             case All:

--- a/server/src/GankedTV.Api/Contracts/Leaderboards/TopGameEntry.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/TopGameEntry.cs
@@ -1,0 +1,5 @@
+using GankedTV.Api.Contracts.Games;
+
+namespace GankedTV.Api.Contracts.Leaderboards;
+
+public sealed record TopGameEntry(int Rank, int WindowLikes, int ClipCount, GameSummary Game, string? CoverUrl);

--- a/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
@@ -136,9 +136,11 @@ public static class GamesEndpoints
 
         // Resolve game first so "no such game" stays a 404 even when there are no likes in
         // the window — otherwise an unknown slug would silently return an empty board.
+        // Inline the GameSummary columns so EF projects rather than materializing the full
+        // entity (extension-method calls inside Select can't be translated).
         var game = await db.Games.AsNoTracking()
             .Where(g => g.Slug == slug)
-            .Select(g => new { g.Id, Summary = g.ToGameSummary() })
+            .Select(g => new { g.Id, Summary = new GameSummary(g.Id, g.Name, g.Slug, g.Tag) })
             .FirstOrDefaultAsync(ct);
 
         if (game is null)

--- a/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Contracts.Leaderboards;
 using GankedTV.Api.Data;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.ObjectStorage;
@@ -19,6 +20,7 @@ public static class GamesEndpoints
         group.MapGet("/", GetGames);
         group.MapGet("/{slug}", GetBySlug);
         group.MapGet("/{slug}/clips", GetClipsForGame);
+        group.MapGet("/{slug}/leaderboard", GetLeaderboardForGame);
         return app;
     }
 
@@ -114,5 +116,41 @@ public static class GamesEndpoints
         var response = await ClipsReadEndpoints.BuildFeedPageAsync(
             baseQuery, cursor, limit, principal, db, storage, s3, ct);
         return Results.Ok(response);
+    }
+
+    private static async Task<IResult> GetLeaderboardForGame(
+        string slug,
+        string? window,
+        int? limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        var windowKey = window ?? LeaderboardWindow.Default;
+        if (!LeaderboardWindow.TryParse(windowKey, out var since))
+        {
+            return ProblemResults.BadRequest("invalid_window");
+        }
+
+        // Resolve game first so "no such game" stays a 404 even when there are no likes in
+        // the window — otherwise an unknown slug would silently return an empty board.
+        var game = await db.Games.AsNoTracking()
+            .Where(g => g.Slug == slug)
+            .Select(g => new { g.Id, Summary = g.ToGameSummary() })
+            .FirstOrDefaultAsync(ct);
+
+        if (game is null)
+            return ProblemResults.NotFound("not_found");
+
+        var cap = Math.Clamp(limit ?? LeaderboardsEndpoints.DefaultClipsLimit, 1, LeaderboardsEndpoints.MaxClipsLimit);
+        var baseQuery = db.Clips.AsNoTracking()
+            .Where(c => c.GameId == game.Id && c.Visibility == "public" && c.Status == "ready");
+
+        var entries = await LeaderboardsEndpoints.BuildEntriesAsync(
+            baseQuery, since, cap, principal, db, storage, s3, ct);
+
+        return Results.Ok(new GameLeaderboardResponse(windowKey, game.Summary, entries));
     }
 }

--- a/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
@@ -99,8 +99,13 @@ public static class LeaderboardsEndpoints
             .ToList();
 
         var topIds = ranked.Select(r => r.ClipId).ToList();
+        // Re-apply the public+ready predicate as a belt-and-braces guard: a clip can flip
+        // to private/unlisted or out of `ready` between the candidate fetch above and this
+        // hydrate. Trending tolerates that race ("self-healing on the next request"), but
+        // a leaderboard surfacing an unlisted clip in a "Most Liked This Week" board is
+        // more user-visible/confusing, and the extra WHERE clause is free.
         var hydrated = await db.Clips.AsNoTracking()
-            .Where(c => topIds.Contains(c.Id))
+            .Where(c => topIds.Contains(c.Id) && c.Visibility == "public" && c.Status == "ready")
             .IncludeFeedRelations()
             .ToListAsync(ct);
         var byId = hydrated.ToDictionary(c => c.Id);
@@ -111,8 +116,8 @@ public static class LeaderboardsEndpoints
 
         // Walk ranked + feedItems in lockstep: feedItems was built from ranked-ordered
         // clips, so index i corresponds to the same clip in both lists. A clip dropped
-        // between candidate fetch and hydrate (rare but possible mid-delete) just falls
-        // out of both lists together.
+        // between candidate fetch and hydrate (mid-delete, or filtered out by the
+        // re-applied visibility/status guard above) just falls out of both lists together.
         var entries = new List<LeaderboardEntry>(feedItems.Count);
         var rank = 0;
         var feedIndex = 0;

--- a/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
@@ -1,0 +1,167 @@
+using System.Security.Claims;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Contracts.Games;
+using GankedTV.Api.Contracts.Leaderboards;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Services.ObjectStorage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Endpoints;
+
+public static class LeaderboardsEndpoints
+{
+    internal const int DefaultClipsLimit = 10;
+    internal const int MaxClipsLimit = 50;
+    internal const int DefaultGamesLimit = 10;
+    internal const int MaxGamesLimit = 25;
+
+    public static IEndpointRouteBuilder MapLeaderboardsEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/leaderboards", GetGlobal);
+        return app;
+    }
+
+    private static async Task<IResult> GetGlobal(
+        string? window,
+        int? clipsLimit,
+        int? gamesLimit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        // Default to "week" when the caller omits window — the standalone /leaderboards
+        // landing page renders week-first; explicit-but-unknown values still 400 so a UI
+        // typo (`?window=mounth`) surfaces immediately instead of being silently coerced.
+        var windowKey = window ?? LeaderboardWindow.Default;
+        if (!LeaderboardWindow.TryParse(windowKey, out var since))
+        {
+            return ProblemResults.BadRequest("invalid_window");
+        }
+
+        var clipsCap = Math.Clamp(clipsLimit ?? DefaultClipsLimit, 1, MaxClipsLimit);
+        var gamesCap = Math.Clamp(gamesLimit ?? DefaultGamesLimit, 1, MaxGamesLimit);
+
+        var clipsBase = db.Clips.AsNoTracking()
+            .Where(c => c.Visibility == "public" && c.Status == "ready");
+        var topClips = await BuildEntriesAsync(clipsBase, since, clipsCap, principal, db, storage, s3, ct);
+
+        var topGames = await BuildTopGamesAsync(since, gamesCap, db, ct);
+
+        return Results.Ok(new GlobalLeaderboardResponse(windowKey, topClips, topGames));
+    }
+
+    // Shared helper: turn a pre-filtered Clip IQueryable into a ranked list of leaderboard
+    // entries scoped to a window. Owns the windowed-count query, deterministic tiebreak,
+    // hydration with feed includes, and the rank-numbering pass.
+    //
+    // Tie-breaking goes (likes desc, clip.created_at desc, clip.id asc): newer clips with
+    // equal likes outrank older ones (rewards momentum); equal createdAt falls back to a
+    // total ordering on Guid so the ranking is stable across requests.
+    internal static async Task<List<LeaderboardEntry>> BuildEntriesAsync(
+        IQueryable<Clip> baseQuery,
+        DateTimeOffset since,
+        int limit,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IObjectStorageService storage,
+        IOptions<S3Options> s3,
+        CancellationToken ct)
+    {
+        // Pre-filter to clips with ANY like in the window so the COUNT subquery only fires
+        // for candidates that could plausibly rank. Same shape as BuildTrendingFeedAsync —
+        // bounded candidate set, then sort in memory because EF + Postgres can't reliably
+        // order on a correlated COUNT alongside the tiebreak chain we want.
+        var candidates = await baseQuery
+            .Where(c => db.Likes.Any(l => l.ClipId == c.Id && l.CreatedAt >= since))
+            .Select(c => new
+            {
+                ClipId = c.Id,
+                c.CreatedAt,
+                WindowLikes = db.Likes.Count(l => l.ClipId == c.Id && l.CreatedAt >= since),
+            })
+            .ToListAsync(ct);
+
+        if (candidates.Count == 0)
+        {
+            return [];
+        }
+
+        var ranked = candidates
+            .OrderByDescending(x => x.WindowLikes)
+            .ThenByDescending(x => x.CreatedAt)
+            .ThenBy(x => x.ClipId)
+            .Take(limit)
+            .ToList();
+
+        var topIds = ranked.Select(r => r.ClipId).ToList();
+        var hydrated = await db.Clips.AsNoTracking()
+            .Where(c => topIds.Contains(c.Id))
+            .IncludeFeedRelations()
+            .ToListAsync(ct);
+        var byId = hydrated.ToDictionary(c => c.Id);
+
+        var feedItems = await ClipsReadEndpoints.ProjectFeedItemsAsync(
+            [.. ranked.Where(r => byId.ContainsKey(r.ClipId)).Select(r => byId[r.ClipId])],
+            principal, db, storage, s3, ct);
+
+        // Walk ranked + feedItems in lockstep: feedItems was built from ranked-ordered
+        // clips, so index i corresponds to the same clip in both lists. A clip dropped
+        // between candidate fetch and hydrate (rare but possible mid-delete) just falls
+        // out of both lists together.
+        var entries = new List<LeaderboardEntry>(feedItems.Count);
+        var rank = 0;
+        var feedIndex = 0;
+        foreach (var r in ranked)
+        {
+            if (!byId.ContainsKey(r.ClipId)) continue;
+            rank++;
+            entries.Add(feedItems[feedIndex].ToEntry(rank, r.WindowLikes));
+            feedIndex++;
+        }
+        return entries;
+    }
+
+    // Top games for a window: sum windowed likes across each game's public+ready clips.
+    // Skips games with zero likes in the window so the response only ranks games that
+    // actually have activity. ClipCount counts public+ready clips for the whole catalog
+    // (not just clips with likes in the window) so the number matches what GameView's
+    // header shows — otherwise the same game would display two different counts.
+    private static async Task<List<TopGameEntry>> BuildTopGamesAsync(
+        DateTimeOffset since,
+        int limit,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        var rows = await db.Games.AsNoTracking()
+            .Select(g => new
+            {
+                Game = g,
+                WindowLikes = db.Likes.Count(l =>
+                    l.CreatedAt >= since
+                    && l.Clip.GameId == g.Id
+                    && l.Clip.Visibility == "public"
+                    && l.Clip.Status == "ready"),
+                ClipCount = db.Clips.Count(c =>
+                    c.GameId == g.Id && c.Visibility == "public" && c.Status == "ready"),
+            })
+            .Where(x => x.WindowLikes > 0)
+            .ToListAsync(ct);
+
+        return [.. rows
+            .OrderByDescending(x => x.WindowLikes)
+            .ThenByDescending(x => x.ClipCount)
+            .ThenBy(x => x.Game.Name, StringComparer.Ordinal)
+            .Take(limit)
+            .Select((x, i) => new TopGameEntry(
+                i + 1,
+                x.WindowLikes,
+                x.ClipCount,
+                x.Game.ToGameSummary(),
+                x.Game.CoverUrl))];
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
@@ -118,15 +118,13 @@ public static class LeaderboardsEndpoints
         // clips, so index i corresponds to the same clip in both lists. A clip dropped
         // between candidate fetch and hydrate (mid-delete, or filtered out by the
         // re-applied visibility/status guard above) just falls out of both lists together.
+        // `entries.Count` doubles as both the next rank (1-based after +1) and the next
+        // feedItems index, since each addition increments them together.
         var entries = new List<LeaderboardEntry>(feedItems.Count);
-        var rank = 0;
-        var feedIndex = 0;
         foreach (var r in ranked)
         {
             if (!byId.ContainsKey(r.ClipId)) continue;
-            rank++;
-            entries.Add(feedItems[feedIndex].ToEntry(rank, r.WindowLikes));
-            feedIndex++;
+            entries.Add(feedItems[entries.Count].ToEntry(entries.Count + 1, r.WindowLikes));
         }
         return entries;
     }

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -385,6 +385,7 @@ app.MapUsersEndpoints();
 app.MapFollowsEndpoints();
 app.MapNotificationsEndpoints();
 app.MapGamesEndpoints();
+app.MapLeaderboardsEndpoints();
 app.MapTagsEndpoints();
 app.MapSearchEndpoints();
 

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LeaderboardsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LeaderboardsEndpointsTests.cs
@@ -1,0 +1,375 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class LeaderboardsEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public LeaderboardsEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    // ---- GET /leaderboards ----
+
+    [Fact]
+    public async Task Global_Empty_Returns200WithEmptyArrays()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/leaderboards?window=week");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("window").GetString().Should().Be("week");
+        body.GetProperty("topClips").GetArrayLength().Should().Be(0);
+        body.GetProperty("topGames").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Global_OmittedWindow_DefaultsToWeek()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/leaderboards");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("window").GetString().Should().Be("week");
+    }
+
+    [Fact]
+    public async Task Global_InvalidWindow_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/leaderboards?window=mounth");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Global_RanksClipsByWindowedLikesNotAllTimeLikeCount()
+    {
+        // Clip A: 5 old likes (outside window) + 1 fresh like (in window)
+        // Clip B: 3 fresh likes (in window)
+        // All-time LikeCount would put A on top (6 vs 3); windowed ranking must put B first.
+        await _fx.ResetAsync();
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        var now = DateTimeOffset.UtcNow;
+        var (a, _) = await SeedClipAsync(authorId, now.AddDays(-10), gameId, "clipA");
+        var (b, _) = await SeedClipAsync(authorId, now.AddDays(-1), gameId, "clipB");
+
+        var oldStamp = now.AddDays(-30); // outside week
+        var freshStamp = now.AddHours(-1); // inside week
+        await SeedLikesAsync(a, oldStamp, 5);
+        await SeedLikesAsync(a, freshStamp, 1);
+        await SeedLikesAsync(b, freshStamp, 3);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/leaderboards?window=week");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var entries = body.GetProperty("topClips").EnumerateArray().ToList();
+        entries.Should().HaveCount(2);
+        entries[0].GetProperty("clip").GetProperty("id").GetGuid().Should().Be(b);
+        entries[0].GetProperty("rank").GetInt32().Should().Be(1);
+        entries[0].GetProperty("windowLikes").GetInt32().Should().Be(3);
+        entries[1].GetProperty("clip").GetProperty("id").GetGuid().Should().Be(a);
+        entries[1].GetProperty("rank").GetInt32().Should().Be(2);
+        entries[1].GetProperty("windowLikes").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Global_OnlyPublicReadyClipsAppear()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        var now = DateTimeOffset.UtcNow;
+        var freshStamp = now.AddHours(-1);
+        var (publicReady, _) = await SeedClipAsync(authorId, now, gameId, "good");
+        var (processing, _) = await SeedClipAsync(authorId, now, gameId, "processing", status: "processing");
+        var (unlisted, _) = await SeedClipAsync(authorId, now, gameId, "unlisted", visibility: "unlisted");
+
+        await SeedLikesAsync(publicReady, freshStamp, 2);
+        await SeedLikesAsync(processing, freshStamp, 5);
+        await SeedLikesAsync(unlisted, freshStamp, 5);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/leaderboards?window=week");
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("topClips").EnumerateArray()
+            .Select(e => e.GetProperty("clip").GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(publicReady);
+    }
+
+    [Fact]
+    public async Task Global_TiesBreakOnNewerThenById_DeterministicallyAndStably()
+    {
+        // Three clips with identical windowed like counts. Newer createdAt outranks older;
+        // identical createdAt falls back to Guid ascending. Running the request twice must
+        // produce the same order (stability), and the documented tiebreak must hold.
+        await _fx.ResetAsync();
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        var now = DateTimeOffset.UtcNow;
+        var shared = now.AddHours(-3);
+        var (older, _) = await SeedClipAsync(authorId, now.AddHours(-5), gameId, "older");
+        var (sameA, _) = await SeedClipAsync(authorId, shared, gameId, "sameA");
+        var (sameB, _) = await SeedClipAsync(authorId, shared, gameId, "sameB");
+
+        var freshStamp = now.AddMinutes(-10);
+        await SeedLikesAsync(older, freshStamp, 2);
+        await SeedLikesAsync(sameA, freshStamp, 2);
+        await SeedLikesAsync(sameB, freshStamp, 2);
+
+        using var client = _factory!.CreateClient();
+        var resp1 = await client.GetAsync("/leaderboards?window=week");
+        var ids1 = (await resp1.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("topClips").EnumerateArray()
+            .Select(e => e.GetProperty("clip").GetProperty("id").GetGuid()).ToList();
+
+        var resp2 = await client.GetAsync("/leaderboards?window=week");
+        var ids2 = (await resp2.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("topClips").EnumerateArray()
+            .Select(e => e.GetProperty("clip").GetProperty("id").GetGuid()).ToList();
+
+        ids2.Should().Equal(ids1);
+        // First two slots are the shared-createdAt pair, ordered by Guid asc; older is last.
+        var expectedSamePair = new[] { sameA, sameB }.OrderBy(g => g).ToList();
+        ids1.Take(2).Should().Equal(expectedSamePair);
+        ids1[2].Should().Be(older);
+    }
+
+    [Fact]
+    public async Task Global_TopGamesRanksByWindowedLikesSummedAcrossClips()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var valorant = await GetGameIdBySlugAsync("valorant");
+        var apex = await GetGameIdBySlugAsync("apex-legends");
+        var now = DateTimeOffset.UtcNow;
+        var fresh = now.AddHours(-1);
+        var (valClip1, _) = await SeedClipAsync(authorId, now, valorant, "v1");
+        var (valClip2, _) = await SeedClipAsync(authorId, now, valorant, "v2");
+        var (apexClip, _) = await SeedClipAsync(authorId, now, apex, "a1");
+
+        await SeedLikesAsync(valClip1, fresh, 2);
+        await SeedLikesAsync(valClip2, fresh, 2);
+        await SeedLikesAsync(apexClip, fresh, 3);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/leaderboards?window=week");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var games = body.GetProperty("topGames").EnumerateArray().ToList();
+
+        games.Should().HaveCount(2);
+        games[0].GetProperty("game").GetProperty("slug").GetString().Should().Be("valorant");
+        games[0].GetProperty("windowLikes").GetInt32().Should().Be(4);
+        games[0].GetProperty("rank").GetInt32().Should().Be(1);
+        games[1].GetProperty("game").GetProperty("slug").GetString().Should().Be("apex-legends");
+        games[1].GetProperty("windowLikes").GetInt32().Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Global_AllWindowIncludesOldLikesThatWeekExcludes()
+    {
+        // Same clip, one ancient like. `week` rejects it; `all` includes it.
+        await _fx.ResetAsync();
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        var (clipId, _) = await SeedClipAsync(authorId, DateTimeOffset.UtcNow.AddDays(-90), gameId, "ancient");
+        await SeedLikesAsync(clipId, DateTimeOffset.UtcNow.AddDays(-90), 1);
+
+        using var client = _factory!.CreateClient();
+        var weekBody = await (await client.GetAsync("/leaderboards?window=week")).Content.ReadFromJsonAsync<JsonElement>();
+        weekBody.GetProperty("topClips").GetArrayLength().Should().Be(0);
+
+        var allBody = await (await client.GetAsync("/leaderboards?window=all")).Content.ReadFromJsonAsync<JsonElement>();
+        allBody.GetProperty("topClips").GetArrayLength().Should().Be(1);
+        allBody.GetProperty("topClips")[0].GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clipId);
+    }
+
+    // ---- GET /games/{slug}/leaderboard ----
+
+    [Fact]
+    public async Task GameLeaderboard_UnknownSlug_Returns404()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/games/does-not-exist/leaderboard?window=week");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GameLeaderboard_InvalidWindow_Returns400()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/games/valorant/leaderboard?window=fortnight");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GameLeaderboard_EmptyWindow_Returns200WithEmptyEntries()
+    {
+        // Known game, no likes in week → empty entries, NOT 404.
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/games/valorant/leaderboard?window=week");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("game").GetProperty("slug").GetString().Should().Be("valorant");
+        body.GetProperty("entries").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GameLeaderboard_ScopesToSelectedGameOnly()
+    {
+        // A more-liked clip in a different game must not appear in valorant's board.
+        await _fx.ResetAsync();
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var valorant = await GetGameIdBySlugAsync("valorant");
+        var apex = await GetGameIdBySlugAsync("apex-legends");
+        var now = DateTimeOffset.UtcNow;
+        var fresh = now.AddHours(-1);
+        var (valClip, _) = await SeedClipAsync(authorId, now, valorant, "v");
+        var (apexClip, _) = await SeedClipAsync(authorId, now, apex, "a");
+        await SeedLikesAsync(valClip, fresh, 1);
+        await SeedLikesAsync(apexClip, fresh, 9);
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant/leaderboard?window=week");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("entries").EnumerateArray()
+            .Select(e => e.GetProperty("clip").GetProperty("id").GetGuid()).ToList();
+        ids.Should().Equal(valClip);
+    }
+
+    [Fact]
+    public async Task GameLeaderboard_LimitClampedAndRanksAssigned()
+    {
+        await _fx.ResetAsync();
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        var now = DateTimeOffset.UtcNow;
+        var fresh = now.AddHours(-1);
+
+        // Seed 3 clips with decreasing like counts so ranking is unambiguous regardless
+        // of tiebreak.
+        var clips = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            var (id, _) = await SeedClipAsync(authorId, now.AddMinutes(-i), gameId, $"c{i}");
+            clips.Add(id);
+            await SeedLikesAsync(id, fresh, 5 - i);
+        }
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync("/games/valorant/leaderboard?window=week&limit=2");
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var entries = body.GetProperty("entries").EnumerateArray().ToList();
+        entries.Should().HaveCount(2);
+        entries[0].GetProperty("rank").GetInt32().Should().Be(1);
+        entries[0].GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clips[0]);
+        entries[1].GetProperty("rank").GetInt32().Should().Be(2);
+        entries[1].GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clips[1]);
+    }
+
+    // ---- helpers ----
+
+    private async Task<int> GetGameIdBySlugAsync(string slug)
+    {
+        await using var db = _fx.CreateContext();
+        return await db.Games.Where(g => g.Slug == slug).Select(g => g.Id).FirstAsync();
+    }
+
+    private async Task<(Guid id, string shareCode)> SeedClipAsync(
+        Guid userId,
+        DateTimeOffset createdAt,
+        int? gameId,
+        string title,
+        string status = "ready",
+        string visibility = "public")
+    {
+        var id = Guid.NewGuid();
+        var shareCode = ShareCodeGenerator.Next();
+        await using var db = _fx.CreateContext();
+        db.Clips.Add(new Clip
+        {
+            Id = id,
+            UserId = userId,
+            GameId = gameId,
+            Title = title,
+            VideoKey = $"{userId}/{id}.mp4",
+            ThumbnailKey = $"thumbs/{id}.jpg",
+            ShareCode = shareCode,
+            Status = status,
+            Visibility = visibility,
+            DurationSecs = 30,
+            Width = 1920,
+            Height = 1080,
+            FileSizeBytes = 1_000_000,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        });
+        await db.SaveChangesAsync();
+        return (id, shareCode);
+    }
+
+    // Each like needs a distinct UserId (composite PK is (UserId, ClipId)), so spin up
+    // throwaway user rows per like. Throwaway usernames are unique-per-call to avoid the
+    // username UNIQUE constraint across the same test run.
+    private async Task SeedLikesAsync(Guid clipId, DateTimeOffset stamp, int count)
+    {
+        await using var db = _fx.CreateContext();
+        for (var i = 0; i < count; i++)
+        {
+            var userId = Guid.NewGuid();
+            db.Users.Add(new User
+            {
+                Id = userId,
+                Username = $"liker-{userId:N}".Substring(0, 20),
+                Email = $"{userId:N}@test.local",
+            });
+            db.Likes.Add(new Like { UserId = userId, ClipId = clipId, CreatedAt = stamp });
+        }
+        await db.SaveChangesAsync();
+    }
+}

--- a/web/src/api/__tests__/leaderboards.spec.ts
+++ b/web/src/api/__tests__/leaderboards.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { leaderboards } from '../leaderboards'
+import { configureAuth, BASE_URL } from '../client'
+
+beforeEach(() => {
+  configureAuth({
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    onTokenRefreshed: () => {},
+    onRefreshFailed: () => {},
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('api/leaderboards', () => {
+  describe('global()', () => {
+    it('GETs /leaderboards with the requested window', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ window: 'week', topClips: [], topGames: [] })),
+      )
+
+      await leaderboards.global({ window: 'week' })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/leaderboards?window=week`)
+    })
+
+    it('appends clipsLimit and gamesLimit when provided', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ window: 'month', topClips: [], topGames: [] })),
+      )
+
+      await leaderboards.global({ window: 'month', clipsLimit: 20, gamesLimit: 5 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/leaderboards?window=month&clipsLimit=20&gamesLimit=5`)
+    })
+
+    it('omits limit params when not provided', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse({ window: 'all', topClips: [], topGames: [] })),
+      )
+
+      await leaderboards.global({ window: 'all' })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/leaderboards?window=all`)
+    })
+
+    it('returns the parsed body', async () => {
+      const body = {
+        window: 'week',
+        topClips: [],
+        topGames: [
+          {
+            rank: 1,
+            windowLikes: 5,
+            clipCount: 3,
+            game: { id: 1, name: 'Valorant', slug: 'valorant', tag: 'VAL' },
+            coverUrl: null,
+          },
+        ],
+      }
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(body)),
+      )
+
+      const result = await leaderboards.global({ window: 'week' })
+
+      expect(result).toEqual(body)
+    })
+  })
+
+  describe('forGame()', () => {
+    it('GETs /games/{slug}/leaderboard with the window', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          jsonResponse({
+            window: 'week',
+            game: { id: 1, name: 'Valorant', slug: 'valorant', tag: 'VAL' },
+            entries: [],
+          }),
+        ),
+      )
+
+      await leaderboards.forGame('valorant', { window: 'week' })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/games/valorant/leaderboard?window=week`)
+    })
+
+    it('URL-encodes the slug', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          jsonResponse({
+            window: 'week',
+            game: { id: 1, name: 'Rocket League', slug: 'rocket league', tag: 'RL' },
+            entries: [],
+          }),
+        ),
+      )
+
+      await leaderboards.forGame('rocket league', { window: 'week' })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/games/rocket%20league/leaderboard?window=week`)
+    })
+
+    it('appends limit when provided', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          jsonResponse({
+            window: 'all',
+            game: { id: 1, name: 'Valorant', slug: 'valorant', tag: 'VAL' },
+            entries: [],
+          }),
+        ),
+      )
+
+      await leaderboards.forGame('valorant', { window: 'all', limit: 25 })
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toBe(`${BASE_URL}/games/valorant/leaderboard?window=all&limit=25`)
+    })
+  })
+})

--- a/web/src/api/leaderboards.ts
+++ b/web/src/api/leaderboards.ts
@@ -1,0 +1,60 @@
+import { api } from './client'
+import type { ClipFeedItem, GameSummary } from './clips'
+
+export type LeaderboardWindow = 'week' | 'month' | 'all'
+
+export interface LeaderboardEntry {
+  rank: number
+  windowLikes: number
+  clip: ClipFeedItem
+}
+
+export interface TopGameEntry {
+  rank: number
+  windowLikes: number
+  clipCount: number
+  game: GameSummary
+  coverUrl: string | null
+}
+
+export interface GameLeaderboardResponse {
+  window: LeaderboardWindow
+  game: GameSummary
+  entries: LeaderboardEntry[]
+}
+
+export interface GlobalLeaderboardResponse {
+  window: LeaderboardWindow
+  topClips: LeaderboardEntry[]
+  topGames: TopGameEntry[]
+}
+
+export interface LeaderboardQuery {
+  window: LeaderboardWindow
+  limit?: number
+}
+
+export interface GlobalLeaderboardQuery {
+  window: LeaderboardWindow
+  clipsLimit?: number
+  gamesLimit?: number
+}
+
+export const leaderboards = {
+  global(query: GlobalLeaderboardQuery): Promise<GlobalLeaderboardResponse> {
+    const params = new URLSearchParams()
+    params.set('window', query.window)
+    if (query.clipsLimit !== undefined) params.set('clipsLimit', String(query.clipsLimit))
+    if (query.gamesLimit !== undefined) params.set('gamesLimit', String(query.gamesLimit))
+    return api<GlobalLeaderboardResponse>(`/leaderboards?${params.toString()}`)
+  },
+
+  forGame(slug: string, query: LeaderboardQuery): Promise<GameLeaderboardResponse> {
+    const params = new URLSearchParams()
+    params.set('window', query.window)
+    if (query.limit !== undefined) params.set('limit', String(query.limit))
+    return api<GameLeaderboardResponse>(
+      `/games/${encodeURIComponent(slug)}/leaderboard?${params.toString()}`,
+    )
+  },
+}

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -287,6 +287,13 @@ onBeforeUnmount(() => {
         >
           Trending
         </RouterLink>
+        <RouterLink
+          to="/leaderboards"
+          class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary max-tablet:hidden"
+          :active-class="navLinkActive"
+        >
+          Leaderboards
+        </RouterLink>
       </nav>
 
       <!-- Search (desktop only) -->

--- a/web/src/components/GameLeaderboardBlock.vue
+++ b/web/src/components/GameLeaderboardBlock.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+import { leaderboards, type LeaderboardEntry, type LeaderboardWindow } from '@/api/leaderboards'
+import LeaderboardRow from '@/components/LeaderboardRow.vue'
+
+const props = withDefaults(
+  defineProps<{
+    slug: string
+    window?: LeaderboardWindow
+    // Mini view shows the top-3 only — fits a sidebar/embed nicely. The full /leaderboards
+    // page uses the row component directly with its own limit.
+    limit?: number
+  }>(),
+  { window: 'week', limit: 5 },
+)
+
+const entries = ref<LeaderboardEntry[]>([])
+const loading = ref(false)
+const errored = ref(false)
+let latestLoadId = 0
+
+async function load() {
+  const id = ++latestLoadId
+  loading.value = true
+  errored.value = false
+  try {
+    const resp = await leaderboards.forGame(props.slug, {
+      window: props.window,
+      limit: props.limit,
+    })
+    if (id !== latestLoadId) return
+    entries.value = resp.entries
+  } catch (err) {
+    if (id !== latestLoadId) return
+    console.error('game leaderboard: load failed', err)
+    errored.value = true
+  } finally {
+    if (id === latestLoadId) loading.value = false
+  }
+}
+
+onMounted(load)
+// Refetch when the parent navigates between games (slug changes) without unmounting.
+watch(() => [props.slug, props.window], load)
+
+const windowLabel = {
+  week: 'This Week',
+  month: 'This Month',
+  all: 'All Time',
+} as const
+</script>
+
+<template>
+  <section
+    v-if="loading || errored || entries.length > 0"
+    class="mb-8 overflow-hidden rounded-md border border-border bg-surface-raised"
+  >
+    <div class="flex items-center justify-between border-b border-border px-4 py-3.5">
+      <span class="font-heading text-sm font-bold tracking-wider text-text-secondary uppercase">
+        Top {{ windowLabel[window] }}
+      </span>
+      <RouterLink
+        to="/leaderboards"
+        class="font-mono text-[10px] tracking-widest text-text-muted uppercase no-underline hover:text-text-primary"
+      >
+        All leaderboards →
+      </RouterLink>
+    </div>
+
+    <div
+      v-if="loading && entries.length === 0"
+      class="px-4 py-6 text-center font-mono text-[11px] tracking-widest text-text-muted uppercase"
+    >
+      Loading…
+    </div>
+
+    <div
+      v-else-if="errored && entries.length === 0"
+      class="px-4 py-6 text-center font-mono text-[11px] tracking-widest text-text-muted uppercase"
+    >
+      Couldn't load leaderboard.
+    </div>
+
+    <LeaderboardRow v-for="entry in entries" :key="entry.clip.id" :entry="entry" />
+  </section>
+</template>

--- a/web/src/components/GameLeaderboardBlock.vue
+++ b/web/src/components/GameLeaderboardBlock.vue
@@ -7,8 +7,8 @@ const props = withDefaults(
   defineProps<{
     slug: string
     window?: LeaderboardWindow
-    // Mini view shows the top-3 only — fits a sidebar/embed nicely. The full /leaderboards
-    // page uses the row component directly with its own limit.
+    // Embedded mini-board on GameView. The full /leaderboards page uses the row
+    // component directly with its own limit.
     limit?: number
   }>(),
   { window: 'week', limit: 5 },

--- a/web/src/components/LeaderboardRow.vue
+++ b/web/src/components/LeaderboardRow.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { LeaderboardEntry } from '@/api/leaderboards'
+import { formatNum } from '@/lib/format'
+import GameTag from '@/components/GameTag.vue'
+import DurationBadge from '@/components/DurationBadge.vue'
+import AuthorHandle from '@/components/AuthorHandle.vue'
+import IconChevronRight from '@/components/icons/IconChevronRight.vue'
+
+const props = defineProps<{
+  entry: LeaderboardEntry
+  // When true, surfaces the entry's own `windowLikes` (counted within the window)
+  // instead of the clip's all-time `likeCount`. The standalone /leaderboards page
+  // wants the windowed number — that's what makes the ranking meaningful — while
+  // a global "popular this week" embed can opt back into the all-time count.
+  showWindowLikes?: boolean
+}>()
+
+const isTopThree = computed(() => props.entry.rank <= 3)
+const displayedLikes = computed(() =>
+  props.showWindowLikes === false ? props.entry.clip.likeCount : props.entry.windowLikes,
+)
+</script>
+
+<template>
+  <RouterLink
+    :to="{ name: 'clip', params: { id: entry.clip.id } }"
+    :aria-label="`#${entry.rank}: ${entry.clip.title}`"
+    class="grid grid-cols-[40px_120px_1fr_auto_auto] items-center gap-4 border-b border-border px-4 py-3 outline-none transition-[background] duration-150 last:border-b-0 hover:bg-surface-overlay focus-visible:bg-surface-overlay focus-visible:ring-2 focus-visible:ring-brand-light"
+  >
+    <span
+      class="font-heading text-[28px] leading-none font-bold"
+      :class="isTopThree ? 'text-brand-light' : 'text-text-muted'"
+      >#{{ entry.rank }}</span
+    >
+
+    <div class="relative aspect-video overflow-hidden rounded-[4px] bg-surface-sunken">
+      <img :src="entry.clip.thumbnailUrl" alt="" class="block h-full w-full object-cover" />
+      <DurationBadge :seconds="entry.clip.durationSecs" class="absolute right-1 bottom-1" />
+    </div>
+
+    <div class="flex min-w-0 flex-col gap-1">
+      <span
+        class="line-clamp-2 font-body text-[13px] leading-[1.35] font-medium text-text-primary"
+        >{{ entry.clip.title }}</span
+      >
+      <div class="flex items-center gap-1.5 font-mono text-[10px]">
+        <GameTag v-if="entry.clip.game" :tag="entry.clip.game.tag" tone="subtle" />
+        <AuthorHandle :username="entry.clip.author.username" class="text-neon" />
+      </div>
+    </div>
+
+    <div
+      class="flex flex-col gap-1 text-right font-mono text-[11px] whitespace-nowrap text-text-secondary"
+    >
+      <span>♥ {{ formatNum(displayedLikes) }}</span>
+      <span class="text-text-muted">{{ formatNum(entry.clip.viewCount) }} plays</span>
+    </div>
+
+    <div class="text-text-muted">
+      <IconChevronRight :size="16" />
+    </div>
+  </RouterLink>
+</template>

--- a/web/src/components/LeaderboardRow.vue
+++ b/web/src/components/LeaderboardRow.vue
@@ -9,17 +9,9 @@ import IconChevronRight from '@/components/icons/IconChevronRight.vue'
 
 const props = defineProps<{
   entry: LeaderboardEntry
-  // When true, surfaces the entry's own `windowLikes` (counted within the window)
-  // instead of the clip's all-time `likeCount`. The standalone /leaderboards page
-  // wants the windowed number — that's what makes the ranking meaningful — while
-  // a global "popular this week" embed can opt back into the all-time count.
-  showWindowLikes?: boolean
 }>()
 
 const isTopThree = computed(() => props.entry.rank <= 3)
-const displayedLikes = computed(() =>
-  props.showWindowLikes === false ? props.entry.clip.likeCount : props.entry.windowLikes,
-)
 </script>
 
 <template>
@@ -53,7 +45,7 @@ const displayedLikes = computed(() =>
     <div
       class="flex flex-col gap-1 text-right font-mono text-[11px] whitespace-nowrap text-text-secondary"
     >
-      <span>♥ {{ formatNum(displayedLikes) }}</span>
+      <span>♥ {{ formatNum(entry.windowLikes) }}</span>
       <span class="text-text-muted">{{ formatNum(entry.clip.viewCount) }} plays</span>
     </div>
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -52,6 +52,11 @@ const router = createRouter({
       component: () => import('@/views/TrendingView.vue'),
     },
     {
+      path: '/leaderboards',
+      name: 'leaderboards',
+      component: () => import('@/views/LeaderboardsView.vue'),
+    },
+    {
       path: '/search',
       name: 'search',
       component: () => import('@/views/SearchView.vue'),

--- a/web/src/views/GameView.vue
+++ b/web/src/views/GameView.vue
@@ -7,6 +7,7 @@ import { ApiError } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 import ClipCard from '@/components/ClipCard.vue'
 import GameTag from '@/components/GameTag.vue'
+import GameLeaderboardBlock from '@/components/GameLeaderboardBlock.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import StatusPanel from '@/components/StatusPanel.vue'
 
@@ -248,6 +249,10 @@ watch(slug, () => {
           </PageHeader>
         </div>
       </section>
+
+      <!-- Top this week — block self-hides when the game has no likes in the window
+           so empty games don't carry a phantom leaderboard header. -->
+      <GameLeaderboardBlock :slug="game.slug" window="week" :limit="5" />
 
       <!-- Clip grid -->
       <div v-if="items.length" class="feed-grid">

--- a/web/src/views/LeaderboardsView.vue
+++ b/web/src/views/LeaderboardsView.vue
@@ -157,6 +157,15 @@ const timeBtnInactive = `${timeBtnBase} bg-transparent text-text-secondary curso
               >#{{ entry.rank }}</span
             >
 
+            <div class="aspect-[3/4] w-10 shrink-0 overflow-hidden rounded-[3px] bg-surface-sunken">
+              <img
+                v-if="entry.coverUrl"
+                :src="entry.coverUrl"
+                alt=""
+                class="block h-full w-full object-cover"
+              />
+            </div>
+
             <div class="min-w-0 flex-1 flex flex-col gap-px">
               <span class="font-body text-[13px] font-medium text-text-primary truncate">
                 {{ entry.game.name }}

--- a/web/src/views/LeaderboardsView.vue
+++ b/web/src/views/LeaderboardsView.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+import {
+  leaderboards,
+  type GlobalLeaderboardResponse,
+  type LeaderboardWindow,
+} from '@/api/leaderboards'
+import { formatNum } from '@/lib/format'
+import LeaderboardRow from '@/components/LeaderboardRow.vue'
+import PageHeader from '@/components/PageHeader.vue'
+import StatusPanel from '@/components/StatusPanel.vue'
+
+// Server vocabulary is week|month|all — see LeaderboardWindow.cs. Tabs render in the
+// order the user reads time: shortest window first, all-time last.
+const WINDOWS: { key: LeaderboardWindow; label: string }[] = [
+  { key: 'week', label: 'This Week' },
+  { key: 'month', label: 'This Month' },
+  { key: 'all', label: 'All Time' },
+]
+
+const activeWindow = ref<LeaderboardWindow>('week')
+const data = ref<GlobalLeaderboardResponse | null>(null)
+const loading = ref(false)
+const errored = ref(false)
+
+// Monotonic load token: rapid tab toggles (week → month → week) shouldn't let a slow
+// earlier response overwrite a newer one. Same pattern as TrendingView.
+let latestLoadId = 0
+
+async function load() {
+  const id = ++latestLoadId
+  loading.value = true
+  errored.value = false
+  try {
+    const resp = await leaderboards.global({
+      window: activeWindow.value,
+      clipsLimit: 10,
+      gamesLimit: 10,
+    })
+    if (id !== latestLoadId) return
+    data.value = resp
+  } catch (err) {
+    if (id !== latestLoadId) return
+    console.error('leaderboards: load failed', err)
+    errored.value = true
+  } finally {
+    if (id === latestLoadId) loading.value = false
+  }
+}
+
+onMounted(load)
+watch(activeWindow, load)
+
+function selectWindow(key: LeaderboardWindow) {
+  if (key === activeWindow.value) return
+  activeWindow.value = key
+}
+
+const timeBtnBase =
+  'px-3.5 py-1.5 rounded-sm font-mono text-[11px] uppercase tracking-[0.06em] border-none'
+const timeBtnActive = `${timeBtnBase} bg-brand text-white cursor-pointer transition-[background] duration-150`
+const timeBtnInactive = `${timeBtnBase} bg-transparent text-text-secondary cursor-pointer transition-[color] duration-150`
+</script>
+
+<template>
+  <main class="mx-auto max-w-360 px-6 pt-8 pb-30">
+    <PageHeader title="Leaderboards">
+      <template #caption
+        >Most-liked clips and games, ranked by likes earned within the window.</template
+      >
+
+      <div
+        class="mt-5 inline-flex gap-0.5 p-1 bg-surface-raised border border-border rounded-sm"
+        role="group"
+        aria-label="Leaderboard time window"
+      >
+        <button
+          v-for="tw in WINDOWS"
+          :key="tw.key"
+          type="button"
+          :class="activeWindow === tw.key ? timeBtnActive : timeBtnInactive"
+          :aria-pressed="activeWindow === tw.key"
+          @click="selectWindow(tw.key)"
+        >
+          {{ tw.label }}
+        </button>
+      </div>
+    </PageHeader>
+
+    <StatusPanel v-if="errored" kind="error" message="Couldn't load leaderboards.">
+      <button
+        class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="load"
+      >
+        Retry
+      </button>
+    </StatusPanel>
+
+    <StatusPanel v-else-if="loading && !data" kind="loading" message="Loading…" />
+
+    <StatusPanel
+      v-else-if="data && data.topClips.length === 0 && data.topGames.length === 0"
+      kind="empty"
+      message="No clips have been liked in this window yet."
+    />
+
+    <div
+      v-else-if="data"
+      class="grid grid-cols-[minmax(0,1fr)_340px] gap-7 items-start max-[960px]:grid-cols-1 mt-7"
+    >
+      <!-- LEFT: top clips -->
+      <div class="bg-surface-raised border border-border rounded-md overflow-hidden">
+        <div class="px-4 py-3.5 border-b border-border">
+          <span class="font-heading font-bold text-sm uppercase text-text-secondary tracking-wider">
+            Top Clips
+          </span>
+        </div>
+
+        <div
+          v-if="data.topClips.length === 0"
+          class="px-4 py-6 font-mono text-[11px] uppercase tracking-widest text-text-muted text-center"
+        >
+          No likes recorded in this window.
+        </div>
+
+        <LeaderboardRow v-for="entry in data.topClips" :key="entry.clip.id" :entry="entry" />
+      </div>
+
+      <!-- RIGHT: top games -->
+      <div class="flex flex-col gap-4">
+        <div class="bg-surface-raised border border-border rounded-md overflow-hidden">
+          <div class="px-4 py-3.5 border-b border-border">
+            <span
+              class="font-heading font-bold text-sm uppercase text-text-secondary tracking-wider"
+            >
+              Top Games
+            </span>
+          </div>
+
+          <div
+            v-if="data.topGames.length === 0"
+            class="px-4 py-6 font-mono text-[11px] uppercase tracking-widest text-text-muted text-center"
+          >
+            No game activity yet.
+          </div>
+
+          <RouterLink
+            v-for="entry in data.topGames"
+            :key="entry.game.id"
+            :to="{ name: 'game-detail', params: { slug: entry.game.slug } }"
+            :aria-label="`#${entry.rank}: ${entry.game.name}`"
+            class="flex items-center gap-3 px-4 py-2.5 border-b border-border last:border-b-0 transition-[background] duration-150 outline-none hover:bg-surface-overlay focus-visible:bg-surface-overlay focus-visible:ring-2 focus-visible:ring-brand-light"
+          >
+            <span
+              class="font-heading font-bold text-[20px] leading-none w-7 shrink-0 text-center"
+              :class="entry.rank <= 3 ? 'text-brand-light' : 'text-text-muted'"
+              >#{{ entry.rank }}</span
+            >
+
+            <div class="min-w-0 flex-1 flex flex-col gap-px">
+              <span class="font-body text-[13px] font-medium text-text-primary truncate">
+                {{ entry.game.name }}
+              </span>
+              <span class="font-mono text-[10px] text-text-muted">
+                {{ formatNum(entry.windowLikes) }} ♥ · {{ formatNum(entry.clipCount) }} clips
+              </span>
+            </div>
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>


### PR DESCRIPTION
## Summary

Per-game and global leaderboards ranking clips by likes accrued within a time window (week/month/all), rather than the denormalized all-time `clip.like_count`. Surfaces a standalone `/leaderboards` page and a "Top This Week" block on each game page.

## What's here

- **Server:** `GET /games/{slug}/leaderboard` and `GET /leaderboards` (top clips + top games). Aggregates over `likes.created_at`, filters to `public`+`ready`, deterministic tiebreak (likes desc, createdAt desc, id asc). Contracts/Leaderboards/ with hand-written mapper. Window parser kept separate from trending's so the two endpoints can evolve their window vocabularies independently.
- **Web:** `api/leaderboards.ts` (`global` + `forGame`), `/leaderboards` route + view (window tabs, top clips + top games sidebar), `GameLeaderboardBlock` embedded on `GameView` that self-hides when there's no activity in the window, shared `LeaderboardRow` component, Leaderboards link in `AppNav`.
- **Tests:** 13 server integration tests covering window boundaries, public/ready filtering, deterministic+stable ties, 400/404 paths, empty windows, per-game scoping. Vitest specs for the api module.

Closes #104

## How to test manually

API watcher needs a restart after this lands — new endpoint registrations can't hot-reload. From the worktree (`make ports` for the local URLs):

```bash
curl -s 'http://localhost:5050/leaderboards?window=week' | jq
curl -s 'http://localhost:5050/games/valorant/leaderboard?window=week' \
  | jq '.entries[] | {rank, title: .clip.title, windowLikes}'
curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/leaderboards?window=bogus'     # 400
curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5050/games/no-such/leaderboard?window=week'  # 404
```

Browser: top-nav **Leaderboards** toggles the week/month/all tabs and refetches; `/game/<slug>` shows a "Top This Week" block above the clip grid that disappears when the game has no in-window likes.

## Checklist

- [ ] Verified manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a global leaderboards page displaying top-ranked clips and games filtered by time period
  * Implemented time-window filtering for leaderboards with week, month, and all-time options
  * Added a game-specific leaderboard section on individual game pages showing top clips for that game
  * Added navigation menu link to access the new leaderboards feature

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->