### PR TITLE
[web] Reels: vertical-snap feed with inline comments

### DIFF
--- a/docs/superpowers/specs/2026-05-24-reels-feed-design.md
+++ b/docs/superpowers/specs/2026-05-24-reels-feed-design.md
@@ -1,0 +1,168 @@
+# Reels feed — design spec (issue #108)
+
+Phase 4 (Scale & Grow) stretch item: a full-screen, vertical-swipe "reels" feed as an alternative way to browse clips. Web-only; reuses the existing `clips.feed({ cursor, limit, source })` API. No server changes.
+
+## Scope
+
+| Decision | Value |
+|---|---|
+| Frame strategy | Letterboxed, fits-width — clip at natural 16:9 inside a portrait-shaped column |
+| Desktop layout | Phone-frame, centered (`min(420px, calc(90vh * 9/16))`); page bg shows on either side |
+| Feed source | Public only, no toggle (mirror HomeView's tab UX deferred) |
+| Player | Native `<video muted playsinline>` + custom overlay (not Plyr) |
+| Deep-link | `/feed/reels/:id` — dedicated route; `router.replace` per active clip; no history entries per snap |
+| Entry point | Floating action button on HomeView (bottom-right, position:fixed) |
+| View tracking | 3-second accumulator, identical to `ClipView.vue` (`POST /clips/{id}/view`) |
+| Overlay actions | Like, mute, author handle (→ `/user/:username`), open-in-detail (→ `/clip/:id`) |
+| Out of scope (v1) | Keyboard nav, swipe gestures, comments, share button, game-tag chip, preload tuning knob, virtualization |
+
+## Files
+
+**New**
+- `web/src/views/ReelsView.vue` — route component, owns data + observer + URL sync
+- `web/src/components/reels/ReelClip.vue` — single snap slot (thumbnail/video + overlay + view tracking)
+- `web/src/components/reels/ReelsFab.vue` — FAB on HomeView
+- `web/src/components/icons/IconVolumeMute.vue` — speaker-with-slash variant for the mute overlay
+- `web/src/components/icons/IconExternalLink.vue` — open-in-detail affordance
+
+**Edited**
+- `web/src/router/index.ts` — two routes (`reels`, `reel-clip`) pointing at `ReelsView.vue`
+- `web/src/views/HomeView.vue` — mount `<ReelsFab />` once
+
+## Routing
+
+```ts
+{ path: '/feed/reels',     name: 'reels',     component: () => import('@/views/ReelsView.vue') },
+{ path: '/feed/reels/:id', name: 'reel-clip', component: () => import('@/views/ReelsView.vue') },
+```
+
+Same component for both — `route.params.id` is `undefined` on the bare route, present on the deep-link route. The view does *not* re-fetch on route changes it triggered itself (`router.replace` for URL sync is gated with a `selfNavigating` flag).
+
+## Data flow (`ReelsView`)
+
+State:
+```ts
+const items = ref<ClipFeedItem[]>([])
+const cursor = ref<string | null>(null)
+const loading = ref(false)
+const errored = ref(false)
+const paginationErrored = ref(false)
+const details = reactive(new Map<string, ClipDetail>())  // lazy videoUrl cache
+const detailErrors = reactive(new Set<string>())         // failed prefetches (for retry)
+const detailsInflight = new Set<string>()                // de-dup concurrent getDetail
+const activeIndex = ref(0)
+const globalMuted = ref(true)
+```
+
+Initial load:
+- No seed id: `clips.feed({ limit: 20 })` → `items = page.items`
+- With seed id: `Promise.all([clips.getDetail(seedId), clips.feed({ limit: 20 })])`. `seed` is projected to a `ClipFeedItem` shape and used as `items[0]`; the feed page is `.filter(c => c.id !== seedId)` so the seed isn't duplicated. `details.set(seedId, seed)` so the active clip has its video URL immediately.
+- Failure on initial load → `errored = true`; full-page error panel with retry.
+
+Pagination:
+- `watch(activeIndex)` fires `loadMore()` when `activeIndex >= items.length - 3`.
+- Uses a `latestLoadId` counter (same pattern as `ClipView.loadClip`) so a late response from an abandoned page can't stomp current state.
+- Failure → `paginationErrored = true`; inline retry pill snap-aligned at the bottom of the feed.
+- Cursor exhausted → no retry pill; user just stops snapping.
+
+Detail prefetch:
+- `watch(activeIndex)` computes `windowIds = [items[i-1], items[i], items[i+1]].map(c => c?.id)` (filtered for undefined at edges).
+- For each id ∉ `details`, ∉ `detailsInflight`, ∉ `detailErrors` (don't infinite-retry), fire `clips.getDetail(id)` in the background. Success → `details.set(id, detail)`. Failure → `detailErrors.add(id)`; child shows a per-clip "couldn't load video — retry" overlay.
+
+URL sync:
+- `watch(activeIndex)` does `router.replace({ name: 'reel-clip', params: { id: items[activeIndex].id } })`.
+- `selfNavigating = true` set before the replace; cleared on next route observation. The view's own params watcher early-returns when `selfNavigating === true`.
+
+## Per-clip lifecycle
+
+`ReelClip.vue` props/emits:
+```ts
+defineProps<{
+  clip: ClipFeedItem
+  detail: ClipDetail | null
+  detailErrored: boolean
+  isActive: boolean
+  globalMuted: boolean
+}>()
+defineEmits<{
+  (e: 'toggle-mute'): void
+  (e: 'retry-detail', id: string): void
+  (e: 'liked-changed', payload: { id: string; liked: boolean; count: number }): void
+}>()
+```
+
+Render gates:
+- `detail === null && !detailErrored` → thumbnail + delayed-fade spinner (250ms)
+- `detailErrored` → thumbnail + "Couldn't load video. Retry." overlay → emits `retry-detail`
+- `detail !== null` → `<video muted playsinline preload="metadata">` mounted; thumbnail hidden
+
+`watch([() => props.isActive, () => props.detail, videoEl], ...)`:
+- `active && detail && el` → set `el.muted = globalMuted`, `el.currentTime = 0`, `el.play().catch(needsTapToPlay = true)`; attach view tracking.
+- `!active` → `el.pause()`, detach view tracking, reset `playedMs = 0`.
+
+`watch(() => props.globalMuted, m => { if (videoEl.value) videoEl.value.muted = m })`.
+
+View tracking: direct lift of `ClipView`'s pattern (per-tick `timeupdate` accumulator, clamped delta `[0, 1000ms]`, fire once at 3000ms via `clips.recordView(id)`, fire-and-forget). Scoped per `ReelClip` instance; remount re-arms (server-side 30-min dedup absorbs revisits).
+
+## Observer (`ReelsView`)
+
+Single `IntersectionObserver` on the scroll container:
+```ts
+new IntersectionObserver(handleIntersect, {
+  root: scrollContainerEl.value,
+  threshold: [0, 0.5, 0.75, 0.95],
+})
+```
+
+Children register/unregister via a callback ref: `:ref="(el) => registerClip(clip.id, el)"`. Parent maintains `elToId: WeakMap<Element, string>` and `ratios: Map<string, number>`.
+
+`handleIntersect`: merge entry ratios into `ratios`, then pick highest. Hysteresis gate: only update `activeIndex` if the new candidate's ratio `>= 0.6` *and* it differs from the current. This stops the brief two-clip overlap during a snap from chattering play/pause.
+
+## Overlay UI
+
+Right-rail column (TikTok convention) inside the portrait frame:
+- Like: heart icon + count (formatNum). Optimistic flip, rolls back on error (lift `toggleLike` from ClipView). Anonymous tap → `router.push({ name: 'login', query: { redirect: '/feed/reels/' + clip.id } })`.
+- Mute: speaker icon (or speaker-slash when muted). Emits `toggle-mute` → parent flips `globalMuted`.
+- Author: avatar + `@username` → `/user/:username`.
+- Open-in-detail: external-link icon → `/clip/:id`.
+
+Plus a top-left game/title strip (subtle) and a bottom safe-area for OS chrome on mobile.
+
+## Error / empty / auth states
+
+| State | UX |
+|---|---|
+| Initial load failed | Full-page `StatusPanel` (kind=error), "Retry" |
+| Empty feed (no clips at all) | Full-page `StatusPanel` (kind=empty), "Upload a clip" CTA |
+| Pagination failed | Snap-aligned bottom pill: "Couldn't load more. Retry." |
+| Per-clip detail fetch failed | Per-slot overlay: "Couldn't load video. Retry." (other clips unaffected) |
+| Autoplay rejected | "Tap to play" centered overlay (defensive; shouldn't fire with muted=true) |
+| Deep-link clip 404 | Treat as "no seed", start at top of cursor feed; quiet toast: "That clip is no longer available" |
+| Anonymous + like tap | Redirect to `/login?redirect=/feed/reels/:id` |
+
+## FAB (`ReelsFab.vue`)
+
+Position: `fixed`, `bottom: max(safe-area-inset-bottom, 24px)`, `right: 24px`, `z-50`. Circular, brand-filled, IconPlay glyph (or a custom "stacked" reels glyph; defer to design later). `RouterLink to="/feed/reels"`. No scroll-hiding behavior in v1.
+
+Mounted once in `HomeView.vue` at the root template level, outside the `<main>` flow (so it doesn't shift page padding). Visible to authenticated and anonymous users alike.
+
+## Testing
+
+Coverage gate covers `api/`, `router/`, `stores/` only — reels code is in views/components and not in the denominator. Tests we write are for correctness, not coverage:
+
+- `web/src/components/reels/__tests__/ReelClip.spec.ts` — render gates (thumb vs video), like toggle optimistic flow, mute toggle emits, anonymous like redirects to login.
+- `web/src/views/__tests__/ReelsView.spec.ts` — dedup when seed id is in first page, URL replace on activeIndex change, pagination triggers at items.length - 3, deep-link 404 falls back to top of feed.
+- `web/src/components/reels/__tests__/ReelsFab.spec.ts` — renders, links to `/feed/reels`.
+- `web/src/router/__tests__/` — add assertions for the two new route name resolutions.
+
+We mock `clips.feed`, `clips.getDetail`, `clips.recordView`, `clips.like`, `clips.unlike` directly. `IntersectionObserver` is stubbed on `globalThis` per test.
+
+## What we explicitly defer
+
+- Virtualization (DOM stays full for v1 — cursor pages of 20 mean ~5 pages = 100 nodes max, which is fine).
+- Tab UX (public-only).
+- Keyboard nav (J/K, arrows).
+- Inline comments (open-in-detail bridges this).
+- Share button (open-in-detail then share from there).
+- Preload-window tuning knob (hardcoded ±1).
+- Trending sort in reels.

--- a/docs/superpowers/specs/2026-05-24-reels-feed-design.md
+++ b/docs/superpowers/specs/2026-05-24-reels-feed-design.md
@@ -13,8 +13,8 @@ Phase 4 (Scale & Grow) stretch item: a full-screen, vertical-swipe "reels" feed 
 | Deep-link | `/feed/reels/:id` — dedicated route; `router.replace` per active clip; no history entries per snap |
 | Entry point | Floating action button on HomeView (bottom-right, position:fixed) |
 | View tracking | 3-second accumulator, identical to `ClipView.vue` (`POST /clips/{id}/view`) |
-| Overlay actions | Like, mute, author handle (→ `/user/:username`), open-in-detail (→ `/clip/:id`) |
-| Out of scope (v1) | Keyboard nav, swipe gestures, comments, share button, game-tag chip, preload tuning knob, virtualization |
+| Overlay actions | Like, mute, comments (opens bottom sheet), author handle (→ `/user/:username`). Open-in-detail (→ `/clip/:id`) is reachable from the sheet header as a "View full clip →" link. |
+| Out of scope (v1) | Keyboard nav, swipe gestures, share button, game-tag chip, preload tuning knob, virtualization. (Comments: bottom-sheet `CommentsSection` is in v1; truly inline comments — no sheet — are deferred.) |
 
 ## Files
 
@@ -23,7 +23,9 @@ Phase 4 (Scale & Grow) stretch item: a full-screen, vertical-swipe "reels" feed 
 - `web/src/components/reels/ReelClip.vue` — single snap slot (thumbnail/video + overlay + view tracking)
 - `web/src/components/reels/ReelsFab.vue` — FAB on HomeView
 - `web/src/components/icons/IconVolumeMute.vue` — speaker-with-slash variant for the mute overlay
-- `web/src/components/icons/IconExternalLink.vue` — open-in-detail affordance
+- `web/src/components/icons/IconMessageCircle.vue` — comments button glyph in the right-rail
+- `web/src/components/icons/IconX.vue` — close affordance on the comments bottom sheet
+- `web/src/components/icons/IconReels.vue` — FAB glyph on HomeView
 
 **Edited**
 - `web/src/router/index.ts` — two routes (`reels`, `reel-clip`) pointing at `ReelsView.vue`
@@ -123,8 +125,8 @@ Children register/unregister via a callback ref: `:ref="(el) => registerClip(cli
 Right-rail column (TikTok convention) inside the portrait frame:
 - Like: heart icon + count (formatNum). Optimistic flip, rolls back on error (lift `toggleLike` from ClipView). Anonymous tap → `router.push({ name: 'login', query: { redirect: '/feed/reels/' + clip.id } })`.
 - Mute: speaker icon (or speaker-slash when muted). Emits `toggle-mute` → parent flips `globalMuted`.
+- Comments: message-circle icon. Opens a `<Teleport>`-ed bottom sheet hosting `CommentsSection.vue`. Sheet header has a "View full clip →" link (open-in-detail) and an X close button. Dismiss on backdrop click or `Esc` (window-level listener).
 - Author: avatar + `@username` → `/user/:username`.
-- Open-in-detail: external-link icon → `/clip/:id`.
 
 Plus a top-left game/title strip (subtle) and a bottom safe-area for OS chrome on mobile.
 
@@ -142,7 +144,9 @@ Plus a top-left game/title strip (subtle) and a bottom safe-area for OS chrome o
 
 ## FAB (`ReelsFab.vue`)
 
-Position: `fixed`, `bottom: max(safe-area-inset-bottom, 24px)`, `right: 24px`, `z-50`. Circular, brand-filled, IconPlay glyph (or a custom "stacked" reels glyph; defer to design later). `RouterLink to="/feed/reels"`. No scroll-hiding behavior in v1.
+Position: `fixed`, `bottom: calc(env(safe-area-inset-bottom, 0px) + 24px)`, `right: 24px`, `z-50`. Circular, brand-filled, `IconReels` glyph. `RouterLink to="/feed/reels"`. No scroll-hiding behavior in v1.
+
+Note on bottom positioning: we use `calc(safe-area + 24px)` rather than `max(safe-area, 24px)` so the FAB always sits 24px *above* the home indicator on devices with one, instead of resting directly on it.
 
 Mounted once in `HomeView.vue` at the root template level, outside the `<main>` flow (so it doesn't shift page padding). Visible to authenticated and anonymous users alike.
 
@@ -162,7 +166,7 @@ We mock `clips.feed`, `clips.getDetail`, `clips.recordView`, `clips.like`, `clip
 - Virtualization (DOM stays full for v1 — cursor pages of 20 mean ~5 pages = 100 nodes max, which is fine).
 - Tab UX (public-only).
 - Keyboard nav (J/K, arrows).
-- Inline comments (open-in-detail bridges this).
+- Inline comments rendered directly in the overlay (deferred — the bottom-sheet `CommentsSection` covers the use case for v1).
 - Share button (open-in-detail then share from there).
 - Preload-window tuning knob (hardcoded ±1).
 - Trending sort in reels.

--- a/web/src/components/icons/IconMessageCircle.vue
+++ b/web/src/components/icons/IconMessageCircle.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number; strokeWidth?: number }>(), {
+  size: 16,
+  strokeWidth: 2,
+})
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    :stroke-width="strokeWidth"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path
+      d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"
+    />
+  </svg>
+</template>

--- a/web/src/components/icons/IconReels.vue
+++ b/web/src/components/icons/IconReels.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+// Stacked-rectangles glyph evocative of a vertical-snap reel of cards.
+withDefaults(defineProps<{ size?: number; strokeWidth?: number }>(), {
+  size: 16,
+  strokeWidth: 2,
+})
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    :stroke-width="strokeWidth"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="6" y="3" width="12" height="8" rx="1.5" />
+    <rect x="6" y="13" width="12" height="8" rx="1.5" />
+    <line x1="10" y1="7" x2="14" y2="7" />
+    <line x1="10" y1="17" x2="14" y2="17" />
+  </svg>
+</template>

--- a/web/src/components/icons/IconVolumeMute.vue
+++ b/web/src/components/icons/IconVolumeMute.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number }>(), { size: 16 })
+</script>
+
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path
+      d="M3 9v6h4l5 5V4L7 9H3zm13.59 3L20 8.41 18.59 7 15 10.59 11.41 7 10 8.41 13.59 12 10 15.59 11.41 17 15 13.41 18.59 17 20 15.59 16.59 12z"
+    />
+  </svg>
+</template>

--- a/web/src/components/icons/IconX.vue
+++ b/web/src/components/icons/IconX.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number; strokeWidth?: number }>(), {
+  size: 16,
+  strokeWidth: 2,
+})
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    :stroke-width="strokeWidth"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+</template>

--- a/web/src/components/reels/ReelClip.vue
+++ b/web/src/components/reels/ReelClip.vue
@@ -253,6 +253,22 @@ function openComments() {
 function closeComments() {
   commentsOpen.value = false
 }
+
+function onCommentsKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') closeComments()
+}
+
+watch(commentsOpen, (open) => {
+  if (typeof window === 'undefined') return
+  if (open) window.addEventListener('keydown', onCommentsKeydown)
+  else window.removeEventListener('keydown', onCommentsKeydown)
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('keydown', onCommentsKeydown)
+  }
+})
 </script>
 
 <template>
@@ -426,7 +442,6 @@ function closeComments() {
           v-if="commentsOpen"
           class="fixed inset-0 z-50 bg-black/55"
           @click.self="closeComments"
-          @keydown.esc.window="closeComments"
         >
           <Transition
             enter-active-class="transition-transform duration-200 ease-out"

--- a/web/src/components/reels/ReelClip.vue
+++ b/web/src/components/reels/ReelClip.vue
@@ -438,11 +438,7 @@ onBeforeUnmount(() => {
         enter-from-class="opacity-0"
         leave-to-class="opacity-0"
       >
-        <div
-          v-if="commentsOpen"
-          class="fixed inset-0 z-50 bg-black/55"
-          @click.self="closeComments"
-        >
+        <div v-if="commentsOpen" class="fixed inset-0 z-50 bg-black/55" @click.self="closeComments">
           <Transition
             enter-active-class="transition-transform duration-200 ease-out"
             leave-active-class="transition-transform duration-150 ease-in"

--- a/web/src/components/reels/ReelClip.vue
+++ b/web/src/components/reels/ReelClip.vue
@@ -1,0 +1,437 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { clips, type ClipDetail, type ClipFeedItem } from '@/api/clips'
+import { useAuthStore } from '@/stores/auth'
+import { formatNum } from '@/lib/format'
+import UserAvatar from '@/components/UserAvatar.vue'
+import AuthorHandle from '@/components/AuthorHandle.vue'
+import CommentsSection from '@/components/CommentsSection.vue'
+import IconHeart from '@/components/icons/IconHeart.vue'
+import IconVolume from '@/components/icons/IconVolume.vue'
+import IconVolumeMute from '@/components/icons/IconVolumeMute.vue'
+import IconMessageCircle from '@/components/icons/IconMessageCircle.vue'
+import IconX from '@/components/icons/IconX.vue'
+import IconPlay from '@/components/icons/IconPlay.vue'
+
+const props = defineProps<{
+  clip: ClipFeedItem
+  detail: ClipDetail | null
+  detailErrored: boolean
+  isActive: boolean
+  globalMuted: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'toggle-mute'): void
+  (e: 'retry-detail', id: string): void
+  (e: 'liked-changed', payload: { id: string; liked: boolean; count: number }): void
+  (e: 'view-recorded', id: string): void
+}>()
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const videoEl = useTemplateRef<HTMLVideoElement>('videoEl')
+const needsTapToPlay = ref(false)
+const spinnerVisible = ref(false)
+const commentsOpen = ref(false)
+let spinnerTimer: ReturnType<typeof setTimeout> | null = null
+
+// Like state is local for snappy optimistic UI. Parent gets notified via emit so
+// its `items[]` cache reflects the latest count if the user opens the detail page.
+const liked = ref(props.clip.likedByMe)
+const likeCount = ref(props.clip.likeCount)
+const likeBusy = ref(false)
+
+// Re-sync local like state when the clip prop swaps (parent may have updated
+// its cache from elsewhere — e.g., a refetch).
+watch(
+  () => props.clip.id,
+  () => {
+    liked.value = props.clip.likedByMe
+    likeCount.value = props.clip.likeCount
+  },
+)
+
+// --- View tracking — direct port of ClipView's pattern -----------------------
+// Per-instance accumulator. If the slot remounts later (e.g., user scrolls back
+// to it after we trimmed the DOM), this re-arms — the server's 30-min dedup
+// absorbs the revisit and we err on under-count.
+let viewRecorded = false
+let playedMs = 0
+let lastTickMs = 0
+let viewListener: { el: HTMLVideoElement; handler: () => void } | null = null
+
+function attachViewTracking(targetClipId: string, el: HTMLVideoElement) {
+  detachViewTracking()
+  playedMs = 0
+  lastTickMs = el.currentTime * 1000
+  const onTick = () => {
+    if (viewRecorded || el.paused) {
+      lastTickMs = el.currentTime * 1000
+      return
+    }
+    const now = el.currentTime * 1000
+    const delta = now - lastTickMs
+    lastTickMs = now
+    // Clamp [0, 1000ms] so a scrub forward doesn't credit the gap and a scrub
+    // back doesn't subtract.
+    if (delta > 0 && delta < 1000) playedMs += delta
+    if (playedMs >= 3000) {
+      viewRecorded = true
+      void clips.recordView(targetClipId).catch(() => {
+        // Silent: best-effort. Retry would only fight the server's rate limit.
+      })
+      emit('view-recorded', targetClipId)
+    }
+  }
+  el.addEventListener('timeupdate', onTick)
+  viewListener = { el, handler: onTick }
+}
+
+function detachViewTracking() {
+  if (viewListener) {
+    viewListener.el.removeEventListener('timeupdate', viewListener.handler)
+    viewListener = null
+  }
+}
+
+// --- Playback lifecycle -------------------------------------------------------
+
+watch(
+  [() => props.isActive, () => props.detail, videoEl],
+  ([active, detail, el]) => {
+    if (!detail || !el) return
+    if (active) {
+      el.muted = props.globalMuted
+      el.currentTime = 0
+      needsTapToPlay.value = false
+      // jsdom returns undefined from play(); real browsers return a Promise.
+      // Normalise so .catch is always safe and tests can run without a media
+      // shim. Autoplay rejection (rare with muted=true) flips to tap-to-play.
+      Promise.resolve(el.play()).catch(() => {
+        needsTapToPlay.value = true
+      })
+      attachViewTracking(detail.id, el)
+    } else {
+      el.pause()
+      detachViewTracking()
+      playedMs = 0
+      viewRecorded = false
+    }
+  },
+  { flush: 'post' },
+)
+
+watch(
+  () => props.globalMuted,
+  (m) => {
+    if (videoEl.value) videoEl.value.muted = m
+  },
+)
+
+// Auto-close the comments sheet when the user scrolls to a different clip.
+// Without this, the sheet would remain visible on the previously-active reel
+// when scrolling, even though its parent slot is no longer the focus.
+watch(
+  () => props.isActive,
+  (active) => {
+    if (!active) commentsOpen.value = false
+  },
+)
+
+// Spinner appears only after 250ms of waiting — avoids a flash on fast networks
+// where detail resolves in <100ms.
+watch(
+  [() => props.detail, () => props.detailErrored],
+  ([detail, errored]) => {
+    if (spinnerTimer !== null) {
+      clearTimeout(spinnerTimer)
+      spinnerTimer = null
+    }
+    if (detail || errored) {
+      spinnerVisible.value = false
+      return
+    }
+    spinnerTimer = setTimeout(() => {
+      spinnerVisible.value = true
+    }, 250)
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  detachViewTracking()
+  if (spinnerTimer !== null) clearTimeout(spinnerTimer)
+})
+
+// --- Interactions -------------------------------------------------------------
+
+function handleTapToPlay() {
+  if (!videoEl.value) return
+  Promise.resolve(videoEl.value.play())
+    .then(() => {
+      needsTapToPlay.value = false
+    })
+    .catch(() => {
+      // User gesture didn't help — leave the overlay visible.
+    })
+}
+
+async function toggleLike() {
+  if (likeBusy.value) return
+  if (!auth.isAuthenticated) {
+    router.push({
+      name: 'login',
+      query: { redirect: route.fullPath },
+    })
+    return
+  }
+  const targetId = props.clip.id
+  const wasLiked = liked.value
+  liked.value = !wasLiked
+  likeCount.value += wasLiked ? -1 : 1
+  likeBusy.value = true
+  try {
+    const res = wasLiked ? await clips.unlike(targetId) : await clips.like(targetId)
+    if (props.clip.id !== targetId) return
+    liked.value = res.liked
+    likeCount.value = res.likeCount
+    emit('liked-changed', { id: targetId, liked: res.liked, count: res.likeCount })
+  } catch {
+    if (props.clip.id !== targetId) return
+    liked.value = wasLiked
+    likeCount.value += wasLiked ? 1 : -1
+  } finally {
+    likeBusy.value = false
+  }
+}
+
+function onToggleMute() {
+  emit('toggle-mute')
+}
+
+function onRetryDetail() {
+  emit('retry-detail', props.clip.id)
+}
+
+const detailHref = computed(() => `/clip/${props.clip.id}`)
+const authorHref = computed(() => `/user/${props.clip.author.username}`)
+
+function openComments() {
+  commentsOpen.value = true
+}
+
+function closeComments() {
+  commentsOpen.value = false
+}
+</script>
+
+<template>
+  <article
+    class="relative flex h-full w-full items-center justify-center overflow-hidden bg-surface-sunken"
+  >
+    <!-- Thumbnail layer — visible until video element mounts. -->
+    <img
+      v-if="!detail"
+      :src="clip.thumbnailUrl"
+      :alt="clip.title"
+      class="block max-h-full max-w-full object-contain"
+    />
+
+    <!-- Video layer. -->
+    <video
+      v-if="detail"
+      ref="videoEl"
+      :src="detail.videoUrl"
+      :poster="clip.thumbnailUrl"
+      :loop="true"
+      :muted="globalMuted"
+      playsinline
+      preload="metadata"
+      class="block max-h-full max-w-full object-contain"
+    />
+
+    <!-- Delayed-fade loading spinner. -->
+    <div
+      v-if="spinnerVisible && !detail && !detailErrored"
+      class="pointer-events-none absolute inset-0 flex items-center justify-center"
+    >
+      <div
+        class="h-10 w-10 animate-spin rounded-full border-2 border-white/20 border-t-white/80"
+      ></div>
+    </div>
+
+    <!-- Per-slot detail load error. -->
+    <div
+      v-if="detailErrored"
+      class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/50 text-center"
+    >
+      <p class="font-mono text-xs uppercase tracking-widest text-text-secondary">
+        Couldn't load video
+      </p>
+      <button
+        type="button"
+        class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="onRetryDetail"
+      >
+        Retry
+      </button>
+    </div>
+
+    <!-- Tap-to-play fallback (autoplay rejection). -->
+    <button
+      v-if="needsTapToPlay && detail"
+      type="button"
+      class="absolute inset-0 flex cursor-pointer items-center justify-center bg-transparent"
+      :aria-label="`Play ${clip.title}`"
+      @click="handleTapToPlay"
+    >
+      <span
+        class="inline-flex h-16 w-16 items-center justify-center rounded-full border border-white/20 bg-black/55 text-white backdrop-blur-md"
+      >
+        <IconPlay :size="26" />
+      </span>
+    </button>
+
+    <!-- Top gradient strip — title + game name. -->
+    <div
+      class="pointer-events-none absolute inset-x-0 top-0 flex flex-col gap-1 bg-gradient-to-b from-black/70 to-transparent px-4 pt-4 pb-10 text-white"
+    >
+      <p v-if="clip.game" class="font-mono text-[10px] uppercase tracking-[0.12em] text-white/70">
+        {{ clip.game.tag }}
+      </p>
+      <h2 class="m-0 line-clamp-2 font-heading text-base font-bold uppercase tracking-[0.01em]">
+        {{ clip.title }}
+      </h2>
+    </div>
+
+    <!-- Bottom gradient — author handle. -->
+    <RouterLink
+      :to="authorHref"
+      class="pointer-events-auto absolute inset-x-0 bottom-0 flex items-center gap-2 bg-gradient-to-t from-black/70 to-transparent px-4 pt-10 pb-5 text-white no-underline"
+    >
+      <UserAvatar :user="clip.author" :size="32" />
+      <AuthorHandle :username="clip.author.username" class="text-sm font-semibold" />
+    </RouterLink>
+
+    <!-- Right-rail actions. -->
+    <div class="absolute right-3 bottom-24 flex flex-col items-center gap-4 text-white">
+      <button
+        type="button"
+        class="flex cursor-pointer flex-col items-center gap-1 bg-transparent disabled:opacity-60"
+        :disabled="likeBusy"
+        :aria-label="liked ? 'Unlike' : 'Like'"
+        :aria-pressed="liked"
+        @click="toggleLike"
+      >
+        <span
+          class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/20 backdrop-blur-md"
+          :class="liked ? 'bg-brand text-white' : 'bg-black/45 text-white'"
+        >
+          <IconHeart :size="20" />
+        </span>
+        <span class="font-mono text-[11px] tabular-nums">{{ formatNum(likeCount) }}</span>
+      </button>
+
+      <button
+        type="button"
+        class="flex cursor-pointer flex-col items-center gap-1 bg-transparent"
+        :aria-label="globalMuted ? 'Unmute' : 'Mute'"
+        :aria-pressed="!globalMuted"
+        @click="onToggleMute"
+      >
+        <span
+          class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-black/45 backdrop-blur-md"
+        >
+          <IconVolumeMute v-if="globalMuted" :size="18" />
+          <IconVolume v-else :size="18" />
+        </span>
+      </button>
+
+      <button
+        type="button"
+        class="flex cursor-pointer flex-col items-center gap-1 bg-transparent text-white"
+        aria-label="Open comments"
+        :aria-expanded="commentsOpen"
+        @click="openComments"
+      >
+        <span
+          class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-black/45 backdrop-blur-md"
+        >
+          <IconMessageCircle :size="18" />
+        </span>
+      </button>
+    </div>
+
+    <!-- Comments bottom sheet — teleported to body so it sits above the sticky
+         nav and any other in-flow z-stacks. Backdrop dismisses; Esc handled
+         here too so keyboard users can close without grabbing the X button.
+         The video keeps playing behind the sheet; users can mute via the
+         right-rail button if they want quiet reading. -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition-opacity duration-150"
+        leave-active-class="transition-opacity duration-150"
+        enter-from-class="opacity-0"
+        leave-to-class="opacity-0"
+      >
+        <div
+          v-if="commentsOpen"
+          class="fixed inset-0 z-50 bg-black/55"
+          @click.self="closeComments"
+          @keydown.esc="closeComments"
+        >
+          <Transition
+            enter-active-class="transition-transform duration-200 ease-out"
+            leave-active-class="transition-transform duration-150 ease-in"
+            enter-from-class="translate-y-full"
+            leave-to-class="translate-y-full"
+            appear
+          >
+            <div
+              v-if="commentsOpen"
+              class="absolute inset-x-0 bottom-0 flex max-h-[75vh] flex-col rounded-t-xl border-t border-border bg-surface-raised shadow-[0_-12px_36px_rgba(0,0,0,0.5)]"
+              role="dialog"
+              aria-label="Comments"
+              @click.stop
+            >
+              <div
+                class="mx-auto mt-2 h-1.5 w-10 shrink-0 rounded-full bg-border-strong"
+                aria-hidden="true"
+              ></div>
+              <div class="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
+                <h2
+                  class="m-0 font-heading text-base font-bold uppercase tracking-[0.04em] text-text-primary"
+                >
+                  Comments
+                </h2>
+                <div class="flex items-center gap-2">
+                  <RouterLink
+                    :to="detailHref"
+                    class="font-mono text-[10px] uppercase tracking-[0.08em] text-text-secondary no-underline transition-colors hover:text-text-primary"
+                  >
+                    View full clip →
+                  </RouterLink>
+                  <button
+                    type="button"
+                    class="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-border bg-surface-overlay text-text-secondary transition-colors hover:text-text-primary"
+                    aria-label="Close comments"
+                    @click="closeComments"
+                  >
+                    <IconX :size="14" />
+                  </button>
+                </div>
+              </div>
+              <div class="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+                <CommentsSection :clip-id="clip.id" />
+              </div>
+            </div>
+          </Transition>
+        </div>
+      </Transition>
+    </Teleport>
+  </article>
+</template>

--- a/web/src/components/reels/ReelClip.vue
+++ b/web/src/components/reels/ReelClip.vue
@@ -426,7 +426,7 @@ function closeComments() {
           v-if="commentsOpen"
           class="fixed inset-0 z-50 bg-black/55"
           @click.self="closeComments"
-          @keydown.esc="closeComments"
+          @keydown.esc.window="closeComments"
         >
           <Transition
             enter-active-class="transition-transform duration-200 ease-out"

--- a/web/src/components/reels/ReelClip.vue
+++ b/web/src/components/reels/ReelClip.vue
@@ -37,7 +37,23 @@ const videoEl = useTemplateRef<HTMLVideoElement>('videoEl')
 const needsTapToPlay = ref(false)
 const spinnerVisible = ref(false)
 const commentsOpen = ref(false)
+const codecUnsupported = ref(false)
 let spinnerTimer: ReturnType<typeof setTimeout> | null = null
+
+// AV1 capability probe — same MIME string ClipView uses. ClipView falls back to a
+// just-in-time HLS stream; for reels we send the user to the detail page (which
+// already orchestrates the JIT polling + hls.js attach). Keeping reels lean —
+// no hls.js pulled into this slot, and one URL/codec decision per detail load.
+const AV1_MIME = 'video/mp4; codecs="av01.0.05M.08"'
+
+function canPlayCodec(codec: string | null, el: HTMLVideoElement | null): boolean {
+  if (!el) return true
+  if (!codec || codec === 'h264') return true
+  if (codec === 'av1') return el.canPlayType(AV1_MIME) !== ''
+  // Unknown codec — optimistically attempt direct playback rather than forcing
+  // the user to bounce to the detail page on a maybe-playable file.
+  return true
+}
 
 // Like state is local for snappy optimistic UI. Parent gets notified via emit so
 // its `items[]` cache reflects the latest count if the user opens the detail page.
@@ -104,6 +120,16 @@ watch(
   [() => props.isActive, () => props.detail, videoEl],
   ([active, detail, el]) => {
     if (!detail || !el) return
+    codecUnsupported.value = !canPlayCodec(detail.videoCodec, el)
+    if (codecUnsupported.value) {
+      // Bail before play() — calling it on a clip the browser can't decode
+      // just produces a silent black slot. The template renders an "Open in
+      // detail" affordance so the user can fall through to the JIT-capable
+      // player.
+      el.pause()
+      detachViewTracking()
+      return
+    }
     if (active) {
       el.muted = props.globalMuted
       el.currentTime = 0
@@ -279,6 +305,24 @@ function closeComments() {
       >
         Retry
       </button>
+    </div>
+
+    <!-- Codec the browser can't decode directly (e.g. AV1 on Safari). The detail
+         page handles the just-in-time HLS fallback; reels just delegates rather
+         than pulling hls.js + JIT polling into every slot. -->
+    <div
+      v-else-if="detail && codecUnsupported"
+      class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/50 px-6 text-center"
+    >
+      <p class="font-mono text-xs uppercase tracking-widest text-text-secondary">
+        This format needs the full player
+      </p>
+      <RouterLink
+        :to="detailHref"
+        class="rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary no-underline"
+      >
+        Open in detail →
+      </RouterLink>
     </div>
 
     <!-- Tap-to-play fallback (autoplay rejection). -->

--- a/web/src/components/reels/ReelsFab.vue
+++ b/web/src/components/reels/ReelsFab.vue
@@ -7,7 +7,7 @@ import IconReels from '@/components/icons/IconReels.vue'
     :to="{ name: 'reels' }"
     aria-label="Open reels feed"
     title="Reels"
-    class="fixed right-6 z-40 inline-flex h-14 w-14 items-center justify-center rounded-full bg-brand text-white no-underline shadow-[0_8px_24px_var(--color-brand-glow)] transition-colors duration-150 hover:bg-brand-light"
+    class="fixed right-6 z-50 inline-flex h-14 w-14 items-center justify-center rounded-full bg-brand text-white no-underline shadow-[0_8px_24px_var(--color-brand-glow)] transition-colors duration-150 hover:bg-brand-light"
     style="bottom: calc(env(safe-area-inset-bottom, 0px) + 24px)"
   >
     <IconReels :size="22" :stroke-width="2.2" />

--- a/web/src/components/reels/ReelsFab.vue
+++ b/web/src/components/reels/ReelsFab.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import IconReels from '@/components/icons/IconReels.vue'
+</script>
+
+<template>
+  <RouterLink
+    :to="{ name: 'reels' }"
+    aria-label="Open reels feed"
+    title="Reels"
+    class="fixed right-6 z-40 inline-flex h-14 w-14 items-center justify-center rounded-full bg-brand text-white no-underline shadow-[0_8px_24px_var(--color-brand-glow)] transition-colors duration-150 hover:bg-brand-light"
+    style="bottom: calc(env(safe-area-inset-bottom, 0px) + 24px)"
+  >
+    <IconReels :size="22" :stroke-width="2.2" />
+  </RouterLink>
+</template>

--- a/web/src/components/reels/__tests__/ReelClip.spec.ts
+++ b/web/src/components/reels/__tests__/ReelClip.spec.ts
@@ -62,6 +62,7 @@ function makeDetail(overrides: Partial<ClipDetail> = {}): ClipDetail {
     ...makeClip(),
     videoUrl: 'https://cdn.test/video.mp4',
     videoUrlExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    videoCodec: null,
     width: 1920,
     height: 1080,
     visibility: 'public',

--- a/web/src/components/reels/__tests__/ReelClip.spec.ts
+++ b/web/src/components/reels/__tests__/ReelClip.spec.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import type { ClipDetail, ClipFeedItem } from '@/api/clips'
+import ReelClip from '../ReelClip.vue'
+
+const like = vi.fn()
+const unlike = vi.fn()
+const recordView = vi.fn()
+vi.mock('@/api/clips', async () => {
+  const actual = await vi.importActual<typeof import('@/api/clips')>('@/api/clips')
+  return {
+    ...actual,
+    clips: {
+      ...actual.clips,
+      like: (id: string) => like(id),
+      unlike: (id: string) => unlike(id),
+      recordView: (id: string) => recordView(id),
+    },
+  }
+})
+
+function makeRouter(): Router {
+  const stub = defineComponent({ render: () => h('div') })
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: stub },
+      { path: '/login', name: 'login', component: stub },
+      { path: '/clip/:id', name: 'clip', component: stub },
+      { path: '/user/:username', name: 'user', component: stub },
+      { path: '/feed/reels', name: 'reels', component: stub },
+      { path: '/feed/reels/:id', name: 'reel-clip', component: stub },
+    ],
+  })
+}
+
+function makeClip(overrides: Partial<ClipFeedItem> = {}): ClipFeedItem {
+  return {
+    id: 'clp_01',
+    title: 'No-scope wallbang',
+    description: null,
+    thumbnailUrl: 'https://cdn.test/thumb.jpg',
+    durationSecs: 12,
+    viewCount: 42,
+    likeCount: 7,
+    createdAt: new Date().toISOString(),
+    author: { id: 'u1', username: 'reelsuser', avatarUrl: null },
+    game: { id: 1, name: 'Valorant', slug: 'valorant', tag: 'VALORANT' },
+    tags: [],
+    likedByMe: false,
+    shareCode: 'sc01',
+    ...overrides,
+  }
+}
+
+function makeDetail(overrides: Partial<ClipDetail> = {}): ClipDetail {
+  return {
+    ...makeClip(),
+    videoUrl: 'https://cdn.test/video.mp4',
+    videoUrlExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    width: 1920,
+    height: 1080,
+    visibility: 'public',
+    ...overrides,
+  }
+}
+
+// Track mounted wrappers so afterEach can unmount them — this is what
+// actually removes teleported nodes cleanly. Just nuking document.body races
+// with Vue's pending microtasks and crashes the next render.
+const mountedWrappers: VueWrapper[] = []
+
+async function mountReel(props: {
+  clip?: ClipFeedItem
+  detail?: ClipDetail | null
+  detailErrored?: boolean
+  isActive?: boolean
+  globalMuted?: boolean
+}) {
+  const router = makeRouter()
+  await router.push('/feed/reels/clp_01')
+  await router.isReady()
+  // One pinia for both the test (setActivePinia, so useAuthStore() in the test
+  // body talks to the same store) and the mount (plugins). Without sharing
+  // the instance, auth.setUser in the test body mutates a different pinia
+  // than the component reads from.
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const wrapper = mount(ReelClip, {
+    props: {
+      clip: props.clip ?? makeClip(),
+      detail: props.detail ?? null,
+      detailErrored: props.detailErrored ?? false,
+      isActive: props.isActive ?? false,
+      globalMuted: props.globalMuted ?? true,
+    },
+    global: {
+      plugins: [router, pinia],
+    },
+  })
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+beforeEach(() => {
+  like.mockReset()
+  unlike.mockReset()
+  recordView.mockReset()
+  // jsdom's HTMLMediaElement.play/pause are unimplemented stubs that log
+  // "Not implemented" to stderr. The component defensively wraps the return
+  // in Promise.resolve, so the code path works — silencing the noise here.
+  HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve())
+  HTMLMediaElement.prototype.pause = vi.fn()
+})
+
+afterEach(() => {
+  // The comments bottom sheet is <Teleport to="body">, so its DOM persists
+  // across tests if we don't clean it up. Without this, "is the sheet open?"
+  // assertions in later tests false-positive on stale nodes from earlier
+  // tests in the file.
+  while (mountedWrappers.length) mountedWrappers.pop()!.unmount()
+})
+
+describe('ReelClip — render gates', () => {
+  it('shows the thumbnail and no <video> when detail is null', async () => {
+    const wrapper = await mountReel({ detail: null })
+    expect(wrapper.find('img').attributes('src')).toBe('https://cdn.test/thumb.jpg')
+    expect(wrapper.find('video').exists()).toBe(false)
+  })
+
+  it('mounts the <video> with the detail.videoUrl once detail arrives', async () => {
+    const wrapper = await mountReel({ detail: makeDetail() })
+    const video = wrapper.find('video')
+    expect(video.exists()).toBe(true)
+    expect(video.attributes('src')).toBe('https://cdn.test/video.mp4')
+    expect(video.attributes('poster')).toBe('https://cdn.test/thumb.jpg')
+  })
+
+  it('shows a retry overlay when detail loading failed', async () => {
+    const wrapper = await mountReel({ detail: null, detailErrored: true })
+    expect(wrapper.text()).toContain("Couldn't load video")
+    const retry = wrapper.findAll('button').find((b) => b.text() === 'Retry')
+    expect(retry).toBeDefined()
+    await retry!.trigger('click')
+    expect(wrapper.emitted('retry-detail')).toBeTruthy()
+    expect(wrapper.emitted('retry-detail')![0]).toEqual(['clp_01'])
+  })
+})
+
+describe('ReelClip — like flow', () => {
+  it('optimistically flips like state and emits liked-changed on success', async () => {
+    like.mockResolvedValue({ liked: true, likeCount: 8 })
+    const wrapper = await mountReel({ detail: makeDetail() })
+    const auth = useAuthStore()
+    auth.setUser({
+      id: 'u1',
+      username: 'me',
+      email: null,
+      bio: null,
+      avatarUrl: null,
+      createdAt: '',
+      hasPassword: true,
+    })
+
+    const likeBtn = wrapper.find('button[aria-label="Like"]')
+    expect(likeBtn.exists()).toBe(true)
+    await likeBtn.trigger('click')
+    // Optimistic flip BEFORE the await resolves.
+    expect(wrapper.find('button[aria-label="Unlike"]').exists()).toBe(true)
+    await flushPromises()
+    expect(like).toHaveBeenCalledWith('clp_01')
+    const events = wrapper.emitted('liked-changed')!
+    expect(events[events.length - 1]).toEqual([{ id: 'clp_01', liked: true, count: 8 }])
+  })
+
+  it('rolls back the optimistic flip when the API call fails', async () => {
+    like.mockRejectedValue(new Error('boom'))
+    const wrapper = await mountReel({ detail: makeDetail() })
+    const auth = useAuthStore()
+    auth.setUser({
+      id: 'u1',
+      username: 'me',
+      email: null,
+      bio: null,
+      avatarUrl: null,
+      createdAt: '',
+      hasPassword: true,
+    })
+
+    await wrapper.find('button[aria-label="Like"]').trigger('click')
+    await flushPromises()
+    // Rolled back to the original (un-liked) state, no liked-changed emit.
+    // The optimistic flip happens synchronously inside the handler, but
+    // microtasks (including the rejected promise's catch) all flush before
+    // the await trigger returns — so we only assert the final state.
+    expect(wrapper.find('button[aria-label="Like"]').exists()).toBe(true)
+    expect(wrapper.emitted('liked-changed')).toBeFalsy()
+  })
+
+  it('redirects anonymous users to /login with the reels-route as redirect query', async () => {
+    const wrapper = await mountReel({ detail: makeDetail() })
+    // No auth.setUser — auth.isAuthenticated is false.
+    await wrapper.find('button[aria-label="Like"]').trigger('click')
+    await flushPromises()
+    expect(like).not.toHaveBeenCalled()
+    // Router push lands on /login with redirect=/feed/reels/clp_01.
+    const router = wrapper.vm.$router
+    expect(router.currentRoute.value.name).toBe('login')
+    expect(router.currentRoute.value.query.redirect).toBe('/feed/reels/clp_01')
+  })
+})
+
+describe('ReelClip — mute toggle', () => {
+  it('emits toggle-mute when the mute button is clicked', async () => {
+    const wrapper = await mountReel({ detail: makeDetail(), globalMuted: true })
+    await wrapper.find('button[aria-label="Unmute"]').trigger('click')
+    expect(wrapper.emitted('toggle-mute')).toBeTruthy()
+  })
+
+  it('renders the unmute icon while muted and the mute icon while unmuted', async () => {
+    const muted = await mountReel({ detail: makeDetail(), globalMuted: true })
+    expect(muted.find('button[aria-label="Unmute"]').exists()).toBe(true)
+    expect(muted.find('button[aria-label="Mute"]').exists()).toBe(false)
+
+    const unmuted = await mountReel({ detail: makeDetail(), globalMuted: false })
+    expect(unmuted.find('button[aria-label="Mute"]').exists()).toBe(true)
+    expect(unmuted.find('button[aria-label="Unmute"]').exists()).toBe(false)
+  })
+})
+
+describe('ReelClip — links', () => {
+  it('links the author handle to /user/:username', async () => {
+    const wrapper = await mountReel({ detail: makeDetail() })
+    const userLink = wrapper.findAll('a').find((a) => a.attributes('href') === '/user/reelsuser')
+    expect(userLink).toBeDefined()
+  })
+
+  it('does not render the open-in-detail link until the comments sheet is opened', async () => {
+    const wrapper = await mountReel({ detail: makeDetail() })
+    // The 'View full clip →' link lives inside the bottom-sheet header,
+    // teleported to body. It only exists once the sheet is mounted.
+    expect(
+      wrapper.findAll('a').find((a) => a.attributes('href') === '/clip/clp_01'),
+    ).toBeUndefined()
+  })
+})
+
+describe('ReelClip — comments sheet', () => {
+  it('opens the comments bottom sheet when the comments button is clicked', async () => {
+    const wrapper = await mountReel({ detail: makeDetail(), isActive: true })
+    expect(document.querySelector('[role="dialog"][aria-label="Comments"]')).toBeNull()
+    await wrapper.find('button[aria-label="Open comments"]').trigger('click')
+    await flushPromises()
+    expect(document.querySelector('[role="dialog"][aria-label="Comments"]')).not.toBeNull()
+  })
+
+  it('surfaces the View-full-clip link inside the open sheet', async () => {
+    const wrapper = await mountReel({ detail: makeDetail(), isActive: true })
+    await wrapper.find('button[aria-label="Open comments"]').trigger('click')
+    await flushPromises()
+    const link = document.querySelector('a[href="/clip/clp_01"]')
+    expect(link).not.toBeNull()
+    expect(link?.textContent).toContain('View full clip')
+  })
+
+  it('closes the sheet when the active prop flips false (e.g. user scrolls to the next reel)', async () => {
+    const wrapper = await mountReel({ detail: makeDetail(), isActive: true })
+    await wrapper.find('button[aria-label="Open comments"]').trigger('click')
+    await flushPromises()
+    expect(document.querySelector('[role="dialog"][aria-label="Comments"]')).not.toBeNull()
+    await wrapper.setProps({ isActive: false })
+    await flushPromises()
+    // Vue's <Transition> waits for transitionend before unmounting; jsdom
+    // never fires that event, so we have to manually trigger it on the
+    // leaving element. Fire on every direct child of body just before the
+    // assertion — covers both the backdrop and the sheet wrappers.
+    document
+      .querySelectorAll('[role="dialog"][aria-label="Comments"], .fixed.inset-0')
+      .forEach((el) => el.dispatchEvent(new Event('transitionend')))
+    await flushPromises()
+    expect(document.querySelector('[role="dialog"][aria-label="Comments"]')).toBeNull()
+  })
+
+  it('closes the sheet when the close button is clicked', async () => {
+    const wrapper = await mountReel({ detail: makeDetail(), isActive: true })
+    await wrapper.find('button[aria-label="Open comments"]').trigger('click')
+    await flushPromises()
+    const closeBtn = document.querySelector(
+      'button[aria-label="Close comments"]',
+    ) as HTMLElement | null
+    expect(closeBtn).not.toBeNull()
+    closeBtn?.click()
+    await flushPromises()
+    // Vue's <Transition> waits for transitionend before unmounting; jsdom
+    // never fires that event, so we have to manually trigger it on the
+    // leaving element. Fire on every direct child of body just before the
+    // assertion — covers both the backdrop and the sheet wrappers.
+    document
+      .querySelectorAll('[role="dialog"][aria-label="Comments"], .fixed.inset-0')
+      .forEach((el) => el.dispatchEvent(new Event('transitionend')))
+    await flushPromises()
+    expect(document.querySelector('[role="dialog"][aria-label="Comments"]')).toBeNull()
+  })
+})

--- a/web/src/components/reels/__tests__/ReelsFab.spec.ts
+++ b/web/src/components/reels/__tests__/ReelsFab.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { defineComponent, h } from 'vue'
+import ReelsFab from '../ReelsFab.vue'
+
+function makeRouter() {
+  const stub = defineComponent({ render: () => h('div') })
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: stub },
+      { path: '/feed/reels', name: 'reels', component: stub },
+    ],
+  })
+}
+
+describe('ReelsFab', () => {
+  it('renders a router-link to the reels feed with an accessible label', () => {
+    const wrapper = mount(ReelsFab, { global: { plugins: [makeRouter()] } })
+    const link = wrapper.find('a')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBe('/feed/reels')
+    expect(link.attributes('aria-label')).toBe('Open reels feed')
+  })
+})

--- a/web/src/router/__tests__/index.spec.ts
+++ b/web/src/router/__tests__/index.spec.ts
@@ -15,6 +15,7 @@ vi.mock('@/views/HomeView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/LoginView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/UploadView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/ClipView.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/ReelsView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/UserView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/AuthCallbackView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/NotFoundView.vue', () => ({ default: { template: '<div />' } }))
@@ -86,5 +87,19 @@ describe('share-code route', () => {
     await router.push('/c/abc123')
     expect(router.currentRoute.value.name).toBe('clip-share')
     expect(router.currentRoute.value.params.code).toBe('abc123')
+  })
+})
+
+describe('reels routes', () => {
+  it('resolves /feed/reels to the bare reels route with no id param', async () => {
+    await router.push('/feed/reels')
+    expect(router.currentRoute.value.name).toBe('reels')
+    expect(router.currentRoute.value.params.id).toBeUndefined()
+  })
+
+  it('resolves /feed/reels/:id to the reel-clip route and exposes the id param', async () => {
+    await router.push('/feed/reels/clp_42')
+    expect(router.currentRoute.value.name).toBe('reel-clip')
+    expect(router.currentRoute.value.params.id).toBe('clp_42')
   })
 })

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -62,6 +62,16 @@ const router = createRouter({
       component: () => import('@/views/ClipView.vue'),
     },
     {
+      path: '/feed/reels',
+      name: 'reels',
+      component: () => import('@/views/ReelsView.vue'),
+    },
+    {
+      path: '/feed/reels/:id',
+      name: 'reel-clip',
+      component: () => import('@/views/ReelsView.vue'),
+    },
+    {
       path: '/c/:code',
       name: 'clip-share',
       component: () => import('@/views/ClipView.vue'),

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -14,6 +14,7 @@ import StatusPanel from '@/components/StatusPanel.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import UnderlineTabs from '@/components/UnderlineTabs.vue'
 import LoadMoreButton from '@/components/LoadMoreButton.vue'
+import ReelsFab from '@/components/reels/ReelsFab.vue'
 import IconPlay from '@/components/icons/IconPlay.vue'
 
 const router = useRouter()
@@ -326,5 +327,7 @@ onMounted(loadMore)
         @load="loadMore"
       />
     </template>
+
+    <ReelsFab />
   </main>
 </template>

--- a/web/src/views/ReelsView.vue
+++ b/web/src/views/ReelsView.vue
@@ -1,0 +1,407 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, useTemplateRef, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ApiError } from '@/api/client'
+import { clips, type ClipDetail, type ClipFeedItem } from '@/api/clips'
+import StatusPanel from '@/components/StatusPanel.vue'
+import ReelClip from '@/components/reels/ReelClip.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+// --- State --------------------------------------------------------------------
+
+const items = ref<ClipFeedItem[]>([])
+const itemIds = reactive(new Set<string>())
+const cursor = ref<string | null>(null)
+const loading = ref(false)
+const errored = ref(false)
+const paginationErrored = ref(false)
+const noMore = ref(false)
+
+const details = reactive(new Map<string, ClipDetail>())
+const detailErrors = reactive(new Set<string>())
+const detailsInflight = new Set<string>()
+
+const activeIndex = ref(0)
+const globalMuted = ref(true)
+
+// Race guard for paginated loads — late responses from an abandoned page can't
+// stomp current state. Same pattern as ClipView.loadClip.
+let latestLoadId = 0
+
+const seedId = computed(() => {
+  const id = route.params.id
+  return Array.isArray(id) ? id[0] : (id as string | undefined)
+})
+
+// --- Helpers ------------------------------------------------------------------
+
+// Project a ClipDetail (richer shape, includes videoUrl) into the ClipFeedItem
+// shape used in items[]. Every field we render from items[] is a strict subset
+// of detail — we drop videoUrl/width/height/visibility/videoUrlExpiresAt since
+// the feed-item shape doesn't carry them.
+function projectFeedItem(detail: ClipDetail): ClipFeedItem {
+  return {
+    id: detail.id,
+    title: detail.title,
+    description: detail.description,
+    thumbnailUrl: detail.thumbnailUrl,
+    durationSecs: detail.durationSecs,
+    viewCount: detail.viewCount,
+    likeCount: detail.likeCount,
+    createdAt: detail.createdAt,
+    author: detail.author,
+    game: detail.game,
+    tags: detail.tags,
+    likedByMe: detail.likedByMe,
+    shareCode: detail.shareCode,
+  }
+}
+
+function appendItems(newItems: ClipFeedItem[]) {
+  for (const c of newItems) {
+    if (itemIds.has(c.id)) continue
+    items.value.push(c)
+    itemIds.add(c.id)
+  }
+}
+
+// --- Initial load -------------------------------------------------------------
+
+async function loadFirstPage() {
+  loading.value = true
+  errored.value = false
+  paginationErrored.value = false
+  const seed = seedId.value
+  try {
+    if (seed) {
+      // Race detail + first page in parallel. If detail 404s, fall through to
+      // the page-only behavior with a quiet console note (no toast for v1 —
+      // the user's intent was to land on a clip that no longer exists; just
+      // start from the top).
+      const [seedDetail, page] = await Promise.allSettled([
+        clips.getDetail(seed),
+        clips.feed({ limit: 20 }),
+      ])
+
+      if (page.status === 'rejected') {
+        throw page.reason
+      }
+
+      if (seedDetail.status === 'fulfilled') {
+        const head = projectFeedItem(seedDetail.value)
+        details.set(head.id, seedDetail.value)
+        appendItems([head])
+        appendItems(page.value.items)
+      } else {
+        // Seed 404 (or other failure) — start from the regular top of feed.
+        const isMissing = seedDetail.reason instanceof ApiError && seedDetail.reason.status === 404
+        if (!isMissing) console.error('reels: seed detail load failed', seedDetail.reason)
+        appendItems(page.value.items)
+        // Strip the bogus id from the URL so a subsequent reload doesn't keep
+        // trying it. Use replace with the bare-route name and no params.
+        selfNavigating = true
+        await router.replace({ name: 'reels' })
+        selfNavigating = false
+      }
+
+      cursor.value = page.value.nextCursor
+      noMore.value = page.value.nextCursor === null
+      activeIndex.value = 0
+    } else {
+      const page = await clips.feed({ limit: 20 })
+      appendItems(page.items)
+      cursor.value = page.nextCursor
+      noMore.value = page.nextCursor === null
+      activeIndex.value = 0
+    }
+  } catch (err) {
+    console.error('reels: initial load failed', err)
+    errored.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadMore() {
+  if (loading.value || noMore.value) return
+  const myLoadId = ++latestLoadId
+  loading.value = true
+  paginationErrored.value = false
+  try {
+    const page = await clips.feed({ cursor: cursor.value, limit: 20 })
+    if (myLoadId !== latestLoadId) return
+    appendItems(page.items)
+    cursor.value = page.nextCursor
+    if (page.nextCursor === null) noMore.value = true
+  } catch (err) {
+    if (myLoadId !== latestLoadId) return
+    console.error('reels: pagination failed', err)
+    paginationErrored.value = true
+  } finally {
+    if (myLoadId === latestLoadId) loading.value = false
+  }
+}
+
+// --- Detail prefetch (±1 window around activeIndex) ---------------------------
+
+function prefetchDetailFor(id: string | undefined) {
+  if (!id) return
+  if (details.has(id) || detailsInflight.has(id) || detailErrors.has(id)) return
+  detailsInflight.add(id)
+  clips
+    .getDetail(id)
+    .then((d) => {
+      details.set(id, d)
+    })
+    .catch((err) => {
+      console.error('reels: detail prefetch failed', { id, err })
+      detailErrors.add(id)
+    })
+    .finally(() => {
+      detailsInflight.delete(id)
+    })
+}
+
+function refreshPrefetchWindow() {
+  const i = activeIndex.value
+  const window = [items.value[i - 1]?.id, items.value[i]?.id, items.value[i + 1]?.id]
+  for (const id of window) prefetchDetailFor(id)
+}
+
+function retryDetail(id: string) {
+  detailErrors.delete(id)
+  prefetchDetailFor(id)
+}
+
+watch(activeIndex, () => {
+  refreshPrefetchWindow()
+  // Pagination trigger — fire when we're within 3 of the end of the loaded list.
+  if (
+    !loading.value &&
+    !noMore.value &&
+    items.value.length > 0 &&
+    activeIndex.value >= items.value.length - 3
+  ) {
+    loadMore()
+  }
+})
+
+// Once items first arrive, kick the prefetch for index 0.
+watch(
+  () => items.value.length,
+  (len, prev) => {
+    if (prev === 0 && len > 0) refreshPrefetchWindow()
+  },
+)
+
+// --- URL sync -----------------------------------------------------------------
+
+let selfNavigating = false
+
+// Watch the active clip's id (not the index) so the sync fires both when the
+// user scrolls AND when items[] first populates after the initial load — in
+// the bare-route case activeIndex stays 0 but items[0]?.id transitions from
+// undefined → 'first', which an index-only watcher would miss.
+watch(
+  () => items.value[activeIndex.value]?.id,
+  async (id) => {
+    if (!id) return
+    if (route.name === 'reel-clip' && route.params.id === id) return
+    selfNavigating = true
+    try {
+      await router.replace({ name: 'reel-clip', params: { id } })
+    } finally {
+      selfNavigating = false
+    }
+  },
+)
+
+// Re-react to user-initiated route changes (e.g., browser back/forward).
+// router.replace from our own URL-sync flips selfNavigating to suppress this.
+watch(
+  () => route.params.id,
+  (newId) => {
+    if (selfNavigating) return
+    if (!newId || Array.isArray(newId)) return
+    const idx = items.value.findIndex((c) => c.id === newId)
+    if (idx >= 0 && idx !== activeIndex.value) {
+      // Scroll the snap container to the target index; observer will follow.
+      scrollToIndex(idx)
+    }
+  },
+)
+
+// --- Observer + scroll container ----------------------------------------------
+
+const scrollEl = useTemplateRef<HTMLDivElement>('scrollEl')
+const clipEls = new Map<string, HTMLElement>()
+const elToId = new WeakMap<Element, string>()
+const ratios = new Map<string, number>()
+let observer: IntersectionObserver | null = null
+
+function registerClip(id: string, el: Element | null) {
+  // The callback ref signature gives us Element | null (unmount). Vue's
+  // template-ref ergonomics use `null` on teardown.
+  if (!el) {
+    const prev = clipEls.get(id)
+    if (prev) {
+      observer?.unobserve(prev)
+      elToId.delete(prev)
+    }
+    clipEls.delete(id)
+    ratios.delete(id)
+    return
+  }
+  const htmlEl = el as HTMLElement
+  clipEls.set(id, htmlEl)
+  elToId.set(htmlEl, id)
+  observer?.observe(htmlEl)
+}
+
+function handleIntersect(entries: IntersectionObserverEntry[]) {
+  for (const e of entries) {
+    const id = elToId.get(e.target)
+    if (!id) continue
+    ratios.set(id, e.intersectionRatio)
+  }
+  // Pick the most-visible slot. Hysteresis: only switch if the new candidate
+  // is clearly more visible (>= 0.6) AND differs from the current. Without
+  // the gate, the moment two slots both sit at ~0.5 during a snap, activeIndex
+  // would chatter and play/pause would thrash.
+  let bestId: string | null = null
+  let bestRatio = 0
+  for (const [id, r] of ratios) {
+    if (r > bestRatio) {
+      bestRatio = r
+      bestId = id
+    }
+  }
+  if (bestRatio < 0.6 || !bestId) return
+  const idx = items.value.findIndex((c) => c.id === bestId)
+  if (idx >= 0 && idx !== activeIndex.value) activeIndex.value = idx
+}
+
+function scrollToIndex(idx: number) {
+  const target = items.value[idx]
+  if (!target) return
+  const el = clipEls.get(target.id)
+  if (!el || !scrollEl.value) return
+  scrollEl.value.scrollTo({ top: el.offsetTop, behavior: 'smooth' })
+}
+
+onMounted(async () => {
+  await loadFirstPage()
+  // Initialize the observer after first paint so scrollEl is real.
+  if (!scrollEl.value) return
+  observer = new IntersectionObserver(handleIntersect, {
+    root: scrollEl.value,
+    threshold: [0, 0.5, 0.6, 0.75, 0.95],
+  })
+  // Observe any already-mounted children. Children mounted after observer
+  // initialization get observed via registerClip directly.
+  for (const el of clipEls.values()) observer.observe(el)
+})
+
+onBeforeUnmount(() => {
+  if (observer) {
+    observer.disconnect()
+    observer = null
+  }
+})
+
+// --- Interactions -------------------------------------------------------------
+
+function onToggleMute() {
+  globalMuted.value = !globalMuted.value
+}
+
+function onLikedChanged(payload: { id: string; liked: boolean; count: number }) {
+  const idx = items.value.findIndex((c) => c.id === payload.id)
+  if (idx < 0) return
+  // Replace the item with a new object so reactivity propagates to child props
+  // (mutating likedByMe in place would also work, but consistency wins).
+  items.value[idx] = {
+    ...items.value[idx],
+    likedByMe: payload.liked,
+    likeCount: payload.count,
+  }
+}
+</script>
+
+<template>
+  <div class="fixed inset-x-0 top-16 bottom-0 z-10 flex justify-center bg-surface-base">
+    <!-- Initial load -->
+    <StatusPanel
+      v-if="loading && items.length === 0 && !errored"
+      kind="loading"
+      message="Loading reels…"
+    />
+
+    <!-- Initial error -->
+    <StatusPanel v-else-if="errored" kind="error" message="Couldn't load reels.">
+      <button
+        type="button"
+        class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+        @click="loadFirstPage"
+      >
+        Retry
+      </button>
+    </StatusPanel>
+
+    <!-- Empty feed -->
+    <StatusPanel
+      v-else-if="!loading && items.length === 0"
+      kind="empty"
+      message="No clips yet — be the first."
+    >
+      <RouterLink
+        to="/upload"
+        class="rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+      >
+        Upload a clip
+      </RouterLink>
+    </StatusPanel>
+
+    <!-- Feed -->
+    <div
+      v-else
+      ref="scrollEl"
+      class="h-full w-full max-w-[min(420px,calc(100vh*9/16))] snap-y snap-mandatory overflow-y-scroll overscroll-contain scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      aria-label="Reels feed"
+    >
+      <div
+        v-for="clip in items"
+        :key="clip.id"
+        :ref="(el) => registerClip(clip.id, el as HTMLElement | null)"
+        class="h-full w-full snap-start snap-always"
+      >
+        <ReelClip
+          :clip="clip"
+          :detail="details.get(clip.id) ?? null"
+          :detail-errored="detailErrors.has(clip.id)"
+          :is-active="items[activeIndex]?.id === clip.id"
+          :global-muted="globalMuted"
+          @toggle-mute="onToggleMute"
+          @retry-detail="retryDetail"
+          @liked-changed="onLikedChanged"
+        />
+      </div>
+
+      <!-- Pagination retry pill, snap-aligned at the bottom. -->
+      <div
+        v-if="paginationErrored"
+        class="flex h-full w-full snap-start snap-always items-center justify-center"
+      >
+        <button
+          type="button"
+          class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
+          @click="loadMore"
+        >
+          Couldn't load more — retry
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/views/__tests__/ReelsView.spec.ts
+++ b/web/src/views/__tests__/ReelsView.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+import { createPinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import type { ClipDetail, ClipFeedItem, ClipFeedPage } from '@/api/clips'
+import { ApiError } from '@/api/client'
+
+const feed = vi.fn()
+const getDetail = vi.fn()
+const recordView = vi.fn()
+vi.mock('@/api/clips', async () => {
+  const actual = await vi.importActual<typeof import('@/api/clips')>('@/api/clips')
+  return {
+    ...actual,
+    clips: {
+      ...actual.clips,
+      feed: (q?: unknown) => feed(q),
+      getDetail: (id: string) => getDetail(id),
+      recordView: (id: string) => recordView(id),
+    },
+  }
+})
+
+import ReelsView from '../ReelsView.vue'
+
+// jsdom doesn't ship IntersectionObserver. The implementation never relies on
+// it firing during these tests (we drive activeIndex through direct route
+// navigation instead), but the constructor must exist so onMounted doesn't
+// throw before pagination/URL-sync logic runs.
+class FakeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+beforeEach(() => {
+  feed.mockReset()
+  getDetail.mockReset()
+  recordView.mockReset()
+  // Default-resolve getDetail so the prefetch watcher (which fires for the
+  // active clip and its neighbors whenever items[] is non-empty) never hits
+  // an undefined return. Tests that care about prefetch calls re-stub it.
+  getDetail.mockImplementation((id: string) => Promise.resolve(makeDetail(id)))
+  vi.stubGlobal('IntersectionObserver', FakeObserver)
+  // Silence jsdom's unimplemented-media-element warnings; same rationale as
+  // in the ReelClip spec.
+  HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve())
+  HTMLMediaElement.prototype.pause = vi.fn()
+})
+
+function makeRouter(): Router {
+  const stub = defineComponent({ render: () => h('div') })
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: stub },
+      { path: '/login', name: 'login', component: stub },
+      { path: '/clip/:id', name: 'clip', component: stub },
+      { path: '/user/:username', name: 'user', component: stub },
+      { path: '/upload', name: 'upload', component: stub },
+      { path: '/feed/reels', name: 'reels', component: ReelsView },
+      { path: '/feed/reels/:id', name: 'reel-clip', component: ReelsView },
+    ],
+  })
+}
+
+function makeClip(id: string, overrides: Partial<ClipFeedItem> = {}): ClipFeedItem {
+  return {
+    id,
+    title: `Clip ${id}`,
+    description: null,
+    thumbnailUrl: `https://cdn.test/${id}.jpg`,
+    durationSecs: 10,
+    viewCount: 0,
+    likeCount: 0,
+    createdAt: new Date().toISOString(),
+    author: { id: 'u1', username: 'creator', avatarUrl: null },
+    game: null,
+    tags: [],
+    likedByMe: false,
+    shareCode: id,
+    ...overrides,
+  }
+}
+
+function makeDetail(id: string, overrides: Partial<ClipDetail> = {}): ClipDetail {
+  return {
+    ...makeClip(id),
+    videoUrl: `https://cdn.test/${id}.mp4`,
+    videoUrlExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    width: 1920,
+    height: 1080,
+    visibility: 'public',
+    ...overrides,
+  }
+}
+
+function makePage(items: ClipFeedItem[], nextCursor: string | null = null): ClipFeedPage {
+  return { items, nextCursor }
+}
+
+async function mountAt(path: string) {
+  const router = makeRouter()
+  await router.push(path)
+  await router.isReady()
+  const wrapper = mount(ReelsView, { global: { plugins: [router, createPinia()] } })
+  return { wrapper, router }
+}
+
+describe('ReelsView — single-root invariant', () => {
+  // The route-level <Transition mode="out-in"> in App.vue can only animate a
+  // single-root component. A leading comment node before the root element
+  // makes the component multi-root — Transition's leave never resolves and
+  // the NEXT route's view never mounts, so navigating from /login to
+  // /feed/reels/:id (post-like-redirect) renders a blank page until refresh.
+  // Same regression UserView.spec.ts guards against (issue #92).
+  it('renders a single element root, not a leading-comment fragment', async () => {
+    feed.mockReturnValue(new Promise(() => {}))
+    const { wrapper } = await mountAt('/feed/reels')
+    expect(wrapper.html().trimStart().startsWith('<!--')).toBe(false)
+    expect(wrapper.html().trimStart().startsWith('<div')).toBe(true)
+  })
+})
+
+describe('ReelsView — initial load', () => {
+  it('loads the public feed when no seed id is provided', async () => {
+    feed.mockResolvedValue(makePage([makeClip('a'), makeClip('b')], 'cursor-1'))
+    const { wrapper } = await mountAt('/feed/reels')
+    await flushPromises()
+    expect(feed).toHaveBeenCalledWith({ limit: 20 })
+    expect(wrapper.text()).toContain('Clip a')
+    expect(wrapper.text()).toContain('Clip b')
+  })
+
+  it('shows an error state when initial load fails', async () => {
+    feed.mockRejectedValue(new Error('network down'))
+    const { wrapper } = await mountAt('/feed/reels')
+    await flushPromises()
+    expect(wrapper.text()).toContain("Couldn't load reels")
+  })
+
+  it('shows the empty state when the feed returns zero clips', async () => {
+    feed.mockResolvedValue(makePage([]))
+    const { wrapper } = await mountAt('/feed/reels')
+    await flushPromises()
+    expect(wrapper.text()).toContain('No clips yet')
+    expect(wrapper.find('a[href="/upload"]').exists()).toBe(true)
+  })
+})
+
+describe('ReelsView — deep link', () => {
+  it('dedupes the seed clip when it also appears in the first page', async () => {
+    const seed = makeDetail('seed')
+    getDetail.mockResolvedValue(seed)
+    feed.mockResolvedValue(makePage([makeClip('seed'), makeClip('b'), makeClip('c')]))
+    const { wrapper } = await mountAt('/feed/reels/seed')
+    await flushPromises()
+
+    // The seed appears exactly once (head), followed by the rest of the page.
+    const html = wrapper.html()
+    const firstIdx = html.indexOf('Clip seed')
+    const lastIdx = html.lastIndexOf('Clip seed')
+    expect(firstIdx).toBeGreaterThanOrEqual(0)
+    expect(firstIdx).toBe(lastIdx)
+    expect(wrapper.text()).toContain('Clip b')
+    expect(wrapper.text()).toContain('Clip c')
+  })
+
+  it('falls back to the top of the feed and rewrites the URL when the seed 404s', async () => {
+    getDetail.mockImplementation((id: string) => {
+      if (id === 'missing') return Promise.reject(new ApiError(404, null))
+      return Promise.resolve(makeDetail(id))
+    })
+    feed.mockResolvedValue(makePage([makeClip('a'), makeClip('b')]))
+    const { wrapper, router } = await mountAt('/feed/reels/missing')
+    await flushPromises()
+
+    // Items render from the feed page; missing seed not prepended.
+    expect(wrapper.text()).toContain('Clip a')
+    expect(wrapper.text()).not.toContain('Clip missing')
+    // URL stripped back to the bare /feed/reels route. (URL-sync may have
+    // since pushed it forward to /feed/reels/a once activeIndex settles, so
+    // accept either the bare route or the first-item URL.)
+    const name = router.currentRoute.value.name
+    expect(['reels', 'reel-clip']).toContain(name)
+    if (name === 'reel-clip') {
+      expect(router.currentRoute.value.params.id).toBe('a')
+    }
+  })
+
+  it('surfaces the initial error when the feed itself fails even if the seed succeeds', async () => {
+    getDetail.mockResolvedValue(makeDetail('seed'))
+    feed.mockRejectedValue(new Error('feed down'))
+    const { wrapper } = await mountAt('/feed/reels/seed')
+    await flushPromises()
+    expect(wrapper.text()).toContain("Couldn't load reels")
+  })
+})
+
+describe('ReelsView — URL sync', () => {
+  it('replaces the URL with the seed clip id once the deep-link load resolves', async () => {
+    getDetail.mockResolvedValue(makeDetail('seed'))
+    feed.mockResolvedValue(makePage([makeClip('b')]))
+    const { router } = await mountAt('/feed/reels/seed')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('reel-clip')
+    expect(router.currentRoute.value.params.id).toBe('seed')
+  })
+
+  it('replaces the URL with the first clip id on a bare /feed/reels mount', async () => {
+    feed.mockResolvedValue(makePage([makeClip('first'), makeClip('second')]))
+    const { router } = await mountAt('/feed/reels')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('reel-clip')
+    expect(router.currentRoute.value.params.id).toBe('first')
+  })
+})
+
+describe('ReelsView — detail prefetch', () => {
+  it('fetches details for the active clip and its immediate neighbor on mount', async () => {
+    feed.mockResolvedValue(makePage([makeClip('a'), makeClip('b'), makeClip('c')]))
+    getDetail.mockImplementation((id: string) => Promise.resolve(makeDetail(id)))
+    await mountAt('/feed/reels')
+    await flushPromises()
+    // Index 0 is active → window = [undefined, 'a', 'b'] → fetch a + b.
+    expect(getDetail).toHaveBeenCalledWith('a')
+    expect(getDetail).toHaveBeenCalledWith('b')
+    expect(getDetail).not.toHaveBeenCalledWith('c')
+  })
+})

--- a/web/src/views/__tests__/ReelsView.spec.ts
+++ b/web/src/views/__tests__/ReelsView.spec.ts
@@ -88,6 +88,7 @@ function makeDetail(id: string, overrides: Partial<ClipDetail> = {}): ClipDetail
     ...makeClip(id),
     videoUrl: `https://cdn.test/${id}.mp4`,
     videoUrlExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    videoCodec: null,
     width: 1920,
     height: 1080,
     visibility: 'public',


### PR DESCRIPTION
## Summary

Phase 4 stretch item: a TikTok-style vertical-snap "reels" feed at `/feed/reels` as a second way to browse clips. Reuses the existing `clips.feed` cursor API — no server changes. Comments open inline in a bottom sheet, so users don't have to leave the feed to read or write.

## What's here

- **Routes:** `/feed/reels` and `/feed/reels/:id` → `ReelsView.vue`. URL bar tracks the active clip via `router.replace` (no history entries per snap).
- **`ReelsView`** owns the data layer: cursor pagination, deep-link dedup, a ±1 detail-prefetch window (feed items don't carry `videoUrl`, so each near-active clip lazy-fetches its detail), and a single `IntersectionObserver` with a 0.6 hysteresis gate so play/pause doesn't chatter at snap boundaries.
- **`ReelClip`** handles per-slot playback: native `<video muted playsinline>`, play/pause driven by `isActive`, and the same 3-second view-tracking accumulator `ClipView` uses (so view counts stay accurate across surfaces; server's 30-min dedup absorbs remounts).
- **Overlay right-rail:** like (optimistic, anon → login redirect), mute (global, persists across reels), author handle → `/user/:username`, and a comments button that opens a `<Teleport>`-ed bottom sheet wrapping the existing `CommentsSection.vue` (with a "View full clip" escape hatch to `/clip/:id`).
- **`ReelsFab`** — `position: fixed` brand-colored entry point on `HomeView`.
- **Letterboxed phone-frame** (`min(420px, 90vh * 9/16)`) so 16:9 gaming clips render cleanly on any width without cropping.
- **Design spec** committed under `docs/superpowers/specs/2026-05-24-reels-feed-design.md`.

Closes #108

## How to test manually

1. `make seed` if you haven't (creates the `seeduser@dev.local` / `testpass123!` account + sample clips).
2. Visit `/` — a circular brand-colored FAB sits at bottom-right of HomeView.
3. Click it → lands on `/feed/reels`, first clip autoplays muted, letterboxed in a portrait column.
4. Scroll/swipe down → snaps to the next clip; previous pauses, next plays. URL updates to `/feed/reels/<id>`.
5. Right-rail: **heart** (sign in if anon → bounces back, click again to like), **speaker** (tap to unmute, persists), **avatar** (→ `/user/:username`), **💬 comments** (opens bottom sheet with existing comments thread; "View full clip →" link inside).
6. Deep-link test: open `/feed/reels/<some-clip-id>` directly → lands on that clip immediately, scrolls continue normally.
7. Scroll past the loaded page → cursor pagination loads the next set silently.

## Checklist

- [x] Verified manually in browser (FAB, snap-scroll, autoplay/pause, like flow with login redirect, mute persistence, comments sheet, deep-link)
- [x] 215 unit tests passing, web coverage 94/95/94 (gate 85)
- [x] Single-root regression guard added (mirrors UserView's issue-#92 test) so `<Transition mode="out-in">` can't break this view again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added a full-screen vertical-swipe reels feed accessible via a new floating action button on the home page. Users can like, mute, view comments, and deep-link to individual reels.

* **Documentation**
  - Added design specification for the reels feed feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->