### PR TITLE
[server][web] import clips from Medal.tv / YouTube URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ The dev workflow runs `dotnet watch` on the host, which means the API process �
   - Override the binary location with `YTDLP_PATH` when not on `$PATH`.
 - **`bun`** for the web app.
 
-[server/Dockerfile.api](server/Dockerfile.api) ships an API image with ffmpeg pre-installed — it's there for production / CI parity builds, not used by the dev compose stack.
+[server/Dockerfile.api](server/Dockerfile.api) ships an API image with both **ffmpeg** and **yt-dlp** pre-installed (`YTDLP_PATH` overrides the binary location) — it's there for production / CI parity builds, not used by the dev compose stack.
 
 ### Media pipeline: compress-in-place + just-in-time playback (issue #102)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,11 @@ The dev workflow runs `dotnet watch` on the host, which means the API process �
   - Debian/Ubuntu: `sudo apt install ffmpeg`
   - macOS: `brew install ffmpeg`
   - Override the binary location with `FFMPEG_PATH` / `FFPROBE_PATH` env vars when not on `$PATH`.
+- **`yt-dlp`** — required for the URL-import worker (issue #106) that fetches Medal.tv / YouTube clips on behalf of `POST /clips/import`. Without it, imports stay in `status='importing'` and eventually land in `status='failed'`; you can also disable the feature with `MEDIA_IMPORT_ENABLED=false` (the endpoint then 503s).
+  - Arch/CachyOS: `sudo pacman -S yt-dlp`
+  - Debian/Ubuntu: `sudo apt install yt-dlp`
+  - macOS: `brew install yt-dlp`
+  - Override the binary location with `YTDLP_PATH` when not on `$PATH`.
 - **`bun`** for the web app.
 
 [server/Dockerfile.api](server/Dockerfile.api) ships an API image with ffmpeg pre-installed — it's there for production / CI parity builds, not used by the dev compose stack.

--- a/server/Dockerfile.api
+++ b/server/Dockerfile.api
@@ -15,8 +15,12 @@ COPY src/ src/
 RUN dotnet publish src/GankedTV.Api/GankedTV.Api.csproj -c Release -o /app/publish --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS runtime
+# yt-dlp is required by the URL-import worker (issue #106) on the same instance that runs
+# ImportWorker — i.e. the API host, not the GPU box (which leaves MEDIA_IMPORT_WORKER_ENABLED
+# off). It's a single-file Python script with no runtime deps beyond python3, so apt's
+# packaged version is the cheapest path to a reproducible build.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg \
+    && apt-get install -y --no-install-recommends ffmpeg yt-dlp \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 1001 gankedtv \
     && useradd --system --uid 1001 --gid gankedtv --home-dir /app --shell /usr/sbin/nologin gankedtv

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipDetailResponse.cs
@@ -28,4 +28,8 @@ public sealed record ClipDetailResponse(
     GameSummary? Game,
     IReadOnlyList<TagSummary> Tags,
     bool LikedByMe,
-    string Visibility);
+    string Visibility,
+    // Source URL when this clip was ingested via POST /clips/import (Medal.tv / YouTube).
+    // Null for direct uploads. The web detail view renders a "From {host}" attribution
+    // badge linking back to the original — credit + reduces friction over reuploads.
+    string? ImportSourceUrl);

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipMappings.cs
@@ -19,6 +19,12 @@ public static class ClipMappings
     public static CompleteClipResponse ToCompleteClipResponse(this CompleteClipResult result) =>
         new(result.ClipId, result.FileSizeBytes);
 
+    public static ImportClipResponse ToImportClipResponse(this ImportClipResult result) =>
+        new(result.ClipId, result.Status);
+
+    public static PreviewImportResponse ToPreviewResponse(this ImportClipPreviewResult result) =>
+        new(result.Title, result.DurationSecs, result.Width, result.Height, result.ThumbnailUrl, result.MaxClipDurationSecs);
+
     public static ClipFeedItem ToFeedItem(this Clip clip, string thumbnailUrl, bool likedByMe) =>
         new(
             clip.Id,
@@ -60,7 +66,8 @@ public static class ClipMappings
             clip.Game?.ToGameSummary(),
             clip.ToTagSummaries(),
             likedByMe,
-            clip.Visibility);
+            clip.Visibility,
+            clip.ImportSourceUrl);
 
     // Tag projection used by both ToFeedItem and ToDetail. Sorted by slug so cards
     // render deterministically regardless of clip_tags insertion order. Callers must

--- a/server/src/GankedTV.Api/Contracts/Clips/ClipStatusResponse.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ClipStatusResponse.cs
@@ -1,0 +1,14 @@
+namespace GankedTV.Api.Contracts.Clips;
+
+// Lightweight projection used by GET /clips/{id}/status — enough for the wizard to poll
+// for transitions (importing → processing → transcoding → ready/failed) and redirect via
+// share code once the clip is feed-visible. On failure, FailureReason carries one of the
+// ClipFailureReasons.* codes and the optional Duration / Limit fields let the web layer
+// render specific copy ("your clip is X seconds; limit is Y").
+public sealed record ClipStatusResponse(
+    Guid Id,
+    string Status,
+    string ShareCode,
+    string? FailureReason,
+    short? DurationSecs,
+    int? MaxClipDurationSecs);

--- a/server/src/GankedTV.Api/Contracts/Clips/ImportClipRequest.cs
+++ b/server/src/GankedTV.Api/Contracts/Clips/ImportClipRequest.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using GankedTV.Api.Validation;
+
+namespace GankedTV.Api.Contracts.Clips;
+
+// Wire shape for POST /clips/import. Url is required; Title/Description/GameId/Visibility/Tags
+// are optional — when omitted, sensible defaults apply (title = placeholder filled later by
+// the extractor, visibility = public, no game, no tags).
+public sealed record ImportClipRequest(
+    [property: Required]
+    [property: Url]
+    [property: StringLength(2048, MinimumLength = 1)]
+    string? Url,
+    [property: StringLength(ClipValidationLimits.MaxTitleLength)]
+    string? Title,
+    [property: StringLength(ClipValidationLimits.MaxDescriptionLength)]
+    string? Description,
+    int? GameId,
+    string? Visibility,
+    List<string>? Tags);
+
+public sealed record ImportClipResponse(Guid Id, string Status);
+
+// Wire shape for POST /clips/import/preview — same allow-list + URL validation as a full
+// submit, but no clip row is created. Returns title + duration so the wizard can gate
+// "Continue" before the user fills in step 2.
+public sealed record PreviewImportRequest(
+    [property: System.ComponentModel.DataAnnotations.Required]
+    [property: System.ComponentModel.DataAnnotations.Url]
+    [property: System.ComponentModel.DataAnnotations.StringLength(2048, MinimumLength = 1)]
+    string? Url);
+
+public sealed record PreviewImportResponse(
+    string? Title,
+    int? DurationSecs,
+    int? Width,
+    int? Height,
+    string? ThumbnailUrl,
+    int MaxClipDurationSecs);

--- a/server/src/GankedTV.Api/Data/Entities/Clip.cs
+++ b/server/src/GankedTV.Api/Data/Entities/Clip.cs
@@ -36,6 +36,16 @@ public class Clip
     public DateTimeOffset? ProcessingStartedAt { get; set; }
     public int ProcessingAttempts { get; set; }
 
+    // Set on rows ingested via POST /clips/import — preserves the original Medal.tv /
+    // YouTube URL the fetcher pulled from. Stays populated after the clip reaches 'ready'
+    // (cheap audit trail + lets us short-circuit a re-import of the same URL).
+    public string? ImportSourceUrl { get; set; }
+
+    // Machine-readable code set by the worker when status flips to 'failed'. Lets the web
+    // wizard surface a specific message ("clip too long") instead of a generic "failed".
+    // Null while in flight or once the clip lands 'ready'. Short codes — never raw stderr.
+    public string? FailureReason { get; set; }
+
     // Postgres-managed `tsvector` (GENERATED ALWAYS AS … STORED). Populated by the DB from
     // title (weight A) + description (weight B); never set by application code. Used by
     // SearchEndpoints for full-text matching/ranking against `plainto_tsquery('simple', q)`.

--- a/server/src/GankedTV.Api/Data/Entities/ClipStatuses.cs
+++ b/server/src/GankedTV.Api/Data/Entities/ClipStatuses.cs
@@ -1,8 +1,25 @@
 namespace GankedTV.Api.Data.Entities;
 
+// Short, machine-readable codes persisted in clips.failure_reason. The web wizard maps
+// these to human copy ("clip is too long…"). Adding a code is safe; never rename.
+public static class ClipFailureReasons
+{
+    public const string SourceTooLong = "source_too_long";
+    public const string SourceTooLarge = "source_too_large";
+    public const string SourceUnavailable = "source_unavailable";
+    public const string FetchFailed = "fetch_failed";
+    public const string TranscodeFailed = "transcode_failed";
+    public const string ThumbnailFailed = "thumbnail_failed";
+}
+
 public static class ClipStatuses
 {
     public const string Draft = "draft";
+    // URL-import stage: the row exists, but the server-side fetcher (yt-dlp) hasn't pulled
+    // the source bytes into the clips bucket yet. ImportWorker advances 'importing' →
+    // 'processing' after a successful fetch, mirroring how /clips/{id}/complete flips a
+    // drafted upload from 'draft' → 'processing'.
+    public const string Importing = "importing";
     public const string Processing = "processing";
     public const string Transcoding = "transcoding";
     public const string Ready = "ready";

--- a/server/src/GankedTV.Api/Data/Migrations/20260524140823_AddClipImportSource.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260524140823_AddClipImportSource.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524140823_AddClipImportSource")]
+    partial class AddClipImportSource
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -44,10 +47,6 @@ namespace GankedTV.Api.Data.Migrations
                     b.Property<short?>("DurationSecs")
                         .HasColumnType("smallint")
                         .HasColumnName("duration_secs");
-
-                    b.Property<string>("FailureReason")
-                        .HasColumnType("text")
-                        .HasColumnName("failure_reason");
 
                     b.Property<long?>("FileSizeBytes")
                         .HasColumnType("bigint")

--- a/server/src/GankedTV.Api/Data/Migrations/20260524140823_AddClipImportSource.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260524140823_AddClipImportSource.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClipImportSource : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "import_source_url",
+                table: "clips",
+                type: "text",
+                nullable: true);
+
+            // Sibling of idx_clips_processing_updated_at / idx_clips_transcoding_updated_at
+            // for the new ImportWorker's claim query (status = 'importing' ORDER BY updated_at).
+            // Raw SQL rather than the EF model: EF keys indexes by column set, so a third
+            // modeled index on { status, updated_at } would overwrite the 'processing' one.
+            migrationBuilder.Sql(
+                "CREATE INDEX idx_clips_importing_updated_at ON clips (status, updated_at) "
+                + "WHERE status = 'importing';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP INDEX IF EXISTS idx_clips_importing_updated_at;");
+
+            migrationBuilder.DropColumn(
+                name: "import_source_url",
+                table: "clips");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Data/Migrations/20260524151853_AddClipFailureReason.Designer.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260524151853_AddClipFailureReason.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GankedTV.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace GankedTV.Api.Data.Migrations
 {
     [DbContext(typeof(GankedTvDbContext))]
-    partial class GankedTvDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524151853_AddClipFailureReason")]
+    partial class AddClipFailureReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/GankedTV.Api/Data/Migrations/20260524151853_AddClipFailureReason.cs
+++ b/server/src/GankedTV.Api/Data/Migrations/20260524151853_AddClipFailureReason.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GankedTV.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClipFailureReason : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "failure_reason",
+                table: "clips",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "failure_reason",
+                table: "clips");
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsImportEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsImportEndpoints.cs
@@ -80,7 +80,10 @@ public static class ClipsImportEndpoints
         ClipUploadError.InvalidUrl => ProblemResults.BadRequest("invalid_url"),
         ClipUploadError.UnsupportedHost => ProblemResults.BadRequest("unsupported_host"),
         ClipUploadError.SourceUnavailable => ProblemResults.BadRequest("source_unavailable"),
-        ClipUploadError.FetchFailed => ProblemResults.BadRequest("fetch_failed"),
+        // 503, not 400: fetch_failed is "yt-dlp / network / extractor infra broke", which is
+        // a server-side problem the caller can retry — not a malformed request. Pairs with
+        // the same code surfaced by the worker on retry exhaustion.
+        ClipUploadError.FetchFailed => ProblemResults.ServiceUnavailable("fetch_failed"),
         ClipUploadError.ImportDisabled => ProblemResults.ServiceUnavailable("import_disabled"),
         ClipUploadError.InvalidTitle => ProblemResults.BadRequest("invalid_title"),
         ClipUploadError.InvalidDescription => ProblemResults.BadRequest("invalid_description"),

--- a/server/src/GankedTV.Api/Endpoints/ClipsImportEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsImportEndpoints.cs
@@ -1,0 +1,108 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Contracts.Clips;
+using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Services.Tags;
+using GankedTV.Api.Validation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace GankedTV.Api.Endpoints;
+
+// Sibling of ClipsUploadEndpoints. Single endpoint POST /clips/import that mirrors the
+// existing /clips create handler shape — same auth, same rate limiter, same error envelope.
+public static class ClipsImportEndpoints
+{
+    private static readonly string LogCategory = typeof(ClipsImportEndpoints).FullName!;
+
+    public static IEndpointRouteBuilder MapClipsImportEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/clips")
+            .RequireAuthorization()
+            .RequireRateLimiting(ClipsRateLimiting.ClipsWritePolicy);
+        group.MapPost("/import", ImportClip).WithValidation<ImportClipRequest>();
+        group.MapPost("/import/preview", PreviewImport).WithValidation<PreviewImportRequest>();
+        return app;
+    }
+
+    private static async Task<IResult> PreviewImport(
+        [FromBody] PreviewImportRequest? req,
+        ClaimsPrincipal principal,
+        IClipImportService imports,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out _))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+        if (req is null)
+        {
+            return ProblemResults.InvalidBody();
+        }
+
+        var result = await imports.PreviewAsync(req.Url, ct);
+        return result.IsSuccess
+            ? Results.Ok(result.Value!.ToPreviewResponse())
+            : MapError(result.Error!.Value, loggerFactory);
+    }
+
+    private static async Task<IResult> ImportClip(
+        [FromBody] ImportClipRequest? req,
+        ClaimsPrincipal principal,
+        IClipImportService imports,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+        if (req is null)
+        {
+            return ProblemResults.InvalidBody();
+        }
+
+        var result = await imports.SubmitAsync(
+            userId,
+            new ImportClipInput(req.Url, req.Title, req.Description, req.GameId, req.Visibility, req.Tags),
+            ct);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value!.ToImportClipResponse())
+            : MapError(result.Error!.Value, loggerFactory);
+    }
+
+    private static IResult MapError(ClipUploadError error, ILoggerFactory loggerFactory) => error switch
+    {
+        ClipUploadError.InvalidUrl => ProblemResults.BadRequest("invalid_url"),
+        ClipUploadError.UnsupportedHost => ProblemResults.BadRequest("unsupported_host"),
+        ClipUploadError.SourceUnavailable => ProblemResults.BadRequest("source_unavailable"),
+        ClipUploadError.FetchFailed => ProblemResults.BadRequest("fetch_failed"),
+        ClipUploadError.ImportDisabled => ProblemResults.ServiceUnavailable("import_disabled"),
+        ClipUploadError.InvalidTitle => ProblemResults.BadRequest("invalid_title"),
+        ClipUploadError.InvalidDescription => ProblemResults.BadRequest("invalid_description"),
+        ClipUploadError.InvalidVisibility => ProblemResults.BadRequest("invalid_visibility"),
+        ClipUploadError.InvalidGame => ProblemResults.BadRequest("invalid_game"),
+        ClipUploadError.TooManyTags => ProblemResults.BadRequest(TagsResolveProblemCodes.TooManyTags),
+        ClipUploadError.InvalidTag => ProblemResults.BadRequest(TagsResolveProblemCodes.InvalidTag),
+        _ => UnmappedError(error, loggerFactory),
+    };
+
+    private static IResult UnmappedError(ClipUploadError error, ILoggerFactory loggerFactory)
+    {
+        loggerFactory.CreateLogger(LogCategory)
+            .LogError("Unmapped ClipUploadError value {Error} in import endpoint; add a case to MapError.", error);
+        return ProblemResults.Internal("unmapped_error", $"Unhandled error: {error}");
+    }
+
+    private static bool TryGetUserId(ClaimsPrincipal principal, out Guid userId)
+    {
+        userId = default;
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out userId);
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -38,12 +38,41 @@ public static class ClipsReadEndpoints
         var group = app.MapGroup("/clips");
         group.MapGet("/feed", GetFeed);
         group.MapGet("/{id:guid}", GetDetail);
+        // Owner-scoped status probe. Lets the upload/import UI poll for status transitions
+        // (importing → processing → transcoding → ready/failed) without needing the full
+        // detail payload, which only exists once status='ready'.
+        group.MapGet("/{id:guid}/status", GetStatus).RequireAuthorization();
         // Anonymous like GetDetail, but each call does a DB lookup + S3 HEAD (+ enqueue on
         // miss), so it rides the same per-IP view rate limit to bound abuse.
         group.MapGet("/{id:guid}/stream", GetStream)
             .RequireRateLimiting(ClipsRateLimiting.ClipsViewPolicy);
         app.MapGet("/c/{code:length(6,12)}", GetByShareCode);
         return app;
+    }
+
+    // Returns the wizard's polling payload for the requesting user's own clip. Carries the
+    // clip's status, share code, and (when failed) the structured failure reason + the
+    // observed duration + the configured cap, so the front-end can show "your clip is X
+    // seconds; max is Y" instead of a generic error.
+    private static async Task<IResult> GetStatus(
+        Guid id,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        IOptions<GankedTV.Api.Validation.ClipValidationOptions> validationOptions,
+        CancellationToken ct)
+    {
+        if (!TryGetUserId(principal, out var userId))
+        {
+            return ProblemResults.Unauthorized("unauthorized");
+        }
+
+        var cap = validationOptions.Value.MaxClipDurationSecs;
+        var row = await db.Clips.AsNoTracking()
+            .Where(c => c.Id == id && c.UserId == userId)
+            .Select(c => new ClipStatusResponse(c.Id, c.Status, c.ShareCode, c.FailureReason, c.DurationSecs, cap))
+            .SingleOrDefaultAsync(ct);
+
+        return row is null ? ProblemResults.NotFound("not_found") : Results.Ok(row);
     }
 
     // Just-in-time H.264 stream for devices that can't decode a clip's stored master (e.g.

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -11,6 +11,7 @@ using GankedTV.Api.Pagination;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.Media;
+using GankedTV.Api.Validation;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -58,7 +59,7 @@ public static class ClipsReadEndpoints
         Guid id,
         ClaimsPrincipal principal,
         GankedTvDbContext db,
-        IOptions<GankedTV.Api.Validation.ClipValidationOptions> validationOptions,
+        IOptions<ClipValidationOptions> validationOptions,
         CancellationToken ct)
     {
         if (!TryGetUserId(principal, out var userId))

--- a/server/src/GankedTV.Api/Problems/ProblemResults.cs
+++ b/server/src/GankedTV.Api/Problems/ProblemResults.cs
@@ -33,6 +33,9 @@ public static class ProblemResults
     public static IResult Internal(string code, string? detail = null) =>
         Build(StatusCodes.Status500InternalServerError, code, detail);
 
+    public static IResult ServiceUnavailable(string code, string? detail = null) =>
+        Build(StatusCodes.Status503ServiceUnavailable, code, detail);
+
     /// <summary>
     /// Shared null-body response used by both <c>ValidationEndpointFilter&lt;T&gt;</c> and
     /// handler-side defensive guards, so clients see one shape regardless of which guard fires.

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -155,6 +155,24 @@ builder.Services.AddOptions<MediaJobOptions>()
         if (int.TryParse(segDur, out var sd) && sd > 0) opts.SegmentDuration = TimeSpan.FromSeconds(sd);
         var transcodeMin = Environment.GetEnvironmentVariable("MEDIA_TRANSCODE_TIMEOUT_MINUTES");
         if (int.TryParse(transcodeMin, out var tm) && tm > 0) opts.TranscodeTimeout = TimeSpan.FromMinutes(tm);
+        // URL import (issue #106). Independent of the GPU split — the fetch is I/O bound and
+        // belongs on the API host. AllowedHosts is comma-separated, trimmed, lowercased.
+        var importEnabled = Environment.GetEnvironmentVariable("MEDIA_IMPORT_ENABLED");
+        if (bool.TryParse(importEnabled, out var ie)) opts.Import.Enabled = ie;
+        var importWorkerEnabled = Environment.GetEnvironmentVariable("MEDIA_IMPORT_WORKER_ENABLED");
+        if (bool.TryParse(importWorkerEnabled, out var iwe)) opts.Import.WorkerEnabled = iwe;
+        var ytdlp = Environment.GetEnvironmentVariable("YTDLP_PATH");
+        if (!string.IsNullOrWhiteSpace(ytdlp)) opts.Import.YtdlpPath = ytdlp;
+        var fetchSecs = Environment.GetEnvironmentVariable("MEDIA_IMPORT_FETCH_TIMEOUT_SECS");
+        if (int.TryParse(fetchSecs, out var fs) && fs > 0) opts.Import.FetchTimeout = TimeSpan.FromSeconds(fs);
+        var importHosts = Environment.GetEnvironmentVariable("MEDIA_IMPORT_ALLOWED_HOSTS");
+        if (!string.IsNullOrWhiteSpace(importHosts))
+        {
+            opts.Import.AllowedHosts = importHosts
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(h => h.ToLowerInvariant())
+                .ToList();
+        }
     })
     .Validate(o => o.PollInterval > TimeSpan.Zero, "MediaJobs.PollInterval must be positive.")
     .Validate(o => o.LeaseDuration > TimeSpan.Zero, "MediaJobs.LeaseDuration must be positive.")
@@ -171,6 +189,9 @@ builder.Services.AddOptions<MediaJobOptions>()
     .Validate(o => !string.IsNullOrWhiteSpace(o.VideoCodec), "MediaJobs.VideoCodec must be set.")
     .Validate(o => !string.IsNullOrWhiteSpace(o.JitVideoEncoder), "MediaJobs.JitVideoEncoder must be set.")
     .Validate(o => o.Ladder is { Count: > 0 }, "MediaJobs.Ladder must define at least one rung.")
+    .Validate(o => o.Import.FetchTimeout > TimeSpan.Zero, "MediaJobs.Import.FetchTimeout must be positive.")
+    .Validate(o => !string.IsNullOrWhiteSpace(o.Import.YtdlpPath), "MediaJobs.Import.YtdlpPath must be set.")
+    .Validate(o => o.Import.AllowedHosts is { Count: > 0 }, "MediaJobs.Import.AllowedHosts must list at least one host.")
     .ValidateOnStart();
 builder.Services.AddSingleton<IFfmpegRunner, FfmpegRunner>();
 builder.Services.AddScoped<IClipMediaJobStore, ClipMediaJobStore>();
@@ -181,6 +202,11 @@ builder.Services.AddScoped<IJitLadderService, JitLadderService>();
 builder.Services.AddHostedService<ThumbnailWorker>();
 builder.Services.AddHostedService<CompressWorker>();
 builder.Services.AddHostedService<StreamRenditionWorker>();
+// URL-import stage (issue #106). Worker exits at startup when MEDIA_IMPORT_ENABLED=false
+// (or MEDIA_IMPORT_WORKER_ENABLED=false on the GPU box), mirroring the IGDB-sync pattern.
+builder.Services.AddSingleton<GankedTV.Api.Services.Media.Import.IClipImportSource,
+    GankedTV.Api.Services.Media.Import.YtDlpImportSource>();
+builder.Services.AddHostedService<ImportWorker>();
 
 builder.Services.AddOptions<ClipValidationOptions>()
     .Configure(opts =>
@@ -201,6 +227,8 @@ builder.Services.AddOptions<ClipValidationOptions>()
     .ValidateOnStart();
 
 builder.Services.AddScoped<IClipUploadService, ClipUploadService>();
+builder.Services.AddScoped<IClipImportService, ClipImportService>();
+builder.Services.AddScoped<IClipImportUrlValidator, ClipImportUrlValidator>();
 builder.Services.AddScoped<ITagsResolver, TagsResolver>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 
@@ -432,6 +460,7 @@ app.UseRateLimiter();
 app.MapAuthEndpoints();
 app.MapMeEndpoints();
 app.MapClipsUploadEndpoints();
+app.MapClipsImportEndpoints();
 app.MapClipsReadEndpoints();
 app.MapClipsMutateEndpoints();
 app.MapLikesEndpoints();

--- a/server/src/GankedTV.Api/Services/Clips/ClipImportService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipImportService.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+using GankedTV.Api.Clips;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Media;
+using GankedTV.Api.Services.Media.Import;
+using GankedTV.Api.Services.Tags;
+using GankedTV.Api.Validation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Services.Clips;
+
+// Mirrors ClipUploadService.CreateAsync — same validation cascade (visibility → game → tags),
+// same share-code generator, same ClipKeys.BuildVideoKey — but inserts the row directly in
+// 'importing' status with the source URL stashed. The ImportWorker picks it up from there.
+public sealed class ClipImportService : IClipImportService
+{
+    private readonly GankedTvDbContext _db;
+    private readonly IClipImportUrlValidator _urlValidator;
+    private readonly ITagsResolver _tagsResolver;
+    private readonly IClipImportSource _source;
+    private readonly ClipValidationOptions _validation;
+    private readonly IOptionsMonitor<MediaJobOptions> _mediaOptions;
+    private readonly TimeProvider _clock;
+
+    public ClipImportService(
+        GankedTvDbContext db,
+        IClipImportUrlValidator urlValidator,
+        ITagsResolver tagsResolver,
+        IClipImportSource source,
+        IOptions<ClipValidationOptions> validation,
+        IOptionsMonitor<MediaJobOptions> mediaOptions,
+        TimeProvider clock)
+    {
+        _db = db;
+        _urlValidator = urlValidator;
+        _tagsResolver = tagsResolver;
+        _source = source;
+        _validation = validation.Value;
+        _mediaOptions = mediaOptions;
+        _clock = clock;
+    }
+
+    public async Task<ClipResult<ImportClipPreviewResult>> PreviewAsync(string? url, CancellationToken ct)
+    {
+        if (!_mediaOptions.CurrentValue.Import.Enabled)
+        {
+            return ClipResult<ImportClipPreviewResult>.Fail(ClipUploadError.ImportDisabled);
+        }
+        if (!_urlValidator.TryParse(url, out var normalisedUrl, out var urlError))
+        {
+            return ClipResult<ImportClipPreviewResult>.Fail(urlError switch
+            {
+                ImportUrlValidationError.InvalidUrl => ClipUploadError.InvalidUrl,
+                ImportUrlValidationError.UnsupportedHost => ClipUploadError.UnsupportedHost,
+                _ => ClipUploadError.InvalidUrl,
+            });
+        }
+
+        try
+        {
+            var media = await _source.ProbeAsync(normalisedUrl, ct);
+            return ClipResult<ImportClipPreviewResult>.Ok(new ImportClipPreviewResult(
+                Title: media.Title,
+                DurationSecs: media.DurationSecs,
+                Width: media.Width,
+                Height: media.Height,
+                ThumbnailUrl: media.ThumbnailUrl,
+                MaxClipDurationSecs: _validation.MaxClipDurationSecs));
+        }
+        catch (ImportSourceRejectedException)
+        {
+            // Reuse UnsupportedHost? No — we want a distinct "source unavailable" surface.
+            // Map onto a new error code below (private/geo-blocked/removed).
+            return ClipResult<ImportClipPreviewResult>.Fail(ClipUploadError.SourceUnavailable);
+        }
+        catch (ImportFetchException)
+        {
+            return ClipResult<ImportClipPreviewResult>.Fail(ClipUploadError.FetchFailed);
+        }
+    }
+
+    public async Task<ClipResult<ImportClipResult>> SubmitAsync(
+        Guid userId,
+        ImportClipInput input,
+        CancellationToken ct)
+    {
+        // Pipeline-level kill switch — covers prod incidents (e.g. yt-dlp host outage) without
+        // having to ship code. Mirrors how /clips would 503 if the upload pipeline were down.
+        if (!_mediaOptions.CurrentValue.Import.Enabled)
+        {
+            return ClipResult<ImportClipResult>.Fail(ClipUploadError.ImportDisabled);
+        }
+
+        if (!_urlValidator.TryParse(input.Url, out var normalisedUrl, out var urlError))
+        {
+            return ClipResult<ImportClipResult>.Fail(urlError switch
+            {
+                ImportUrlValidationError.InvalidUrl => ClipUploadError.InvalidUrl,
+                ImportUrlValidationError.UnsupportedHost => ClipUploadError.UnsupportedHost,
+                _ => ClipUploadError.InvalidUrl,
+            });
+        }
+
+        // Title is optional for imports — when omitted, the worker fills it from the extractor's
+        // metadata. When provided, it goes through the same length cap as direct uploads.
+        var trimmedTitle = input.Title?.Trim();
+        var title = string.IsNullOrEmpty(trimmedTitle) ? ClipImportDefaults.PlaceholderTitle : trimmedTitle;
+        if (title.Length > _validation.MaxTitleLength)
+        {
+            return ClipResult<ImportClipResult>.Fail(ClipUploadError.InvalidTitle);
+        }
+
+        if (input.Description is { Length: var descLen } && descLen > _validation.MaxDescriptionLength)
+        {
+            return ClipResult<ImportClipResult>.Fail(ClipUploadError.InvalidDescription);
+        }
+
+        var rawVisibility = input.Visibility ?? ClipVisibilities.Public;
+        if (!ClipVisibilities.IsValid(rawVisibility))
+        {
+            return ClipResult<ImportClipResult>.Fail(ClipUploadError.InvalidVisibility);
+        }
+        var visibility = ClipVisibilities.Normalize(rawVisibility);
+
+        string? gameSlug = null;
+        if (input.GameId is { } gameId)
+        {
+            gameSlug = await _db.Games.AsNoTracking()
+                .Where(g => g.Id == gameId)
+                .Select(g => g.Slug)
+                .FirstOrDefaultAsync(ct);
+            if (gameSlug is null)
+            {
+                return ClipResult<ImportClipResult>.Fail(ClipUploadError.InvalidGame);
+            }
+        }
+
+        var requestedTags = input.Tags ?? [];
+        var tagsResult = await _tagsResolver.ResolveAsync(requestedTags, ct);
+        if (!tagsResult.IsSuccess)
+        {
+            return ClipResult<ImportClipResult>.Fail(MapTagsError(tagsResult.Error!.Value));
+        }
+
+        var id = Guid.NewGuid();
+        var now = _clock.GetUtcNow();
+        var shareCode = await ShareCodeGenerator.GenerateUniqueAsync(_db.Clips, ct);
+        var clip = new Clip
+        {
+            Id = id,
+            UserId = userId,
+            GameId = input.GameId,
+            Title = title,
+            Description = string.IsNullOrEmpty(input.Description) ? null : input.Description,
+            VideoKey = ClipKeys.BuildVideoKey(userId, id, gameSlug),
+            ShareCode = shareCode,
+            Status = ClipStatuses.Importing,
+            Visibility = visibility,
+            ImportSourceUrl = normalisedUrl,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        _tagsResolver.SetClipTags(clip, tagsResult.Tags);
+        _db.Clips.Add(clip);
+        await _db.SaveChangesAsync(ct);
+
+        return ClipResult<ImportClipResult>.Ok(new ImportClipResult(id, ClipStatuses.Importing));
+    }
+
+    // Same mapping as ClipUploadService.MapTagsError. Duplicated rather than exposed because
+    // both services exhaustively map the same enum and the mirroring keeps each service's
+    // error space self-contained.
+    private static ClipUploadError MapTagsError(TagsResolveError error) => error switch
+    {
+        TagsResolveError.TooManyTags => ClipUploadError.TooManyTags,
+        TagsResolveError.InvalidTag => ClipUploadError.InvalidTag,
+        _ => throw new UnreachableException($"Unmapped TagsResolveError: {error}"),
+    };
+}

--- a/server/src/GankedTV.Api/Services/Clips/ClipImportService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipImportService.cs
@@ -7,6 +7,7 @@ using GankedTV.Api.Services.Media.Import;
 using GankedTV.Api.Services.Tags;
 using GankedTV.Api.Validation;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace GankedTV.Api.Services.Clips;
@@ -23,6 +24,7 @@ public sealed class ClipImportService : IClipImportService
     private readonly ClipValidationOptions _validation;
     private readonly IOptionsMonitor<MediaJobOptions> _mediaOptions;
     private readonly TimeProvider _clock;
+    private readonly ILogger<ClipImportService> _logger;
 
     public ClipImportService(
         GankedTvDbContext db,
@@ -31,7 +33,8 @@ public sealed class ClipImportService : IClipImportService
         IClipImportSource source,
         IOptions<ClipValidationOptions> validation,
         IOptionsMonitor<MediaJobOptions> mediaOptions,
-        TimeProvider clock)
+        TimeProvider clock,
+        ILogger<ClipImportService> logger)
     {
         _db = db;
         _urlValidator = urlValidator;
@@ -40,6 +43,7 @@ public sealed class ClipImportService : IClipImportService
         _validation = validation.Value;
         _mediaOptions = mediaOptions;
         _clock = clock;
+        _logger = logger;
     }
 
     public async Task<ClipResult<ImportClipPreviewResult>> PreviewAsync(string? url, CancellationToken ct)
@@ -69,14 +73,22 @@ public sealed class ClipImportService : IClipImportService
                 ThumbnailUrl: media.ThumbnailUrl,
                 MaxClipDurationSecs: _validation.MaxClipDurationSecs));
         }
-        catch (ImportSourceRejectedException)
+        catch (ImportSourceRejectedException ex)
         {
-            // Reuse UnsupportedHost? No — we want a distinct "source unavailable" surface.
-            // Map onto a new error code below (private/geo-blocked/removed).
+            // Info, not Warning: this is the normal "private / removed / geo-blocked" path,
+            // not an infra failure. Keeps operator dashboards quiet but leaves a trail.
+            _logger.LogInformation(
+                "Preview for {Url} rejected by source: {Reason} ({Message})",
+                normalisedUrl, ex.Reason, ex.Message);
             return ClipResult<ImportClipPreviewResult>.Fail(ClipUploadError.SourceUnavailable);
         }
-        catch (ImportFetchException)
+        catch (ImportFetchException ex)
         {
+            // Warning: yt-dlp infra problem (binary missing, timeout, network). Operators
+            // need visibility — "every preview fails for everyone" should surface in logs
+            // rather than as a stream of opaque 400s.
+            _logger.LogWarning(ex,
+                "Preview probe failed for {Url}: {Message}", normalisedUrl, ex.Message);
             return ClipResult<ImportClipPreviewResult>.Fail(ClipUploadError.FetchFailed);
         }
     }

--- a/server/src/GankedTV.Api/Services/Clips/ClipImportUrlValidator.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipImportUrlValidator.cs
@@ -1,0 +1,63 @@
+using GankedTV.Api.Services.Media;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Services.Clips;
+
+public sealed class ClipImportUrlValidator : IClipImportUrlValidator
+{
+    private readonly IOptionsMonitor<MediaJobOptions> _options;
+
+    public ClipImportUrlValidator(IOptionsMonitor<MediaJobOptions> options)
+    {
+        _options = options;
+    }
+
+    public bool TryParse(string? url, out string normalised, out ImportUrlValidationError error)
+    {
+        normalised = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            error = ImportUrlValidationError.InvalidUrl;
+            return false;
+        }
+
+        // Absolute URI + https scheme only — http would expose us to MITM during the fetch,
+        // and platform CDNs (Medal, YouTube) all serve https anyway.
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var parsed)
+            || parsed.Scheme != Uri.UriSchemeHttps)
+        {
+            error = ImportUrlValidationError.InvalidUrl;
+            return false;
+        }
+
+        var allowedHosts = _options.CurrentValue.Import.AllowedHosts;
+        var host = parsed.Host.ToLowerInvariant();
+        var allowed = false;
+        for (var i = 0; i < allowedHosts.Count; i++)
+        {
+            if (string.Equals(allowedHosts[i], host, StringComparison.OrdinalIgnoreCase))
+            {
+                allowed = true;
+                break;
+            }
+        }
+
+        if (!allowed)
+        {
+            error = ImportUrlValidationError.UnsupportedHost;
+            return false;
+        }
+
+        // Strip fragments and rebuild a canonical absolute URL so the worker's defence-in-depth
+        // re-check sees exactly the string we persisted. Query string is preserved — Medal.tv
+        // and YouTube both encode the clip id in the query path.
+        var builder = new UriBuilder(parsed)
+        {
+            Fragment = string.Empty,
+        };
+        normalised = builder.Uri.AbsoluteUri;
+        error = default;
+        return true;
+    }
+}

--- a/server/src/GankedTV.Api/Services/Clips/ClipKeys.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipKeys.cs
@@ -1,0 +1,20 @@
+namespace GankedTV.Api.Services.Clips;
+
+// Object-storage key builder for clip artefacts. Centralised so every ingestion path
+// (direct upload, URL import, dev seed) writes to the same layout — namespaced by user id
+// (immutable) and grouped by game slug (when set) so listing the bucket is human-readable.
+// No-game uploads omit the slug segment rather than inserting a "null/" placeholder.
+public static class ClipKeys
+{
+    public static string BuildVideoKey(Guid userId, Guid clipId, string? gameSlug) =>
+        gameSlug is { Length: > 0 }
+            ? $"{userId}/{gameSlug}/{clipId}.mp4"
+            : $"{userId}/{clipId}.mp4";
+
+    // Mirrors BuildVideoKey so the thumbnail and video for a given clip live at parallel
+    // paths in their respective buckets — keeps manual inspection / GDPR purges simple.
+    public static string BuildThumbnailKey(Guid userId, Guid clipId, string? gameSlug) =>
+        gameSlug is { Length: > 0 }
+            ? $"{userId}/{gameSlug}/{clipId}.jpg"
+            : $"{userId}/{clipId}.jpg";
+}

--- a/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/ClipUploadService.cs
@@ -103,7 +103,7 @@ public sealed class ClipUploadService : IClipUploadService
             // Namespace by user id (immutable — username can change via PATCH /auth/me)
             // and by game slug so listing the bucket groups one user's clips per title.
             // No-game uploads omit the slug segment (no `null/` placeholder).
-            VideoKey = BuildVideoKey(userId, id, gameSlug),
+            VideoKey = ClipKeys.BuildVideoKey(userId, id, gameSlug),
             ShareCode = shareCode,
             Status = ClipStatuses.Draft,
             Visibility = visibility,
@@ -221,18 +221,6 @@ public sealed class ClipUploadService : IClipUploadService
 
         return ClipResult<CompleteClipResult>.Ok(new CompleteClipResult(clipId, meta.SizeBytes));
     }
-
-    internal static string BuildVideoKey(Guid userId, Guid clipId, string? gameSlug) =>
-        gameSlug is { Length: > 0 }
-            ? $"{userId}/{gameSlug}/{clipId}.mp4"
-            : $"{userId}/{clipId}.mp4";
-
-    // Mirrors BuildVideoKey so the thumbnail and video for a given clip live at parallel
-    // paths in their respective buckets — keeps manual inspection / GDPR purges simple.
-    internal static string BuildThumbnailKey(Guid userId, Guid clipId, string? gameSlug) =>
-        gameSlug is { Length: > 0 }
-            ? $"{userId}/{gameSlug}/{clipId}.jpg"
-            : $"{userId}/{clipId}.jpg";
 
     private bool IsAllowedContentType(string? contentType)
     {

--- a/server/src/GankedTV.Api/Services/Clips/IClipImportService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/IClipImportService.cs
@@ -1,0 +1,49 @@
+namespace GankedTV.Api.Services.Clips;
+
+public interface IClipImportService
+{
+    // Validates the URL + metadata, inserts a Clip in status='importing', and returns its id.
+    // The background ImportWorker picks the row up, fetches the source via yt-dlp, writes the
+    // bytes to S3 at the clip's VideoKey, and advances the row into 'processing' — at which
+    // point the existing thumbnail → compress → ready pipeline takes over.
+    Task<ClipResult<ImportClipResult>> SubmitAsync(
+        Guid userId,
+        ImportClipInput input,
+        CancellationToken ct);
+
+    // Metadata-only preview. Validates the URL (allow-list) and runs a no-download yt-dlp
+    // probe so the wizard can show duration + title in step 1 — and gate "Continue" when the
+    // source already exceeds MaxClipDurationSecs. Authoritative duration enforcement still
+    // happens in the worker (ffprobe on the downloaded file); this is a UX shortcut so the
+    // user doesn't waste time filling step 2 for a doomed clip.
+    Task<ClipResult<ImportClipPreviewResult>> PreviewAsync(string? url, CancellationToken ct);
+}
+
+public sealed record ImportClipInput(
+    string? Url,
+    string? Title,
+    string? Description,
+    int? GameId,
+    string? Visibility,
+    IReadOnlyList<string>? Tags);
+
+public sealed record ImportClipResult(Guid ClipId, string Status);
+
+// Wire response for POST /clips/import/preview. All metadata fields are nullable because
+// not every extractor exposes them — the frontend gates only when DurationSecs is known.
+// MaxClipDurationSecs is always included so the client doesn't have to know the cap.
+public sealed record ImportClipPreviewResult(
+    string? Title,
+    int? DurationSecs,
+    int? Width,
+    int? Height,
+    string? ThumbnailUrl,
+    int MaxClipDurationSecs);
+
+// Default title for imports that don't ship one up-front. The ImportWorker swaps this for
+// the extractor's title (when it has one) by matching on this exact string — kept here so
+// service + worker + tests all reference the same constant.
+public static class ClipImportDefaults
+{
+    public const string PlaceholderTitle = "Importing…";
+}

--- a/server/src/GankedTV.Api/Services/Clips/IClipImportUrlValidator.cs
+++ b/server/src/GankedTV.Api/Services/Clips/IClipImportUrlValidator.cs
@@ -1,0 +1,16 @@
+namespace GankedTV.Api.Services.Clips;
+
+public enum ImportUrlValidationError
+{
+    InvalidUrl,
+    UnsupportedHost,
+}
+
+public interface IClipImportUrlValidator
+{
+    // Parses the user-supplied URL and confirms its host is on the configured allow-list.
+    // Returns the canonical https://host/path form on success (so the worker re-validates
+    // against the same string the user submitted). Returns null when the URL is malformed
+    // or the host isn't allowed; the error tells callers which case.
+    bool TryParse(string? url, out string normalised, out ImportUrlValidationError error);
+}

--- a/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
+++ b/server/src/GankedTV.Api/Services/Clips/IClipUploadService.cs
@@ -31,6 +31,13 @@ public enum ClipUploadError
     UnsupportedContentType,
     TooManyTags,
     InvalidTag,
+    // URL-import only (issue #106). Live in the same enum so the import endpoint can reuse
+    // the existing MapError table (visibility/game/tag errors are shared with /clips create).
+    InvalidUrl,
+    UnsupportedHost,
+    ImportDisabled,
+    SourceUnavailable,
+    FetchFailed,
 }
 
 public readonly record struct ClipResult<T>(T? Value, ClipUploadError? Error)

--- a/server/src/GankedTV.Api/Services/Media/ClipMediaJobStore.cs
+++ b/server/src/GankedTV.Api/Services/Media/ClipMediaJobStore.cs
@@ -1,5 +1,6 @@
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Validation;
 using Microsoft.EntityFrameworkCore;
 
 namespace GankedTV.Api.Services.Media;
@@ -245,8 +246,12 @@ public sealed class ClipMediaJobStore : IClipMediaJobStore
 
         // Only swap the title if it still equals the user-supplied placeholder. A user who
         // typed a real title before submit keeps it; the placeholder-only path picks up the
-        // extractor's title here. Truncate to MaxTitleLength to honor the validator's cap.
-        var truncated = trimmedExtractor.Length > 255 ? trimmedExtractor[..255] : trimmedExtractor;
+        // extractor's title here. Truncate to the shared ClipValidationLimits ceiling so the
+        // hard cap stays single-sourced — the upload path also clamps against it via
+        // DataAnnotations.
+        var truncated = trimmedExtractor.Length > ClipValidationLimits.MaxTitleLength
+            ? trimmedExtractor[..ClipValidationLimits.MaxTitleLength]
+            : trimmedExtractor;
         await _db.Clips
             .Where(c => c.Id == clipId && c.Title == placeholderTitle)
             .ExecuteUpdateAsync(setters => setters

--- a/server/src/GankedTV.Api/Services/Media/ClipMediaJobStore.cs
+++ b/server/src/GankedTV.Api/Services/Media/ClipMediaJobStore.cs
@@ -125,7 +125,7 @@ public sealed class ClipMediaJobStore : IClipMediaJobStore
                 .SetProperty(c => c.UpdatedAt, now), ct);
     }
 
-    public async Task MarkFailedAsync(Guid clipId, int expectedAttempt, string fromStatus, CancellationToken ct)
+    public async Task MarkFailedAsync(Guid clipId, int expectedAttempt, string fromStatus, CancellationToken ct, string? reason = null)
     {
         var now = _clock.GetUtcNow();
         await _db.Clips
@@ -135,6 +135,7 @@ public sealed class ClipMediaJobStore : IClipMediaJobStore
             .ExecuteUpdateAsync(setters => setters
                 .SetProperty(c => c.Status, ClipStatuses.Failed)
                 .SetProperty(c => c.ProcessingStartedAt, (DateTimeOffset?)null)
+                .SetProperty(c => c.FailureReason, reason)
                 .SetProperty(c => c.UpdatedAt, now), ct);
     }
 
@@ -147,6 +148,109 @@ public sealed class ClipMediaJobStore : IClipMediaJobStore
                 && c.ProcessingAttempts == expectedAttempt)
             .ExecuteUpdateAsync(setters => setters
                 .SetProperty(c => c.ProcessingStartedAt, (DateTimeOffset?)null)
+                .SetProperty(c => c.UpdatedAt, now), ct);
+    }
+
+    public async Task<ClaimedImportJob?> ClaimNextImportAsync(
+        TimeSpan leaseDuration,
+        int maxAttempts,
+        CancellationToken ct)
+    {
+        var now = _clock.GetUtcNow();
+        var leaseExpiry = now - leaseDuration;
+        var importingStatus = ClipStatuses.Importing;
+
+        // Same SKIP LOCKED + lease-bump shape as ClaimNextAsync — replicated here because the
+        // import claim needs to return ImportSourceUrl + Title, which aren't on ClaimedMediaJob.
+        // Refactoring the existing claim to a generic shape would balloon the diff; copying
+        // the 20 lines is the cheaper route. Backed by idx_clips_importing_updated_at.
+        await using var tx = await _db.Database.BeginTransactionAsync(ct);
+
+        var rows = await _db.Clips
+            .FromSqlInterpolated($@"
+                SELECT *
+                FROM clips
+                WHERE status = {importingStatus}
+                  AND (processing_started_at IS NULL OR processing_started_at < {leaseExpiry})
+                  AND processing_attempts < {maxAttempts}
+                ORDER BY updated_at
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1
+            ")
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        if (rows.Count == 0)
+        {
+            await tx.CommitAsync(ct);
+            return null;
+        }
+
+        var clip = rows[0];
+        var nextAttempt = clip.ProcessingAttempts + 1;
+
+        await _db.Clips
+            .Where(c => c.Id == clip.Id)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(c => c.ProcessingStartedAt, now)
+                .SetProperty(c => c.ProcessingAttempts, nextAttempt)
+                .SetProperty(c => c.UpdatedAt, now), ct);
+
+        await tx.CommitAsync(ct);
+
+        // ImportSourceUrl is guaranteed non-null on importing rows by the submit service. The
+        // null-coalescing is a defence-in-depth fallback: if the column is somehow null, the
+        // worker re-validates and fails fast rather than feeding an empty string to yt-dlp.
+        return new ClaimedImportJob(
+            clip.Id,
+            clip.UserId,
+            clip.GameId,
+            clip.VideoKey,
+            clip.ImportSourceUrl ?? string.Empty,
+            clip.Title,
+            nextAttempt);
+    }
+
+    public async Task AdvanceImportAsync(
+        Guid clipId,
+        int expectedAttempt,
+        long fileSizeBytes,
+        string? extractorTitle,
+        string placeholderTitle,
+        CancellationToken ct)
+    {
+        var now = _clock.GetUtcNow();
+        var trimmedExtractor = string.IsNullOrWhiteSpace(extractorTitle) ? null : extractorTitle.Trim();
+
+        // Two-phase update so the title overwrite is conditional on placeholder match without
+        // an extra round-trip. EF's ExecuteUpdateAsync can't conditionally set one property,
+        // so we apply the always-set columns first, then the title separately when applicable.
+        var rowsAffected = await _db.Clips
+            .Where(c => c.Id == clipId
+                && c.Status == ClipStatuses.Importing
+                && c.ProcessingAttempts == expectedAttempt)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(c => c.Status, ClipStatuses.Processing)
+                .SetProperty(c => c.FileSizeBytes, fileSizeBytes)
+                .SetProperty(c => c.ProcessingStartedAt, (DateTimeOffset?)null)
+                // Reset attempts so the next stage (thumbnail) gets its own full budget, just
+                // like AdvanceThumbnailAsync does for the compress stage.
+                .SetProperty(c => c.ProcessingAttempts, 0)
+                .SetProperty(c => c.UpdatedAt, now), ct);
+
+        if (rowsAffected == 0 || trimmedExtractor is null)
+        {
+            return;
+        }
+
+        // Only swap the title if it still equals the user-supplied placeholder. A user who
+        // typed a real title before submit keeps it; the placeholder-only path picks up the
+        // extractor's title here. Truncate to MaxTitleLength to honor the validator's cap.
+        var truncated = trimmedExtractor.Length > 255 ? trimmedExtractor[..255] : trimmedExtractor;
+        await _db.Clips
+            .Where(c => c.Id == clipId && c.Title == placeholderTitle)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(c => c.Title, truncated)
                 .SetProperty(c => c.UpdatedAt, now), ct);
     }
 }

--- a/server/src/GankedTV.Api/Services/Media/ClipStageWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/ClipStageWorker.cs
@@ -20,6 +20,13 @@ public abstract class ClipStageWorker : MediaStageWorker<ClaimedMediaJob>
     // The clip status this stage claims ('processing' or 'transcoding').
     protected abstract string ClaimStatus { get; }
 
+    // Machine-readable code persisted to clips.failure_reason when this stage exhausts its
+    // retry budget. Lets the wizard surface specific copy per stage instead of a generic
+    // "import failed" default. Null falls back to "no reason recorded" — kept null on the
+    // base for safety so a new stage that forgets to override doesn't accidentally inherit
+    // a misleading code.
+    protected virtual string? TerminalFailureReason => null;
+
     protected override Task<ClaimedMediaJob?> ClaimAsync(IServiceProvider scope, MediaJobOptions opts, CancellationToken ct) =>
         scope.GetRequiredService<IClipMediaJobStore>().ClaimNextAsync(ClaimStatus, opts.LeaseDuration, opts.MaxAttempts, ct);
 
@@ -30,7 +37,8 @@ public abstract class ClipStageWorker : MediaStageWorker<ClaimedMediaJob>
         scope.GetRequiredService<IClipMediaJobStore>().ReleaseLeaseAsync(job.ClipId, job.AttemptNumber, ClaimStatus, ct);
 
     protected override Task FailAsync(IServiceProvider scope, ClaimedMediaJob job, CancellationToken ct) =>
-        scope.GetRequiredService<IClipMediaJobStore>().MarkFailedAsync(job.ClipId, job.AttemptNumber, ClaimStatus, ct);
+        scope.GetRequiredService<IClipMediaJobStore>()
+            .MarkFailedAsync(job.ClipId, job.AttemptNumber, ClaimStatus, ct, reason: TerminalFailureReason);
 
     // Drop cached feed pages once a clip becomes feed-visible (reaches 'ready'). Best-effort: the
     // status transition has already committed, so a cache failure (e.g. Redis down) must NOT bubble

--- a/server/src/GankedTV.Api/Services/Media/CompressWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/CompressWorker.cs
@@ -25,6 +25,7 @@ public sealed class CompressWorker : ClipStageWorker
 
     protected override string ClaimStatus => ClipStatuses.Transcoding;
     protected override string StageName => "compress";
+    protected override string? TerminalFailureReason => ClipFailureReasons.TranscodeFailed;
     protected override bool IsWorkerEnabled(MediaJobOptions opts) => opts.TranscodeWorkerEnabled;
 
     protected override async Task ProcessAsync(

--- a/server/src/GankedTV.Api/Services/Media/IClipMediaJobStore.cs
+++ b/server/src/GankedTV.Api/Services/Media/IClipMediaJobStore.cs
@@ -8,6 +8,18 @@ public sealed record ClaimedMediaJob(
     short? SourceHeight,
     int AttemptNumber);
 
+// Import-stage variant — extends ClaimedMediaJob with the source URL the fetcher needs.
+// Kept as a record-with-extra-property rather than a brand-new shape so the import worker
+// can still share the base MediaStageWorker plumbing.
+public sealed record ClaimedImportJob(
+    Guid ClipId,
+    Guid UserId,
+    int? GameId,
+    string VideoKey,
+    string ImportSourceUrl,
+    string Title,
+    int AttemptNumber);
+
 public sealed record FinalizedMediaJob(
     string ThumbnailKey,
     short? DurationSecs,
@@ -55,12 +67,35 @@ public interface IClipMediaJobStore
 
     // Marks the claimed job permanently failed (status fromStatus → 'failed'). Called only
     // after attempts >= max. The expectedAttempt + fromStatus guards prevent a late failure
-    // from killing a row that another worker has since re-claimed or advanced.
-    Task MarkFailedAsync(Guid clipId, int expectedAttempt, string fromStatus, CancellationToken ct);
+    // from killing a row that another worker has since re-claimed or advanced. Optional
+    // `reason` (one of ClipFailureReasons.*) lets the status endpoint surface a specific
+    // user-facing message instead of a generic "failed".
+    Task MarkFailedAsync(Guid clipId, int expectedAttempt, string fromStatus, CancellationToken ct, string? reason = null);
 
     // Releases a lease without changing status by clearing ProcessingStartedAt, so the
     // row becomes immediately eligible for re-claim by any worker on the next tick.
     // Used after a transient failure that hasn't yet exhausted attempts. The expectedAttempt
     // + fromStatus guards prevent this worker from releasing another worker's lease.
     Task ReleaseLeaseAsync(Guid clipId, int expectedAttempt, string fromStatus, CancellationToken ct);
+
+    // Atomically claims one row in status 'importing' that isn't currently leased and hasn't
+    // exhausted its retry budget. Same SKIP LOCKED + lease bump as ClaimNextAsync but returns
+    // the import URL alongside (the worker needs it for the fetch).
+    Task<ClaimedImportJob?> ClaimNextImportAsync(
+        TimeSpan leaseDuration,
+        int maxAttempts,
+        CancellationToken ct);
+
+    // Import stage success: writes file size + (optionally) the extractor's title onto the
+    // row, clears the lease, and advances status 'importing' → 'processing'. The title is
+    // overwritten only when the current value still equals `placeholderTitle` — so users who
+    // typed a real title before submitting keep it, and the worker fills in extractor titles
+    // for the placeholder-only path.
+    Task AdvanceImportAsync(
+        Guid clipId,
+        int expectedAttempt,
+        long fileSizeBytes,
+        string? extractorTitle,
+        string placeholderTitle,
+        CancellationToken ct);
 }

--- a/server/src/GankedTV.Api/Services/Media/Import/IClipImportSource.cs
+++ b/server/src/GankedTV.Api/Services/Media/Import/IClipImportSource.cs
@@ -41,10 +41,17 @@ public sealed class ImportSourceRejectedException : Exception
 public interface IClipImportSource
 {
     // Pulls the source video at `url` into `destinationFilePath`. Returns metadata parsed
-    // from the extractor's JSON dump. Throws ImportFetchException on any non-recoverable
-    // error (exit code, timeout, file missing, size/duration cap exceeded). The base
-    // worker turns the throw into a release-for-retry or permanent fail per its retry
-    // budget — same contract as the thumbnail/compress stages.
+    // from the extractor's JSON dump.
+    //
+    // Exception contract — implementations MUST classify failures so the worker can
+    // distinguish retry-worthy from terminal:
+    //   * <see cref="ImportFetchException"/>: transient / retryable — network errors,
+    //     timeouts, non-zero exit, "exited 0 but no file produced". The MediaStageWorker
+    //     loop releases the lease and another attempt picks the clip back up.
+    //   * <see cref="ImportSourceRejectedException"/>: non-retryable — duration/size cap
+    //     exceeded, or the extractor reports the source as private/geo-blocked/removed.
+    //     Retrying won't change the outcome; the worker marks the clip 'failed' with the
+    //     exception's structured Reason code on the first attempt.
     Task<ImportedMedia> FetchAsync(
         string url,
         string destinationFilePath,

--- a/server/src/GankedTV.Api/Services/Media/Import/IClipImportSource.cs
+++ b/server/src/GankedTV.Api/Services/Media/Import/IClipImportSource.cs
@@ -1,0 +1,59 @@
+namespace GankedTV.Api.Services.Media.Import;
+
+// Metadata extracted from the source by yt-dlp's --print output. All fields are optional
+// because not every extractor exposes every field (Medal.tv tends to expose less than
+// YouTube). ThumbnailUrl is the platform CDN URL yt-dlp resolves — passed to the wizard
+// so the preview card shows the actual clip frame even before the import finishes.
+public sealed record ImportedMedia(
+    string? Title,
+    int? DurationSecs,
+    int? Width,
+    int? Height,
+    string? ThumbnailUrl);
+
+// Per-fetch caps. The worker passes the same limits the upload path enforces
+// (ClipValidationOptions.MaxUploadSizeBytes / MaxClipDurationSecs) so an imported
+// clip can never sneak past the cap that direct-upload clips obey.
+public sealed record ImportFetchOptions(long MaxBytes, int MaxDurationSecs);
+
+public sealed class ImportFetchException : Exception
+{
+    public ImportFetchException(string message) : base(message) { }
+    public ImportFetchException(string message, Exception inner) : base(message, inner) { }
+}
+
+// Thrown when the source fails a pre-flight cap check (duration or size). Distinct from
+// the generic ImportFetchException so the worker can mark the clip 'failed' with a
+// machine-readable Reason code and skip retries — the cap won't change between attempts.
+public sealed class ImportSourceRejectedException : Exception
+{
+    public ImportSourceRejectedException(string reason, string message, int? actualDurationSecs = null)
+        : base(message)
+    {
+        Reason = reason;
+        ActualDurationSecs = actualDurationSecs;
+    }
+
+    public string Reason { get; }
+    public int? ActualDurationSecs { get; }
+}
+
+public interface IClipImportSource
+{
+    // Pulls the source video at `url` into `destinationFilePath`. Returns metadata parsed
+    // from the extractor's JSON dump. Throws ImportFetchException on any non-recoverable
+    // error (exit code, timeout, file missing, size/duration cap exceeded). The base
+    // worker turns the throw into a release-for-retry or permanent fail per its retry
+    // budget — same contract as the thumbnail/compress stages.
+    Task<ImportedMedia> FetchAsync(
+        string url,
+        string destinationFilePath,
+        ImportFetchOptions options,
+        CancellationToken ct);
+
+    // Metadata-only probe. Same shape as FetchAsync's metadata return but no download —
+    // costs one HTTP roundtrip to the extractor's metadata endpoint. Used by the import
+    // preview endpoint to surface duration/title before the user fills out step 2. Throws
+    // ImportSourceRejectedException when the source is unavailable (private, geo-blocked).
+    Task<ImportedMedia> ProbeAsync(string url, CancellationToken ct);
+}

--- a/server/src/GankedTV.Api/Services/Media/Import/YtDlpImportSource.cs
+++ b/server/src/GankedTV.Api/Services/Media/Import/YtDlpImportSource.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Globalization;
 using System.Text.Json;
 using GankedTV.Api.Data.Entities;
@@ -92,7 +93,7 @@ public sealed class YtDlpImportSource : IClipImportSource
             throw new ImportFetchException(
                 $"yt-dlp timed out fetching the source after {snapshot.Import.FetchTimeout.TotalMinutes:F0} min.", ex);
         }
-        catch (System.ComponentModel.Win32Exception ex)
+        catch (Win32Exception ex)
         {
             _logger.LogError(ex,
                 "yt-dlp binary '{Path}' could not be launched. Install yt-dlp or set YTDLP_PATH.",
@@ -161,7 +162,7 @@ public sealed class YtDlpImportSource : IClipImportSource
             // the worker retries (transient network issues sometimes cause this).
             throw new ImportFetchException("yt-dlp metadata probe timed out.", ex);
         }
-        catch (System.ComponentModel.Win32Exception ex)
+        catch (Win32Exception ex)
         {
             _logger.LogError(ex,
                 "yt-dlp binary '{Path}' could not be launched (probe). Install yt-dlp or set YTDLP_PATH.",

--- a/server/src/GankedTV.Api/Services/Media/Import/YtDlpImportSource.cs
+++ b/server/src/GankedTV.Api/Services/Media/Import/YtDlpImportSource.cs
@@ -1,0 +1,233 @@
+using System.Globalization;
+using System.Text.Json;
+using GankedTV.Api.Data.Entities;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Services.Media.Import;
+
+// yt-dlp adapter. Reuses IFfmpegRunner (despite the name — it's a generic process runner with
+// stdout/stderr capture + timeout + safe redaction). Two-pass flow:
+//   1. Metadata probe (--skip-download --dump-json) — cheap, no bandwidth used. Reveals the
+//      real duration/size, so cap violations turn into a structured ImportSourceRejectedException
+//      that the worker can surface as a specific user-facing error ("clip is X seconds, max Y").
+//   2. Actual download — only runs when the probe passed. We drop yt-dlp's --match-filter
+//      here because we've already gated on duration; leaving it in causes yt-dlp to silently
+//      exit 0 with empty stdout/stderr when the filter rejects (the bug the two-pass fixes).
+public sealed class YtDlpImportSource : IClipImportSource
+{
+    private readonly IFfmpegRunner _runner;
+    private readonly IOptionsMonitor<MediaJobOptions> _options;
+    private readonly ILogger<YtDlpImportSource> _logger;
+
+    public YtDlpImportSource(
+        IFfmpegRunner runner,
+        IOptionsMonitor<MediaJobOptions> options,
+        ILogger<YtDlpImportSource> logger)
+    {
+        _runner = runner;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<ImportedMedia> ProbeAsync(string url, CancellationToken ct)
+    {
+        var snapshot = _options.CurrentValue;
+        // Probe is best-effort: an extractor that doesn't expose duration returns a media
+        // record with DurationSecs=null. The caller (preview endpoint OR fetch path) decides
+        // what to do with that.
+        return await ProbeMetadataAsync(snapshot, url, ct) ?? new ImportedMedia(null, null, null, null, null);
+    }
+
+    public async Task<ImportedMedia> FetchAsync(
+        string url,
+        string destinationFilePath,
+        ImportFetchOptions options,
+        CancellationToken ct)
+    {
+        var snapshot = _options.CurrentValue;
+
+        // ---- Pass 1: metadata-only probe --------------------------------------------------
+        // --dump-single-json + --skip-download gives us the same JSON as --print-json without
+        // touching any bytes. Cheap (single HTTP roundtrip to the extractor's metadata
+        // endpoint) and lets us reject with the actual duration in the error.
+        var probeMetadata = await ProbeMetadataAsync(snapshot, url, ct);
+        if (probeMetadata is { DurationSecs: { } actualDur } && actualDur > options.MaxDurationSecs)
+        {
+            throw new ImportSourceRejectedException(
+                reason: ClipFailureReasons.SourceTooLong,
+                message: $"Source duration {actualDur}s exceeds cap {options.MaxDurationSecs}s.",
+                actualDurationSecs: actualDur);
+        }
+
+        // ---- Pass 2: actual download ------------------------------------------------------
+        // No --match-filter here: we already gated on duration in pass 1, and leaving it in
+        // makes yt-dlp silently exit 0 with no file when the filter rejects (the very failure
+        // mode this two-pass design exists to surface clearly).
+        //
+        // --print with the field-subset template emits a tiny JSON ({title,duration,...})
+        // instead of yt-dlp's default 500KB+ info dump — the FfmpegRunner buffers at 256 KB
+        // and would otherwise truncate a normal --print-json into unparseable garbage.
+        var args = new List<string>
+        {
+            url,
+            "--no-playlist",
+            "--no-warnings",
+            "--no-progress",
+            "--max-filesize", options.MaxBytes.ToString(CultureInfo.InvariantCulture),
+            "--format", "best[ext=mp4][vcodec!=none][acodec!=none]/best[ext=mp4]/best",
+            "--merge-output-format", "mp4",
+            "--restrict-filenames",
+            "-o", destinationFilePath,
+            "--print", CompactInfoTemplate,
+            "--no-simulate",
+        };
+
+        FfmpegResult result;
+        try
+        {
+            result = await _runner.RunAsync(snapshot.Import.YtdlpPath, args, snapshot.Import.FetchTimeout, ct);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new ImportFetchException(
+                $"yt-dlp timed out fetching the source after {snapshot.Import.FetchTimeout.TotalMinutes:F0} min.", ex);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            _logger.LogError(ex,
+                "yt-dlp binary '{Path}' could not be launched. Install yt-dlp or set YTDLP_PATH.",
+                snapshot.Import.YtdlpPath);
+            throw new ImportFetchException(
+                $"yt-dlp binary '{snapshot.Import.YtdlpPath}' is not available. Install it or set YTDLP_PATH.", ex);
+        }
+
+        if (result.ExitCode != 0)
+        {
+            _logger.LogWarning(
+                "yt-dlp exited {ExitCode} for {Url}. Stderr tail: {Stderr}",
+                result.ExitCode, url, Tail(result.Stderr, 500));
+            throw new ImportFetchException(
+                $"yt-dlp exited with code {result.ExitCode}. Stderr tail: {Tail(result.Stderr, 200)}");
+        }
+
+        if (!File.Exists(destinationFilePath))
+        {
+            var stderrTail = Tail(result.Stderr, 800);
+            var stdoutTail = Tail(result.Stdout, 400);
+            _logger.LogWarning(
+                "yt-dlp exited 0 for {Url} but produced no file. Stderr tail: {Stderr} | Stdout tail: {Stdout}",
+                url, stderrTail, stdoutTail);
+            throw new ImportFetchException(
+                "yt-dlp reported success but produced no output file. Stderr tail: " + stderrTail);
+        }
+
+        // Parse JSON from the download pass — prefer it over the probe's metadata since the
+        // download confirms the actual file's dimensions/title.
+        var fromDownload = ParseFirstJson(result.Stdout);
+        return fromDownload ?? probeMetadata ?? new ImportedMedia(null, null, null, null, null);
+    }
+
+    // yt-dlp output template that emits a compact JSON of ONLY the fields we care about.
+    // --dump-single-json / --print-json blow up to 500+ KB for normal YouTube videos (every
+    // format variant, every thumbnail variant, etc.) and overflow FfmpegRunner's 256 KB
+    // stdout buffer, making the response unparseable. The subset stays well under 1 KB.
+    // 'thumbnail' is the platform-resolved best thumbnail URL (img.youtube.com for YT,
+    // Medal's CDN for Medal.tv) and lets the wizard render a real preview frame regardless
+    // of source — the YouTube-only client-side fallback can't help with Medal.
+    private const string CompactInfoTemplate = "%(.{title,duration,width,height,thumbnail})j";
+
+    private async Task<ImportedMedia?> ProbeMetadataAsync(MediaJobOptions snapshot, string url, CancellationToken ct)
+    {
+        var probeArgs = new List<string>
+        {
+            url,
+            "--no-playlist",
+            "--no-warnings",
+            "--no-progress",
+            "--skip-download",
+            "--print", CompactInfoTemplate,
+        };
+
+        FfmpegResult probe;
+        try
+        {
+            // Use ProcessTimeout (~2 min default) rather than the full FetchTimeout — a metadata
+            // probe that takes minutes is already broken; don't make the user wait 15 min.
+            probe = await _runner.RunAsync(snapshot.Import.YtdlpPath, probeArgs, snapshot.ProcessTimeout, ct);
+        }
+        catch (TimeoutException ex)
+        {
+            // Pre-flight timeout isn't itself a rejection — surface as a generic fetch error so
+            // the worker retries (transient network issues sometimes cause this).
+            throw new ImportFetchException("yt-dlp metadata probe timed out.", ex);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            _logger.LogError(ex,
+                "yt-dlp binary '{Path}' could not be launched (probe). Install yt-dlp or set YTDLP_PATH.",
+                snapshot.Import.YtdlpPath);
+            throw new ImportFetchException(
+                $"yt-dlp binary '{snapshot.Import.YtdlpPath}' is not available. Install it or set YTDLP_PATH.", ex);
+        }
+
+        if (probe.ExitCode != 0)
+        {
+            _logger.LogWarning(
+                "yt-dlp metadata probe exited {ExitCode} for {Url}. Stderr tail: {Stderr}",
+                probe.ExitCode, url, Tail(probe.Stderr, 500));
+            // Non-zero on the probe is usually an extractor error (private video, geo-blocked,
+            // members-only). Surface as ImportSourceRejectedException with the unavailable code
+            // so the worker doesn't waste retry attempts.
+            throw new ImportSourceRejectedException(
+                reason: ClipFailureReasons.SourceUnavailable,
+                message: "Source is unavailable (private, geo-blocked, or removed).");
+        }
+
+        return ParseFirstJson(probe.Stdout);
+    }
+
+    private static ImportedMedia? ParseFirstJson(string stdout)
+    {
+        // yt-dlp may emit banner / deprecation lines before the JSON object, so scan every
+        // line and pick the first one that parses to a JSON object with a 'title' or similar.
+        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (line.Length == 0 || line[0] != '{') continue;
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+                return new ImportedMedia(
+                    Title: GetStringOrNull(root, "title"),
+                    DurationSecs: GetIntOrNull(root, "duration"),
+                    Width: GetIntOrNull(root, "width"),
+                    Height: GetIntOrNull(root, "height"),
+                    ThumbnailUrl: GetStringOrNull(root, "thumbnail"));
+            }
+            catch (JsonException)
+            {
+                // Try the next line.
+            }
+        }
+        return null;
+    }
+
+    private static string? GetStringOrNull(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    private static int? GetIntOrNull(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var prop)) return null;
+        return prop.ValueKind switch
+        {
+            JsonValueKind.Number when prop.TryGetInt32(out var i) => i,
+            JsonValueKind.Number when prop.TryGetDouble(out var d) => (int)Math.Round(d),
+            _ => null,
+        };
+    }
+
+    private static string Tail(string s, int max) =>
+        string.IsNullOrEmpty(s) || s.Length <= max ? s : "..." + s[^max..];
+}

--- a/server/src/GankedTV.Api/Services/Media/ImportWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/ImportWorker.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.Json;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.Clips;
@@ -61,7 +63,11 @@ public sealed class ImportWorker : MediaStageWorker<ClaimedImportJob>
 
     protected override Task FailAsync(IServiceProvider scope, ClaimedImportJob job, CancellationToken ct) =>
         scope.GetRequiredService<IClipMediaJobStore>()
-            .MarkFailedAsync(job.ClipId, job.AttemptNumber, ClipStatuses.Importing, ct);
+            // Retries exhausted with a non-rejection error (timeout, transient extractor
+            // failure, etc.) — surface as 'fetch_failed'. Pre-flight rejections (too long /
+            // unavailable) write their own structured reasons via the catch in ProcessAsync.
+            .MarkFailedAsync(job.ClipId, job.AttemptNumber, ClipStatuses.Importing, ct,
+                reason: ClipFailureReasons.FetchFailed);
 
     protected override async Task ProcessAsync(
         IServiceProvider scope,
@@ -125,8 +131,13 @@ public sealed class ImportWorker : MediaStageWorker<ClaimedImportJob>
                 {
                     try
                     {
+                        // Status filter mirrors MarkFailedAsync's attempt+status guard: if a
+                        // racing worker has already moved the row past 'failed' (unlikely but
+                        // possible during shutdown / re-claim windows), we must not clobber
+                        // its duration. The row was just flipped to 'failed' above, so the
+                        // common path matches.
                         await scope.GetRequiredService<GankedTvDbContext>()
-                            .Clips.Where(c => c.Id == job.ClipId)
+                            .Clips.Where(c => c.Id == job.ClipId && c.Status == ClipStatuses.Failed)
                             .ExecuteUpdateAsync(s => s
                                 .SetProperty(c => c.DurationSecs, (short)actualDur), ct);
                     }
@@ -222,13 +233,12 @@ public sealed class ImportWorker : MediaStageWorker<ClaimedImportJob>
         {
             var result = await ffmpeg.RunAsync(opts.FfprobePath, args, opts.ProcessTimeout, ct);
             if (result.ExitCode != 0) return null;
-            using var doc = System.Text.Json.JsonDocument.Parse(result.Stdout);
+            using var doc = JsonDocument.Parse(result.Stdout);
             if (!doc.RootElement.TryGetProperty("format", out var format)) return null;
             if (!format.TryGetProperty("duration", out var prop)) return null;
             // ffprobe emits duration as a string in JSON ("123.456").
-            var raw = prop.ValueKind == System.Text.Json.JsonValueKind.String ? prop.GetString() : null;
-            return double.TryParse(raw, System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var seconds)
+            var raw = prop.ValueKind == JsonValueKind.String ? prop.GetString() : null;
+            return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds)
                 ? (int)Math.Ceiling(seconds)
                 : null;
         }

--- a/server/src/GankedTV.Api/Services/Media/ImportWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/ImportWorker.cs
@@ -1,0 +1,240 @@
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Services.Media.Import;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Validation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace GankedTV.Api.Services.Media;
+
+// Stage 0 (URL-import): claims 'importing' rows, shells out to yt-dlp to pull the source into
+// a temp file, uploads the bytes to S3 at the clip's VideoKey, and advances status to
+// 'processing'. From there the existing ThumbnailWorker → CompressWorker chain takes over
+// unchanged. Inherits MediaStageWorker<ClaimedImportJob> directly (not ClipStageWorker)
+// because the import claim returns a richer record (ImportSourceUrl + Title).
+public sealed class ImportWorker : MediaStageWorker<ClaimedImportJob>
+{
+    private readonly ILogger<ImportWorker> _logger;
+
+    public ImportWorker(
+        IServiceScopeFactory scopeFactory,
+        IFfmpegRunner ffmpeg,
+        IOptionsMonitor<MediaJobOptions> options,
+        ILogger<ImportWorker> logger)
+        : base(scopeFactory, ffmpeg, options, logger)
+    {
+        _logger = logger;
+    }
+
+    protected override string StageName => "import";
+
+    // Two gates: pipeline-level (Import.Enabled — covers operator kill-switch) AND
+    // instance-level (Import.WorkerEnabled — covers the GPU-host split). Either off → exit.
+    protected override bool IsWorkerEnabled(MediaJobOptions opts) =>
+        opts.Import.Enabled && opts.Import.WorkerEnabled;
+
+    // Boot-time probe extends the base ffmpeg/ffprobe checks with yt-dlp so a missing
+    // binary surfaces as a single startup warning instead of one failed clip after another
+    // with no obvious cause.
+    protected override async Task ProbeBinariesAsync(MediaJobOptions opts, CancellationToken ct)
+    {
+        await base.ProbeBinariesAsync(opts, ct);
+        await ProbeOneAsync(opts.Import.YtdlpPath, ct);
+    }
+
+    protected override Guid ClipIdOf(ClaimedImportJob job) => job.ClipId;
+    protected override int AttemptOf(ClaimedImportJob job) => job.AttemptNumber;
+
+    protected override Task<ClaimedImportJob?> ClaimAsync(
+        IServiceProvider scope,
+        MediaJobOptions opts,
+        CancellationToken ct) =>
+        scope.GetRequiredService<IClipMediaJobStore>()
+            .ClaimNextImportAsync(opts.LeaseDuration, opts.MaxAttempts, ct);
+
+    protected override Task ReleaseAsync(IServiceProvider scope, ClaimedImportJob job, CancellationToken ct) =>
+        scope.GetRequiredService<IClipMediaJobStore>()
+            .ReleaseLeaseAsync(job.ClipId, job.AttemptNumber, ClipStatuses.Importing, ct);
+
+    protected override Task FailAsync(IServiceProvider scope, ClaimedImportJob job, CancellationToken ct) =>
+        scope.GetRequiredService<IClipMediaJobStore>()
+            .MarkFailedAsync(job.ClipId, job.AttemptNumber, ClipStatuses.Importing, ct);
+
+    protected override async Task ProcessAsync(
+        IServiceProvider scope,
+        ClaimedImportJob job,
+        MediaJobOptions opts,
+        CancellationToken ct)
+    {
+        // Defence in depth: a config flip between submit and dequeue could otherwise let an
+        // attacker-supplied host sneak past. Same validator the endpoint uses.
+        var validator = scope.GetRequiredService<IClipImportUrlValidator>();
+        if (!validator.TryParse(job.ImportSourceUrl, out var url, out _))
+        {
+            throw new InvalidOperationException(
+                $"Import URL no longer passes validation for clip={job.ClipId}.");
+        }
+
+        var validation = scope.GetRequiredService<IOptions<ClipValidationOptions>>().Value;
+        var source = scope.GetRequiredService<IClipImportSource>();
+        var storage = scope.GetRequiredService<IObjectStorageService>();
+        var bucket = scope.GetRequiredService<IOptionsMonitor<S3Options>>().CurrentValue.ClipsBucket;
+        var store = scope.GetRequiredService<IClipMediaJobStore>();
+
+        // Per-attempt token in the temp filename so a re-claimed lease can't collide on the
+        // same path. Mirrors the pattern in ThumbnailJobService.
+        var tempFile = Path.Combine(
+            Path.GetTempPath(),
+            $"gankedtv-import-{job.ClipId:N}-{Guid.NewGuid():N}.mp4");
+
+        try
+        {
+            var fetchOpts = new ImportFetchOptions(
+                MaxBytes: validation.MaxUploadSizeBytes,
+                MaxDurationSecs: validation.MaxClipDurationSecs);
+            ImportedMedia media;
+            try
+            {
+                media = await source.FetchAsync(url, tempFile, fetchOpts, ct);
+                // ProcessAsync continues below — moved post-download checks into the inner try
+                // so an authoritative ffprobe rejection (duration > cap, regardless of what
+                // yt-dlp reported) is handled the same way as a pre-flight rejection: fail-fast,
+                // persist the actual duration, no retries.
+                await ProcessDownloadedAsync(scope, job, opts, validation, tempFile, media, bucket, storage, store, ct);
+                return;
+            }
+            catch (ImportSourceRejectedException ex)
+            {
+                // Non-transient: retrying won't help (cap won't change between attempts). Persist
+                // the real duration onto the row when the probe reported it so the status endpoint
+                // can surface "your clip is X seconds, max Y" instead of a generic message; then
+                // mark the row 'failed' with the structured reason. Return early — the base's
+                // release/fail logic skips because the row no longer matches 'importing'.
+                _logger.LogInformation(
+                    "Import for clip={ClipId} rejected: reason={Reason} ({Message})",
+                    job.ClipId, ex.Reason, ex.Message);
+                // Mark the row 'failed' FIRST so the polling client sees the outcome even if
+                // the duration write below trips (the duration update is a UX nice-to-have, not
+                // load-bearing). Best-effort try around the duration write keeps a missing
+                // DbContext / DB hiccup from masking the actual rejection.
+                await store.MarkFailedAsync(job.ClipId, job.AttemptNumber, ClipStatuses.Importing, ct, reason: ex.Reason);
+                if (ex.ActualDurationSecs is { } actualDur && actualDur > 0 && actualDur <= short.MaxValue)
+                {
+                    try
+                    {
+                        await scope.GetRequiredService<GankedTvDbContext>()
+                            .Clips.Where(c => c.Id == job.ClipId)
+                            .ExecuteUpdateAsync(s => s
+                                .SetProperty(c => c.DurationSecs, (short)actualDur), ct);
+                    }
+                    catch (Exception writeEx)
+                    {
+                        _logger.LogWarning(writeEx,
+                            "Could not persist actual duration={Dur}s onto failed clip={ClipId}; the wizard will show generic copy.",
+                            actualDur, job.ClipId);
+                    }
+                }
+                return;
+            }
+        }
+        finally
+        {
+            // Best-effort cleanup — the temp file is replaceable, so a failed delete here is
+            // not worth bubbling up over the work that just succeeded.
+            try { if (File.Exists(tempFile)) File.Delete(tempFile); }
+            catch { }
+        }
+    }
+
+    private static async Task ProcessDownloadedAsync(
+        IServiceProvider scope,
+        ClaimedImportJob job,
+        MediaJobOptions opts,
+        ClipValidationOptions validation,
+        string tempFile,
+        ImportedMedia media,
+        string bucket,
+        IObjectStorageService storage,
+        IClipMediaJobStore store,
+        CancellationToken ct)
+    {
+        var info = new FileInfo(tempFile);
+        // Belt-and-suspenders: yt-dlp's --max-filesize aborts mid-download when the upstream
+        // exposes a known size, but some extractors only know the size after the fact. A
+        // post-download check catches the rest before we burn an S3 PUT on an over-cap file.
+        if (info.Length > validation.MaxUploadSizeBytes)
+        {
+            throw new ImportSourceRejectedException(
+                reason: ClipFailureReasons.SourceTooLarge,
+                message: $"Fetched source is {info.Length} bytes; limit is {validation.MaxUploadSizeBytes}.");
+        }
+        if (info.Length <= 0)
+        {
+            throw new ImportFetchException("yt-dlp produced an empty file.");
+        }
+        // yt-dlp's reported duration is best-effort — some extractors omit it entirely,
+        // so we can't rely on the metadata probe alone. ffprobe the actual downloaded
+        // file: this is the authoritative duration check that nothing can bypass.
+        var ffmpeg = scope.GetRequiredService<IFfmpegRunner>();
+        var probedDuration = await ProbeDurationAsync(ffmpeg, tempFile, opts, ct);
+        if (probedDuration is { } realDur && realDur > validation.MaxClipDurationSecs)
+        {
+            throw new ImportSourceRejectedException(
+                reason: ClipFailureReasons.SourceTooLong,
+                message: $"Source duration {realDur}s exceeds cap {validation.MaxClipDurationSecs}s.",
+                actualDurationSecs: realDur);
+        }
+
+        await using (var stream = File.OpenRead(tempFile))
+        {
+            await storage.PutObjectAsync(bucket, job.VideoKey, stream, "video/mp4", ct);
+        }
+
+        await store.AdvanceImportAsync(
+            job.ClipId,
+            job.AttemptNumber,
+            info.Length,
+            media.Title,
+            ClipImportDefaults.PlaceholderTitle,
+            ct);
+    }
+
+    // Minimal ffprobe wrapper: returns the duration in whole seconds, or null when ffprobe
+    // can't determine it (corrupted file, missing ffprobe, etc.). We use the format-level
+    // duration which is more reliable than the stream-level field for containers like webm.
+    private static async Task<int?> ProbeDurationAsync(
+        IFfmpegRunner ffmpeg,
+        string filePath,
+        MediaJobOptions opts,
+        CancellationToken ct)
+    {
+        var args = new[]
+        {
+            "-v", "error",
+            "-print_format", "json",
+            "-show_format",
+            filePath,
+        };
+        try
+        {
+            var result = await ffmpeg.RunAsync(opts.FfprobePath, args, opts.ProcessTimeout, ct);
+            if (result.ExitCode != 0) return null;
+            using var doc = System.Text.Json.JsonDocument.Parse(result.Stdout);
+            if (!doc.RootElement.TryGetProperty("format", out var format)) return null;
+            if (!format.TryGetProperty("duration", out var prop)) return null;
+            // ffprobe emits duration as a string in JSON ("123.456").
+            var raw = prop.ValueKind == System.Text.Json.JsonValueKind.String ? prop.GetString() : null;
+            return double.TryParse(raw, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var seconds)
+                ? (int)Math.Ceiling(seconds)
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/server/src/GankedTV.Api/Services/Media/MediaJobOptions.cs
+++ b/server/src/GankedTV.Api/Services/Media/MediaJobOptions.cs
@@ -97,6 +97,44 @@ public sealed class MediaJobOptions
         new HlsRung { Height = 720, VideoKbps = 2800, MaxrateKbps = 2996, AudioKbps = 128 },
         new HlsRung { Height = 480, VideoKbps = 1400, MaxrateKbps = 1498, AudioKbps = 96 },
     ];
+
+    // --- URL import (issue #106) --------------------------------------------------------
+    // The /clips/import endpoint inserts a row with status='importing' and returns. The
+    // ImportWorker claims it, shells out to yt-dlp to fetch the source, writes the bytes to
+    // the clips bucket, and advances the row to 'processing' — at which point the existing
+    // thumbnail → compress → ready pipeline takes over with zero downstream changes. Size
+    // and duration caps come from ClipValidationOptions (same caps as direct upload).
+    public ImportOptions Import { get; set; } = new();
+}
+
+public sealed class ImportOptions
+{
+    // Pipeline-level toggle (parallels TranscodeEnabled). When false the endpoint 503s and the
+    // worker exits at startup. Lets operators disable URL ingestion entirely without removing
+    // yt-dlp from the host.
+    public bool Enabled { get; set; } = true;
+
+    // Whether this instance runs the ImportWorker BackgroundService. The fetch is I/O-bound
+    // (network + S3 PUT), so it belongs on the API host; the GPU box leaves this off.
+    public bool WorkerEnabled { get; set; } = true;
+
+    // Host-only allow-list (case-insensitive). The validator rejects any URL whose host isn't
+    // a member, both at the endpoint (fast 400) and inside the worker (defence in depth
+    // against config drift between submit and dequeue).
+    public List<string> AllowedHosts { get; set; } =
+    [
+        "youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be",
+        "medal.tv", "www.medal.tv",
+    ];
+
+    // Path to the yt-dlp binary — overridable via YTDLP_PATH for hosts where it lives outside
+    // the default PATH (e.g. a sidecar virtualenv install).
+    public string YtdlpPath { get; set; } = "yt-dlp";
+
+    // Hard ceiling on a single fetch — far larger than ProcessTimeout because a 500 MB pull
+    // over a slow extractor can legitimately take several minutes. A hung yt-dlp is killed
+    // and the row is released for retry.
+    public TimeSpan FetchTimeout { get; set; } = TimeSpan.FromMinutes(15);
 }
 
 public sealed class HlsRung

--- a/server/src/GankedTV.Api/Services/Media/MediaStageWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/MediaStageWorker.cs
@@ -102,13 +102,15 @@ public abstract class MediaStageWorker<TJob> : BackgroundService
         }
     }
 
-    private async Task ProbeBinariesAsync(MediaJobOptions opts, CancellationToken ct)
+    // Virtual so stages with extra binaries (e.g. ImportWorker → yt-dlp) can extend the
+    // boot probe without duplicating the loop / lease machinery.
+    protected virtual async Task ProbeBinariesAsync(MediaJobOptions opts, CancellationToken ct)
     {
         await ProbeOneAsync(opts.FfmpegPath, ct);
         await ProbeOneAsync(opts.FfprobePath, ct);
     }
 
-    private async Task ProbeOneAsync(string executable, CancellationToken ct)
+    protected async Task ProbeOneAsync(string executable, CancellationToken ct)
     {
         try
         {

--- a/server/src/GankedTV.Api/Services/Media/MediaStageWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/MediaStageWorker.cs
@@ -128,9 +128,13 @@ public abstract class MediaStageWorker<TJob> : BackgroundService
         }
         catch (Exception ex)
         {
+            // Generic message: this probe runs for every binary a stage depends on (ffmpeg,
+            // ffprobe, yt-dlp, …). Stage-specific remediation lives in the per-stage config
+            // (CLAUDE.md "Host requirements" lists the *_PATH envs) — here we just point at
+            // the missing executable + which stage needs it.
             _logger.LogWarning(ex,
-                "Could not invoke '{Executable}'. The {Stage} worker is enabled but jobs will fail until this is fixed. "
-                + "Install ffmpeg or set MediaJobs:FfmpegPath / MediaJobs:FfprobePath (env: FFMPEG_PATH / FFPROBE_PATH).",
+                "Could not invoke '{Executable}'. The {Stage} worker is enabled but jobs will fail "
+                + "until this binary is installed or the configured path is corrected.",
                 executable, StageName);
         }
     }

--- a/server/src/GankedTV.Api/Services/Media/ThumbnailJobService.cs
+++ b/server/src/GankedTV.Api/Services/Media/ThumbnailJobService.cs
@@ -66,7 +66,7 @@ public sealed class ThumbnailJobService : IThumbnailJobService
         {
             await ExtractFrameAsync(videoUrl, thumbPath, seekOffset, opts, ct);
 
-            var thumbnailKey = ClipUploadService.BuildThumbnailKey(job.UserId, job.ClipId, gameSlug);
+            var thumbnailKey = ClipKeys.BuildThumbnailKey(job.UserId, job.ClipId, gameSlug);
             await using (var stream = File.OpenRead(thumbPath))
             {
                 await _storage.PutObjectAsync(buckets.ThumbnailsBucket, thumbnailKey, stream, "image/jpeg", ct);

--- a/server/src/GankedTV.Api/Services/Media/ThumbnailWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/ThumbnailWorker.cs
@@ -20,6 +20,7 @@ public sealed class ThumbnailWorker : ClipStageWorker
 
     protected override string ClaimStatus => ClipStatuses.Processing;
     protected override string StageName => "thumbnail";
+    protected override string? TerminalFailureReason => ClipFailureReasons.ThumbnailFailed;
     protected override bool IsWorkerEnabled(MediaJobOptions opts) => opts.ThumbnailWorkerEnabled;
 
     protected override async Task ProcessAsync(

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsImportEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsImportEndpointsTests.cs
@@ -230,20 +230,30 @@ public class ClipsImportEndpointsTests : IAsyncLifetime
     [Fact]
     public async Task Preview_UnsupportedHost_Returns400_WithoutInvokingSource()
     {
-        // URL allow-list runs BEFORE the import source is touched. Verifies callers can't
-        // burn yt-dlp invocations on disallowed hosts by spamming /preview.
+        // URL allow-list runs BEFORE the import source is touched. Register a substitute
+        // IClipImportSource and assert ProbeAsync was never called — otherwise a future
+        // refactor that accidentally reorders the validator and the probe would let
+        // attackers burn yt-dlp invocations on disallowed hosts by spamming /preview.
         await _fx.ResetAsync();
         var (_, token) = await SeedUserAndIssueTokenAsync();
-        using var client = ClientWithBearer(token);
+
+        var source = Substitute.For<GankedTV.Api.Services.Media.Import.IClipImportSource>();
+        await using var factory = new AuthApiFactory(
+            _fx.ConnectionString,
+            _storage,
+            configureServices: s =>
+            {
+                s.RemoveAll<GankedTV.Api.Services.Media.Import.IClipImportSource>();
+                s.AddSingleton(source);
+            });
+        using var client = AuthTestHelpers.CreateBearerClient(factory, token);
 
         var resp = await client.PostAsJsonAsync("/clips/import/preview", new { url = "https://vimeo.com/x" });
 
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
         body.GetProperty("code").GetString().Should().Be("unsupported_host");
-        // ProbeAsync was never wired in this factory (the default uses YtDlpImportSource),
-        // and the host check short-circuits before yt-dlp would be invoked — so the test
-        // doesn't need a custom source registration to assert correctness of the gate.
+        await source.DidNotReceive().ProbeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsImportEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsImportEndpointsTests.cs
@@ -6,6 +6,8 @@ using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
 
 namespace GankedTV.Api.Tests.Integration.Endpoints;
@@ -188,5 +190,119 @@ public class ClipsImportEndpointsTests : IAsyncLifetime
             var statusResp = await otherClient.GetAsync($"/clips/{id}/status");
             statusResp.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
+    }
+
+    [Fact]
+    public async Task Status_FailedClipWithReason_ExposesFailureReasonAndDuration()
+    {
+        // The wizard renders "Clip is X — max allowed is Y" only when the status endpoint
+        // returns failureReason + durationSecs. This locks in that contract end-to-end so
+        // the worker's MarkFailedAsync writes don't silently stop being surfaced.
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        var clipId = await SeedFailedClipAsync(userId,
+            failureReason: ClipFailureReasons.SourceTooLong, durationSecs: 240);
+
+        using var client = ClientWithBearer(token);
+        var resp = await client.GetAsync($"/clips/{clipId}/status");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("status").GetString().Should().Be(ClipStatuses.Failed);
+        body.GetProperty("failureReason").GetString().Should().Be(ClipFailureReasons.SourceTooLong);
+        body.GetProperty("durationSecs").GetInt32().Should().Be(240);
+        body.GetProperty("maxClipDurationSecs").GetInt32().Should().Be(120);
+    }
+
+    // --- Preview endpoint --------------------------------------------------------------
+
+    [Fact]
+    public async Task Preview_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/clips/import/preview", new { url = "https://medal.tv/x" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Preview_UnsupportedHost_Returns400_WithoutInvokingSource()
+    {
+        // URL allow-list runs BEFORE the import source is touched. Verifies callers can't
+        // burn yt-dlp invocations on disallowed hosts by spamming /preview.
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips/import/preview", new { url = "https://vimeo.com/x" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("unsupported_host");
+        // ProbeAsync was never wired in this factory (the default uses YtDlpImportSource),
+        // and the host check short-circuits before yt-dlp would be invoked — so the test
+        // doesn't need a custom source registration to assert correctness of the gate.
+    }
+
+    [Fact]
+    public async Task Preview_AllowedUrl_ReturnsMetadata()
+    {
+        // End-to-end test of the preview endpoint with a substitute import source so the
+        // test doesn't hit YouTube/Medal. Replaces IClipImportSource via the factory's
+        // configureServices hook.
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+
+        var source = Substitute.For<GankedTV.Api.Services.Media.Import.IClipImportSource>();
+        source.ProbeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GankedTV.Api.Services.Media.Import.ImportedMedia(
+                "Probed Title", 42, 1280, 720, "https://i.ytimg.com/vi/x/hqdefault.jpg"));
+
+        await using var factory = new AuthApiFactory(
+            _fx.ConnectionString,
+            _storage,
+            configureServices: s =>
+            {
+                s.RemoveAll<GankedTV.Api.Services.Media.Import.IClipImportSource>();
+                s.AddSingleton(source);
+            });
+        using var client = AuthTestHelpers.CreateBearerClient(factory, token);
+
+        var resp = await client.PostAsJsonAsync("/clips/import/preview",
+            new { url = "https://www.youtube.com/watch?v=abc" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("title").GetString().Should().Be("Probed Title");
+        body.GetProperty("durationSecs").GetInt32().Should().Be(42);
+        body.GetProperty("thumbnailUrl").GetString().Should().Be("https://i.ytimg.com/vi/x/hqdefault.jpg");
+        body.GetProperty("maxClipDurationSecs").GetInt32().Should().Be(120);
+    }
+
+    // --- Helpers -----------------------------------------------------------------------
+
+    private async Task<Guid> SeedFailedClipAsync(Guid userId, string failureReason, short? durationSecs)
+    {
+        await using var db = _fx.CreateContext();
+        var clip = new Clip
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Title = "failed seed",
+            VideoKey = $"{userId}/x.mp4",
+            ShareCode = GankedTV.Api.Clips.ShareCodeGenerator.Next(),
+            Status = ClipStatuses.Failed,
+            Visibility = "public",
+            FailureReason = failureReason,
+            DurationSecs = durationSecs,
+            ImportSourceUrl = "https://www.youtube.com/watch?v=abc",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.Clips.Add(clip);
+        await db.SaveChangesAsync();
+        return clip.Id;
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsImportEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsImportEndpointsTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Integration.Endpoints;
+
+[Collection("Postgres")]
+public class ClipsImportEndpointsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fx;
+    private AuthApiFactory? _factory;
+    private IObjectStorageService _storage = null!;
+
+    public ClipsImportEndpointsTests(PostgresFixture fx) => _fx = fx;
+
+    public Task InitializeAsync()
+    {
+        _storage = Substitute.For<IObjectStorageService>();
+        _factory = new AuthApiFactory(_fx.ConnectionString, _storage);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+    }
+
+    private Task<(Guid userId, string token)> SeedUserAndIssueTokenAsync(string username = "importer") =>
+        AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, username);
+
+    private HttpClient ClientWithBearer(string token) =>
+        AuthTestHelpers.CreateBearerClient(_factory!, token);
+
+    [Fact]
+    public async Task Import_NoBearer_Returns401()
+    {
+        await _fx.ResetAsync();
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/clips/import", new { url = "https://medal.tv/x" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Import_AllowedHost_CreatesImportingRow()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips/import", new
+        {
+            url = "https://medal.tv/clips/abc123",
+            title = "epic frag",
+            visibility = "public",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var id = body.GetProperty("id").GetGuid();
+        body.GetProperty("status").GetString().Should().Be(ClipStatuses.Importing);
+
+        await using var db = _fx.CreateContext();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == id);
+        clip.UserId.Should().Be(userId);
+        clip.Status.Should().Be(ClipStatuses.Importing);
+        clip.Title.Should().Be("epic frag");
+        clip.ImportSourceUrl.Should().Be("https://medal.tv/clips/abc123");
+    }
+
+    [Fact]
+    public async Task Import_NoTitle_PlaceholderApplied()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips/import", new
+        {
+            url = "https://www.youtube.com/watch?v=abc",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var id = body.GetProperty("id").GetGuid();
+
+        await using var db = _fx.CreateContext();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == id);
+        clip.Title.Should().Be("Importing…");
+    }
+
+    [Fact]
+    public async Task Import_UnsupportedHost_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips/import", new
+        {
+            url = "https://vimeo.com/clip/xyz",
+            title = "elsewhere",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("unsupported_host");
+    }
+
+    [Fact]
+    public async Task Import_HttpScheme_Returns400()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips/import", new
+        {
+            url = "http://www.youtube.com/watch?v=x",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("code").GetString().Should().Be("invalid_url");
+    }
+
+    [Fact]
+    public async Task Import_NullBody_Returns400ValidationProblem()
+    {
+        await _fx.ResetAsync();
+        var (_, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsync("/clips/import",
+            new StringContent("null", System.Text.Encoding.UTF8, "application/json"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Status_Owner_ReturnsCurrentStatus()
+    {
+        await _fx.ResetAsync();
+        var (userId, token) = await SeedUserAndIssueTokenAsync();
+        using var client = ClientWithBearer(token);
+
+        var resp = await client.PostAsJsonAsync("/clips/import", new
+        {
+            url = "https://medal.tv/clips/x",
+        });
+        resp.EnsureSuccessStatusCode();
+        var id = (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetGuid();
+
+        var statusResp = await client.GetAsync($"/clips/{id}/status");
+        statusResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await statusResp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("id").GetGuid().Should().Be(id);
+        body.GetProperty("status").GetString().Should().Be(ClipStatuses.Importing);
+        body.GetProperty("shareCode").GetString().Should().NotBeNullOrEmpty();
+
+        // Discard 'userId' warning suppression — used implicitly to scope ownership.
+        _ = userId;
+    }
+
+    [Fact]
+    public async Task Status_OtherUser_Returns404()
+    {
+        await _fx.ResetAsync();
+        var (_, ownerToken) = await SeedUserAndIssueTokenAsync("owner");
+        using (var ownerClient = ClientWithBearer(ownerToken))
+        {
+            var resp = await ownerClient.PostAsJsonAsync("/clips/import", new
+            {
+                url = "https://medal.tv/clips/x",
+            });
+            resp.EnsureSuccessStatusCode();
+            var id = (await resp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetGuid();
+
+            var (_, otherToken) = await SeedUserAndIssueTokenAsync("other");
+            using var otherClient = ClientWithBearer(otherToken);
+            var statusResp = await otherClient.GetAsync($"/clips/{id}/status");
+            statusResp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ClipsReadEndpointsTests.cs
@@ -45,7 +45,8 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
         string visibility = "public",
         string? title = null,
         int? gameId = null,
-        string? videoCodec = null)
+        string? videoCodec = null,
+        string? importSourceUrl = null)
     {
         var id = Guid.NewGuid();
         var shareCode = ShareCodeGenerator.Next();
@@ -66,6 +67,7 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             Width = 1920,
             Height = 1080,
             FileSizeBytes = 1_000_000,
+            ImportSourceUrl = importSourceUrl,
             CreatedAt = createdAt,
             UpdatedAt = createdAt,
         });
@@ -840,6 +842,51 @@ public class ClipsReadEndpointsTests : IAsyncLifetime
             Arg.Any<string>(),
             $"{userId}/{clipId}.mp4",
             Arg.Is<TimeSpan?>(ts => ts.HasValue && ts.Value == TimeSpan.FromHours(1)));
+    }
+
+    [Fact]
+    public async Task Detail_ImportedClip_ReturnsImportSourceUrl()
+    {
+        // Imported clips carry the original URL on Clip.ImportSourceUrl. The detail endpoint
+        // must expose it so the web "Imported from {host}" attribution badge can render.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("importer");
+        var (clipId, _) = await SeedClipAsync(
+            userId, DateTimeOffset.UtcNow,
+            importSourceUrl: "https://www.youtube.com/watch?v=abc123");
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://minio.local/x");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("importSourceUrl").GetString()
+            .Should().Be("https://www.youtube.com/watch?v=abc123");
+    }
+
+    [Fact]
+    public async Task Detail_DirectUpload_ReturnsNullImportSourceUrl()
+    {
+        // Direct-upload clips never set ImportSourceUrl. The detail response field must be
+        // present (so the front-end's null-guard works) and explicitly null — JSON `null`,
+        // not an omitted property.
+        await _fx.ResetAsync();
+        var (userId, _) = await SeedUserAndIssueTokenAsync("uploader");
+        var (clipId, _) = await SeedClipAsync(userId, DateTimeOffset.UtcNow);
+
+        _storage.GetPresignedGetUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>())
+            .Returns("https://minio.local/x");
+
+        using var client = _factory!.CreateClient();
+        var resp = await client.GetAsync($"/clips/{clipId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.TryGetProperty("importSourceUrl", out var prop).Should().BeTrue();
+        prop.ValueKind.Should().Be(JsonValueKind.Null);
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Integration/Media/ClipMediaJobStoreIntegrationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Media/ClipMediaJobStoreIntegrationTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using GankedTV.Api.Clips;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Clips;
 using GankedTV.Api.Services.Media;
 using GankedTV.Api.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
@@ -520,5 +521,127 @@ public class ClipMediaJobStoreIntegrationTests
         clip.ProcessingStartedAt.Should().NotBeNull();
         clip.ProcessingStartedAt!.Value.Should().BeCloseTo(bLeaseStart, TimeSpan.FromMicroseconds(1));
         clip.ProcessingAttempts.Should().Be(3);
+    }
+
+    // --- Import stage (issue #106) ----------------------------------------------------
+
+    private async Task<Guid> SeedImportingClipAsync(
+        Guid userId,
+        DateTimeOffset updatedAt,
+        string url = "https://medal.tv/clips/x",
+        string title = "imported title")
+    {
+        await using var db = NewContext();
+        var clip = new Clip
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Title = title,
+            VideoKey = $"{userId}/v.mp4",
+            ShareCode = ShareCodeGenerator.Next(),
+            Status = ClipStatuses.Importing,
+            ImportSourceUrl = url,
+            CreatedAt = updatedAt,
+            UpdatedAt = updatedAt,
+        };
+        db.Clips.Add(clip);
+        await db.SaveChangesAsync();
+        return clip.Id;
+    }
+
+    [Fact]
+    public async Task ClaimNextImportAsync_PicksImportingClipAndReturnsUrl()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("oscar");
+        var now = DateTimeOffset.UtcNow;
+        var clipId = await SeedImportingClipAsync(userId, now, "https://medal.tv/clips/abc");
+
+        await using var db = NewContext();
+        var store = NewStore(now, db);
+
+        var result = await store.ClaimNextImportAsync(TimeSpan.FromMinutes(5), 3, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ClipId.Should().Be(clipId);
+        result.ImportSourceUrl.Should().Be("https://medal.tv/clips/abc");
+        result.AttemptNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ClaimNextImportAsync_IgnoresOtherStatuses()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("paula");
+        var now = DateTimeOffset.UtcNow;
+        // A 'processing' clip must be invisible to the import claim — the partial index is
+        // scoped to status='importing'.
+        await SeedClipAsync(userId, ClipStatuses.Processing, now);
+
+        await using var db = NewContext();
+        var store = NewStore(now, db);
+        var result = await store.ClaimNextImportAsync(TimeSpan.FromMinutes(5), 3, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AdvanceImportAsync_AdvancesToProcessing_AndOverwritesPlaceholderTitle()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("queen");
+        var now = DateTimeOffset.UtcNow;
+        var clipId = await SeedImportingClipAsync(userId, now, title: ClipImportDefaults.PlaceholderTitle);
+
+        await using var db = NewContext();
+        var store = NewStore(now, db);
+        // Pretend the worker had bumped attempts via a claim — set the row's attempt to 1
+        // so the expectedAttempt guard inside AdvanceImportAsync passes.
+        await db.Clips.Where(c => c.Id == clipId)
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.ProcessingAttempts, 1));
+
+        await store.AdvanceImportAsync(
+            clipId,
+            expectedAttempt: 1,
+            fileSizeBytes: 1024,
+            extractorTitle: "Extractor Title",
+            placeholderTitle: ClipImportDefaults.PlaceholderTitle,
+            CancellationToken.None);
+
+        await using var verify = NewContext();
+        var clip = await verify.Clips.AsNoTracking().SingleAsync(c => c.Id == clipId);
+        clip.Status.Should().Be(ClipStatuses.Processing);
+        clip.FileSizeBytes.Should().Be(1024);
+        clip.Title.Should().Be("Extractor Title");
+        clip.ProcessingAttempts.Should().Be(0);
+        clip.ProcessingStartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AdvanceImportAsync_KeepsUserSuppliedTitle()
+    {
+        await _fx.ResetAsync();
+        var userId = await SeedUserAsync("ralph");
+        var now = DateTimeOffset.UtcNow;
+        var clipId = await SeedImportingClipAsync(userId, now, title: "My override");
+
+        await using var db = NewContext();
+        var store = NewStore(now, db);
+        await db.Clips.Where(c => c.Id == clipId)
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.ProcessingAttempts, 1));
+
+        await store.AdvanceImportAsync(
+            clipId,
+            expectedAttempt: 1,
+            fileSizeBytes: 2048,
+            extractorTitle: "Extractor Title",
+            placeholderTitle: ClipImportDefaults.PlaceholderTitle,
+            CancellationToken.None);
+
+        await using var verify = NewContext();
+        var clip = await verify.Clips.AsNoTracking().SingleAsync(c => c.Id == clipId);
+        clip.Status.Should().Be(ClipStatuses.Processing);
+        // User-supplied title is preserved because it didn't match the placeholder.
+        clip.Title.Should().Be("My override");
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Services/Clips/ClipImportServiceTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Clips/ClipImportServiceTests.cs
@@ -1,0 +1,225 @@
+using FluentAssertions;
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Services.Media;
+using GankedTV.Api.Services.Tags;
+using GankedTV.Api.Tests.TestSupport;
+using GankedTV.Api.Validation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace GankedTV.Api.Tests.Services.Clips;
+
+[Collection("Postgres")]
+public class ClipImportServiceTests
+{
+    private readonly PostgresFixture _fx;
+
+    public ClipImportServiceTests(PostgresFixture fx) => _fx = fx;
+
+    private async Task<(ClipImportService svc, GankedTvDbContext db, GankedTV.Api.Services.Media.Import.IClipImportSource source, Guid userId)> BuildAsync(
+        bool importEnabled = true)
+    {
+        await _fx.ResetAsync();
+        var db = _fx.CreateContext();
+
+        var userId = Guid.NewGuid();
+        db.Users.Add(new User
+        {
+            Id = userId,
+            Username = "import-user",
+            Email = "import-user@example.com",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+
+        var validator = new ClipImportUrlValidator(MonitorWith(new MediaJobOptions()));
+        var tagsResolver = new TagsResolver(db, TimeProvider.System);
+        var mediaOpts = MonitorWith(new MediaJobOptions { Import = new ImportOptions { Enabled = importEnabled } });
+        // SubmitAsync doesn't touch the import source, so a stub is fine here. PreviewAsync
+        // tests below explicitly configure ProbeAsync on the substitute when needed.
+        var source = Substitute.For<GankedTV.Api.Services.Media.Import.IClipImportSource>();
+
+        var svc = new ClipImportService(
+            db,
+            validator,
+            tagsResolver,
+            source,
+            Microsoft.Extensions.Options.Options.Create(new ClipValidationOptions()),
+            mediaOpts,
+            TimeProvider.System);
+        return (svc, db, source, userId);
+    }
+
+    private static IOptionsMonitor<MediaJobOptions> MonitorWith(MediaJobOptions options)
+    {
+        var m = Substitute.For<IOptionsMonitor<MediaJobOptions>>();
+        m.CurrentValue.Returns(options);
+        return m;
+    }
+
+    [Fact]
+    public async Task Submit_AllowedUrl_InsertsImportingRow()
+    {
+        var (svc, db, _, userId) = await BuildAsync();
+
+        var result = await svc.SubmitAsync(
+            userId,
+            new ImportClipInput("https://medal.tv/clips/abc", "epic", null, null, null, null),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == result.Value!.ClipId);
+        clip.Status.Should().Be(ClipStatuses.Importing);
+        clip.Title.Should().Be("epic");
+        clip.ImportSourceUrl.Should().Be("https://medal.tv/clips/abc");
+        clip.ShareCode.Should().NotBeNullOrEmpty();
+        clip.VideoKey.Should().Be($"{userId}/{clip.Id}.mp4");
+    }
+
+    [Fact]
+    public async Task Submit_NoTitle_UsesPlaceholder()
+    {
+        var (svc, db, _, userId) = await BuildAsync();
+
+        var result = await svc.SubmitAsync(
+            userId,
+            new ImportClipInput("https://medal.tv/x", null, null, null, null, null),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var clip = await db.Clips.AsNoTracking().SingleAsync(c => c.Id == result.Value!.ClipId);
+        clip.Title.Should().Be(ClipImportDefaults.PlaceholderTitle);
+    }
+
+    [Fact]
+    public async Task Submit_UnsupportedHost_ReturnsUnsupportedHostError()
+    {
+        var (svc, _, _, userId) = await BuildAsync();
+
+        var result = await svc.SubmitAsync(
+            userId,
+            new ImportClipInput("https://vimeo.com/x", null, null, null, null, null),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.UnsupportedHost);
+    }
+
+    [Fact]
+    public async Task Submit_InvalidUrl_ReturnsInvalidUrlError()
+    {
+        var (svc, _, _, userId) = await BuildAsync();
+
+        var result = await svc.SubmitAsync(
+            userId,
+            new ImportClipInput("not-a-url", null, null, null, null, null),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.InvalidUrl);
+    }
+
+    [Fact]
+    public async Task Submit_ImportDisabled_ReturnsImportDisabled()
+    {
+        var (svc, _, _, userId) = await BuildAsync(importEnabled: false);
+
+        var result = await svc.SubmitAsync(
+            userId,
+            new ImportClipInput("https://medal.tv/x", null, null, null, null, null),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.ImportDisabled);
+    }
+
+    [Fact]
+    public async Task Submit_InvalidVisibility_Returns400()
+    {
+        var (svc, _, _, userId) = await BuildAsync();
+
+        var result = await svc.SubmitAsync(
+            userId,
+            new ImportClipInput("https://medal.tv/x", "title", null, null, "secret", null),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.InvalidVisibility);
+    }
+
+    [Fact]
+    public async Task Submit_UnknownGameId_ReturnsInvalidGame()
+    {
+        var (svc, _, _, userId) = await BuildAsync();
+
+        var result = await svc.SubmitAsync(
+            userId,
+            new ImportClipInput("https://medal.tv/x", "title", null, 99_999, null, null),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.InvalidGame);
+    }
+
+    [Fact]
+    public async Task Preview_AllowedUrl_ReturnsMetadataAndCap()
+    {
+        var (svc, _, source, _) = await BuildAsync();
+        source.ProbeAsync("https://www.youtube.com/watch?v=abc", Arg.Any<CancellationToken>())
+            .Returns(new GankedTV.Api.Services.Media.Import.ImportedMedia(
+                "My Clip", 42, 1280, 720, "https://i.ytimg.com/vi/abc/maxresdefault.jpg"));
+
+        var result = await svc.PreviewAsync("https://www.youtube.com/watch?v=abc", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Title.Should().Be("My Clip");
+        result.Value.DurationSecs.Should().Be(42);
+        result.Value.MaxClipDurationSecs.Should().Be(120);
+        // The platform-resolved thumbnail must flow through — the wizard uses it as the
+        // preview poster for sources where the client-side YouTube fallback can't help
+        // (Medal.tv etc.).
+        result.Value.ThumbnailUrl.Should().Be("https://i.ytimg.com/vi/abc/maxresdefault.jpg");
+    }
+
+    [Fact]
+    public async Task Preview_UnsupportedHost_DoesNotCallSource()
+    {
+        var (svc, _, source, _) = await BuildAsync();
+
+        var result = await svc.PreviewAsync("https://vimeo.com/x", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.UnsupportedHost);
+        await source.DidNotReceive().ProbeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Preview_ImportDisabled_ReturnsImportDisabled()
+    {
+        var (svc, _, _, _) = await BuildAsync(importEnabled: false);
+
+        var result = await svc.PreviewAsync("https://medal.tv/x", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.ImportDisabled);
+    }
+
+    [Fact]
+    public async Task Preview_SourceRejected_ReturnsSourceUnavailable()
+    {
+        var (svc, _, source, _) = await BuildAsync();
+        source.ProbeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new GankedTV.Api.Services.Media.Import.ImportSourceRejectedException(
+                ClipFailureReasons.SourceUnavailable, "private"));
+
+        var result = await svc.PreviewAsync("https://www.youtube.com/watch?v=abc", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(ClipUploadError.SourceUnavailable);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Clips/ClipImportServiceTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Clips/ClipImportServiceTests.cs
@@ -51,7 +51,8 @@ public class ClipImportServiceTests
             source,
             Microsoft.Extensions.Options.Options.Create(new ClipValidationOptions()),
             mediaOpts,
-            TimeProvider.System);
+            TimeProvider.System,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ClipImportService>.Instance);
         return (svc, db, source, userId);
     }
 

--- a/server/tests/GankedTV.Api.Tests/Services/Clips/ClipImportUrlValidatorTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Clips/ClipImportUrlValidatorTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Services.Media;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace GankedTV.Api.Tests.Services.Clips;
+
+public class ClipImportUrlValidatorTests
+{
+    private static ClipImportUrlValidator Build(params string[] allowed)
+    {
+        var monitor = Substitute.For<IOptionsMonitor<MediaJobOptions>>();
+        var options = new MediaJobOptions();
+        options.Import.AllowedHosts = allowed.Length == 0 ? options.Import.AllowedHosts : allowed.ToList();
+        monitor.CurrentValue.Returns(options);
+        return new ClipImportUrlValidator(monitor);
+    }
+
+    [Theory]
+    [InlineData("https://medal.tv/clips/abc123")]
+    [InlineData("https://www.youtube.com/watch?v=abc")]
+    [InlineData("https://youtu.be/abc")]
+    public void TryParse_AllowedHost_ReturnsOk(string url)
+    {
+        var validator = Build();
+
+        var ok = validator.TryParse(url, out var normalised, out var error);
+
+        ok.Should().BeTrue();
+        normalised.Should().NotBeEmpty();
+        error.Should().Be(default);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com/x")]
+    public void TryParse_MalformedOrNonHttps_ReturnsInvalidUrl(string? url)
+    {
+        var validator = Build();
+
+        var ok = validator.TryParse(url, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Be(ImportUrlValidationError.InvalidUrl);
+    }
+
+    [Fact]
+    public void TryParse_HttpScheme_RejectsAsInvalidUrl()
+    {
+        var validator = Build();
+
+        var ok = validator.TryParse("http://www.youtube.com/x", out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Be(ImportUrlValidationError.InvalidUrl);
+    }
+
+    [Fact]
+    public void TryParse_DisallowedHost_ReturnsUnsupportedHost()
+    {
+        var validator = Build();
+
+        var ok = validator.TryParse("https://vimeo.com/clip/xyz", out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Be(ImportUrlValidationError.UnsupportedHost);
+    }
+
+    [Fact]
+    public void TryParse_StripsFragment_PreservesQueryString()
+    {
+        var validator = Build();
+
+        var ok = validator.TryParse("https://www.youtube.com/watch?v=abc#t=30", out var normalised, out _);
+
+        ok.Should().BeTrue();
+        normalised.Should().Contain("v=abc");
+        normalised.Should().NotContain("#");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Media/Import/YtDlpImportSourceTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Media/Import/YtDlpImportSourceTests.cs
@@ -1,0 +1,244 @@
+using FluentAssertions;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Media;
+using GankedTV.Api.Services.Media.Import;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace GankedTV.Api.Tests.Services.Media.Import;
+
+// Locks in the contract YtDlpImportSource has with the underlying yt-dlp binary. The fix for
+// the "all nulls" probe bug (yt-dlp's default --dump-single-json output is ~570KB for normal
+// YouTube videos, which overflows FfmpegRunner's 256KB capture buffer and gets truncated to
+// unparseable garbage) is enforced here: every yt-dlp invocation must use the field-subset
+// --print template so the captured JSON stays small.
+public class YtDlpImportSourceTests
+{
+    // Field-subset output template — keep in sync with YtDlpImportSource.CompactInfoTemplate.
+    // Hardcoded here on purpose so a future refactor that quietly switches back to
+    // --dump-single-json / --print-json fails this regression test instead of the next user
+    // who imports a YouTube clip. Thumbnail is included so the upload wizard can show a real
+    // preview frame for Medal.tv (where the client-side YouTube fallback doesn't apply).
+    private const string ExpectedTemplate = "%(.{title,duration,width,height,thumbnail})j";
+
+    private static (YtDlpImportSource source, IFfmpegRunner runner) Build()
+    {
+        var runner = Substitute.For<IFfmpegRunner>();
+        var monitor = Substitute.For<IOptionsMonitor<MediaJobOptions>>();
+        monitor.CurrentValue.Returns(new MediaJobOptions
+        {
+            Import = new ImportOptions { YtdlpPath = "yt-dlp", FetchTimeout = TimeSpan.FromMinutes(1) },
+            ProcessTimeout = TimeSpan.FromSeconds(30),
+        });
+        var source = new YtDlpImportSource(runner, monitor, NullLogger<YtDlpImportSource>.Instance);
+        return (source, runner);
+    }
+
+    private static FfmpegResult Ok(string stdout, string stderr = "") => new(0, stdout, stderr);
+
+    [Fact]
+    public async Task ProbeAsync_UsesCompactPrintTemplate_NotDumpSingleJson()
+    {
+        var (source, runner) = Build();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Ok("""{"title":"x","duration":30}"""));
+
+        await source.ProbeAsync("https://www.youtube.com/watch?v=abc", CancellationToken.None);
+
+        // Capture the argument list passed to yt-dlp and assert it carries the compact
+        // --print template. We deliberately also assert that none of the verbose flags are
+        // present — passing one of those WOULD make the probe regress to 500KB+ stdout.
+        var calls = runner.ReceivedCalls().ToList();
+        calls.Should().HaveCount(1);
+        var args = (IReadOnlyList<string>)calls[0].GetArguments()[1]!;
+        args.Should().Contain("--print");
+        args.Should().Contain(ExpectedTemplate);
+        args.Should().Contain("--skip-download");
+        args.Should().NotContain("--dump-single-json");
+        args.Should().NotContain("--dump-json");
+        args.Should().NotContain("--print-json");
+    }
+
+    [Fact]
+    public async Task FetchAsync_UsesCompactPrintTemplate_NotPrintJson()
+    {
+        var (source, runner) = Build();
+        // Probe call returns OK with no metadata; fetch call needs to write a file to the
+        // destination path passed in args[-2] of the second call so the post-download branch
+        // doesn't trip on "no file produced".
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(
+                ci => Ok("{}"),
+                ci =>
+                {
+                    var args = (IReadOnlyList<string>)ci[1]!;
+                    var dest = ResolveOutputArg(args);
+                    if (dest is not null) File.WriteAllBytes(dest, new byte[16]);
+                    return Ok("""{"title":"x","duration":30}""");
+                });
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"ytdlp-test-{Guid.NewGuid():N}.mp4");
+        try
+        {
+            await source.FetchAsync("https://www.youtube.com/watch?v=abc", tempFile,
+                new ImportFetchOptions(MaxBytes: 100_000_000, MaxDurationSecs: 120),
+                CancellationToken.None);
+
+            // The download (2nd) call is the one we care about — must use the compact template.
+            var downloadCall = runner.ReceivedCalls().Skip(1).First();
+            var downloadArgs = (IReadOnlyList<string>)downloadCall.GetArguments()[1]!;
+            downloadArgs.Should().Contain("--print");
+            downloadArgs.Should().Contain(ExpectedTemplate);
+            downloadArgs.Should().NotContain("--print-json");
+            downloadArgs.Should().NotContain("--dump-single-json");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ProbeAsync_ParsesCompactJson_ReturnsMetadata()
+    {
+        var (source, runner) = Build();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Ok("""{"title":"toad sings chandelier","duration":216,"width":1920,"height":1080,"thumbnail":"https://i.ytimg.com/vi/abc/maxresdefault.jpg"}"""));
+
+        var media = await source.ProbeAsync("https://www.youtube.com/watch?v=abc", CancellationToken.None);
+
+        media.Title.Should().Be("toad sings chandelier");
+        media.DurationSecs.Should().Be(216);
+        media.Width.Should().Be(1920);
+        media.Height.Should().Be(1080);
+        media.ThumbnailUrl.Should().Be("https://i.ytimg.com/vi/abc/maxresdefault.jpg");
+    }
+
+    [Fact]
+    public async Task ProbeAsync_MissingThumbnailField_ReturnsNullThumbnail()
+    {
+        // Some extractors don't expose a thumbnail. The probe must surface a null
+        // ThumbnailUrl rather than throw — the wizard falls back to the client-side
+        // YouTube-derived poster (or leaves it blank for Medal etc.).
+        var (source, runner) = Build();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Ok("""{"title":"x","duration":10}"""));
+
+        var media = await source.ProbeAsync("https://medal.tv/clips/foo", CancellationToken.None);
+
+        media.ThumbnailUrl.Should().BeNull();
+        media.Title.Should().Be("x");
+        media.DurationSecs.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_TruncatedJson_ReturnsAllNullsWithoutThrow()
+    {
+        // Simulates the original bug: FfmpegRunner truncates oversized stdout and appends
+        // "...(truncated)". The truncated suffix makes the JSON unparseable. The probe must
+        // handle this gracefully (return null fields) rather than throw — otherwise a single
+        // verbose extractor response wedges every import.
+        var (source, runner) = Build();
+        var truncatedJson = """{"title":"toad sings chandelier","duration":216,"formats":[{"format_id":"sb3""" + "...(truncated)";
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Ok(truncatedJson));
+
+        var media = await source.ProbeAsync("https://www.youtube.com/watch?v=abc", CancellationToken.None);
+
+        // None of the fields are recoverable from a broken JSON — better to return nulls and
+        // let the worker's authoritative ffprobe step (post-download) decide than to crash.
+        media.Title.Should().BeNull();
+        media.DurationSecs.Should().BeNull();
+        media.Width.Should().BeNull();
+        media.Height.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProbeAsync_NonZeroExit_ThrowsSourceUnavailable()
+    {
+        var (source, runner) = Build();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(new FfmpegResult(ExitCode: 1, Stdout: "", Stderr: "ERROR: Private video"));
+
+        var act = async () => await source.ProbeAsync("https://www.youtube.com/watch?v=abc", CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ImportSourceRejectedException>();
+        ex.Which.Reason.Should().Be(ClipFailureReasons.SourceUnavailable);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_BinaryMissing_ThrowsImportFetchException()
+    {
+        var (source, runner) = Build();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Throws(new System.ComponentModel.Win32Exception(2,
+                "An error occurred trying to start process 'yt-dlp'. No such file or directory"));
+
+        var act = async () => await source.ProbeAsync("https://www.youtube.com/watch?v=abc", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ImportFetchException>()
+            .WithMessage("*yt-dlp*not available*");
+    }
+
+    [Fact]
+    public async Task FetchAsync_ProbeDurationOverCap_ThrowsWithActualDuration()
+    {
+        // Pre-flight rejection: the metadata probe returns a duration above the requested cap.
+        // FetchAsync must throw ImportSourceRejectedException carrying the actual duration —
+        // no second yt-dlp call for the download should fire.
+        var (source, runner) = Build();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Ok("""{"title":"long","duration":300}"""));
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"ytdlp-test-{Guid.NewGuid():N}.mp4");
+        var act = async () => await source.FetchAsync("https://www.youtube.com/watch?v=abc", tempFile,
+            new ImportFetchOptions(MaxBytes: 100_000_000, MaxDurationSecs: 120),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ImportSourceRejectedException>();
+        ex.Which.Reason.Should().Be(ClipFailureReasons.SourceTooLong);
+        ex.Which.ActualDurationSecs.Should().Be(300);
+        // Probe was called; the download call must NOT have fired.
+        runner.ReceivedCalls().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task FetchAsync_NoOutputFile_ThrowsImportFetchException()
+    {
+        // Pass 1 (probe) returns OK with no duration. Pass 2 (download) exits 0 but doesn't
+        // write a file — yt-dlp does this for live streams / members-only content even when
+        // it doesn't print an explicit error.
+        var (source, runner) = Build();
+        runner.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Ok("{}"), Ok("{}"));
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"ytdlp-test-missing-{Guid.NewGuid():N}.mp4");
+        var act = async () => await source.FetchAsync("https://www.youtube.com/watch?v=abc", tempFile,
+            new ImportFetchOptions(MaxBytes: 100_000_000, MaxDurationSecs: 120),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ImportFetchException>().WithMessage("*produced no output*");
+    }
+
+    // Helpers ---------------------------------------------------------------------------
+
+    private static string? ResolveOutputArg(IReadOnlyList<string> args)
+    {
+        for (var i = 0; i < args.Count - 1; i++)
+        {
+            if (args[i] == "-o") return args[i + 1];
+        }
+        return null;
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
@@ -22,7 +22,12 @@ public class ImportWorkerTests
         IObjectStorageService Storage,
         IClipImportUrlValidator Validator);
 
-    private static Harness Build(MediaJobOptions? options = null, ClipValidationOptions? validation = null)
+    // ffprobeStdout, when non-null, replaces the default empty-JSON ffmpeg/ffprobe stdout —
+    // lets tests simulate "ffprobe says duration=240s" without rebuilding the harness.
+    private static Harness Build(
+        MediaJobOptions? options = null,
+        ClipValidationOptions? validation = null,
+        string? ffprobeStdout = null)
     {
         var store = Substitute.For<IClipMediaJobStore>();
         var source = Substitute.For<IClipImportSource>();
@@ -49,7 +54,7 @@ public class ImportWorkerTests
         // simulate an actual ffprobe duration.
         var ffmpeg = Substitute.For<IFfmpegRunner>();
         ffmpeg.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
-            .Returns(new FfmpegResult(0, "ok", ""));
+            .Returns(new FfmpegResult(0, ffprobeStdout ?? "ok", ""));
 
         var services = new ServiceCollection();
         services.AddScoped(_ => store);
@@ -156,8 +161,12 @@ public class ImportWorkerTests
 
         await h.Worker.TryProcessOneAsync(CancellationToken.None);
 
+        // Retry-exhaustion terminal failure → 'fetch_failed' so the wizard surfaces a useful
+        // message instead of the neutral fallback. Pre-flight rejections (too long /
+        // unavailable) write their own codes via the ProcessAsync catch.
         await h.Store.Received(1).MarkFailedAsync(
-            job.ClipId, job.AttemptNumber, ClipStatuses.Importing, Arg.Any<CancellationToken>());
+            job.ClipId, job.AttemptNumber, ClipStatuses.Importing, Arg.Any<CancellationToken>(),
+            reason: ClipFailureReasons.FetchFailed);
     }
 
     [Fact]
@@ -209,5 +218,37 @@ public class ImportWorkerTests
             reason: ClipFailureReasons.SourceTooLong);
         await h.Store.DidNotReceive().ReleaseLeaseAsync(
             Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportWorker_FfprobeReportsDurationOverCap_FailsImmediately()
+    {
+        // The authoritative post-download cap check: yt-dlp's metadata may have lied (or
+        // omitted duration), but ffprobe on the actual file is impossible to bypass. When
+        // ffprobe reports duration > cap, the worker must fail-fast with 'source_too_long'
+        // — no S3 upload, no retry, no AdvanceImportAsync.
+        var h = Build(ffprobeStdout: """{"format":{"duration":"240.0"}}""");
+        var job = ImportJob();
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(job);
+        h.Source
+            .FetchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImportFetchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var dest = (string)call[1];
+                File.WriteAllBytes(dest, new byte[1024]);
+                // Metadata says null duration — extractor lied / omitted. ffprobe is the gate.
+                return Task.FromResult(new ImportedMedia(null, null, null, null, null));
+            });
+
+        await h.Worker.TryProcessOneAsync(CancellationToken.None);
+
+        await h.Storage.DidNotReceive().PutObjectAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await h.Store.Received(1).MarkFailedAsync(
+            job.ClipId, job.AttemptNumber, ClipStatuses.Importing, Arg.Any<CancellationToken>(),
+            reason: ClipFailureReasons.SourceTooLong);
+        await h.Store.DidNotReceive().AdvanceImportAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<long>(), Arg.Any<string?>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
@@ -1,0 +1,213 @@
+using FluentAssertions;
+using GankedTV.Api.Data.Entities;
+using GankedTV.Api.Services.Clips;
+using GankedTV.Api.Services.Media;
+using GankedTV.Api.Services.Media.Import;
+using GankedTV.Api.Services.ObjectStorage;
+using GankedTV.Api.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace GankedTV.Api.Tests.Services.Media;
+
+public class ImportWorkerTests
+{
+    private sealed record Harness(
+        ImportWorker Worker,
+        IClipMediaJobStore Store,
+        IClipImportSource Source,
+        IObjectStorageService Storage,
+        IClipImportUrlValidator Validator);
+
+    private static Harness Build(MediaJobOptions? options = null, ClipValidationOptions? validation = null)
+    {
+        var store = Substitute.For<IClipMediaJobStore>();
+        var source = Substitute.For<IClipImportSource>();
+        var storage = Substitute.For<IObjectStorageService>();
+        var validator = Substitute.For<IClipImportUrlValidator>();
+        var s3 = Substitute.For<IOptionsMonitor<S3Options>>();
+        s3.CurrentValue.Returns(new S3Options { ClipsBucket = "clips" });
+        var validationOpts = Microsoft.Extensions.Options.Options.Create(validation ?? new ClipValidationOptions());
+
+        // Default the URL validator to accept anything (TryParse → true). Individual tests
+        // override when they want the worker's defence-in-depth path exercised.
+        validator
+            .TryParse(Arg.Any<string?>(), out Arg.Any<string>(), out Arg.Any<ImportUrlValidationError>())
+            .Returns(call =>
+            {
+                call[1] = (string?)call[0] ?? string.Empty;
+                call[2] = default(ImportUrlValidationError);
+                return true;
+            });
+
+        // Mock ffmpeg runner — default returns exit 0 with empty stdout so ffprobe-derived
+        // duration is null (i.e. unknown), which the worker treats as "skip the duration
+        // cap check, trust yt-dlp's metadata". Individual tests override when they want to
+        // simulate an actual ffprobe duration.
+        var ffmpeg = Substitute.For<IFfmpegRunner>();
+        ffmpeg.RunAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(new FfmpegResult(0, "ok", ""));
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => store);
+        services.AddScoped(_ => source);
+        services.AddScoped(_ => storage);
+        services.AddScoped(_ => validator);
+        services.AddScoped(_ => ffmpeg);
+        services.AddScoped<IOptionsMonitor<S3Options>>(_ => s3);
+        services.AddScoped<IOptions<ClipValidationOptions>>(_ => validationOpts);
+        var sp = services.BuildServiceProvider();
+        var monitor = Substitute.For<IOptionsMonitor<MediaJobOptions>>();
+        monitor.CurrentValue.Returns(options ?? new MediaJobOptions { MaxAttempts = 3 });
+
+        var worker = new ImportWorker(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            ffmpeg,
+            monitor,
+            NullLogger<ImportWorker>.Instance);
+        return new Harness(worker, store, source, storage, validator);
+    }
+
+    private static ClaimedImportJob ImportJob(int attempt = 1) =>
+        new(Guid.NewGuid(), Guid.NewGuid(), GameId: null,
+            VideoKey: "u/v.mp4",
+            ImportSourceUrl: "https://medal.tv/clips/abc",
+            Title: "from import",
+            AttemptNumber: attempt);
+
+    [Fact]
+    public async Task ImportWorker_NoJob_ReturnsFalse()
+    {
+        var h = Build();
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((ClaimedImportJob?)null);
+
+        (await h.Worker.TryProcessOneAsync(CancellationToken.None)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ImportWorker_HappyPath_AdvancesToProcessing()
+    {
+        var h = Build();
+        var job = ImportJob();
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(job);
+
+        // Fake fetch: write a small file at the destination so the worker's stream upload + size
+        // assertions succeed.
+        h.Source
+            .FetchAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<ImportFetchOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var dest = (string)call[1];
+                File.WriteAllBytes(dest, new byte[1024]);
+                return Task.FromResult(new ImportedMedia("Extractor Title", 30, 1280, 720, null));
+            });
+
+        var processed = await h.Worker.TryProcessOneAsync(CancellationToken.None);
+
+        processed.Should().BeTrue();
+        await h.Storage.Received(1).PutObjectAsync(
+            "clips", job.VideoKey, Arg.Any<Stream>(), "video/mp4", Arg.Any<CancellationToken>());
+        await h.Store.Received(1).AdvanceImportAsync(
+            job.ClipId,
+            job.AttemptNumber,
+            Arg.Any<long>(),
+            "Extractor Title",
+            ClipImportDefaults.PlaceholderTitle,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportWorker_FetchThrows_ReleasesLeaseForRetry()
+    {
+        var h = Build();
+        var job = ImportJob(attempt: 1);
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(job);
+        h.Source
+            .FetchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImportFetchOptions>(), Arg.Any<CancellationToken>())
+            .Throws(new ImportFetchException("network"));
+
+        var processed = await h.Worker.TryProcessOneAsync(CancellationToken.None);
+
+        processed.Should().BeTrue();
+        await h.Store.Received(1).ReleaseLeaseAsync(
+            job.ClipId, job.AttemptNumber, ClipStatuses.Importing, Arg.Any<CancellationToken>());
+        await h.Store.DidNotReceive().AdvanceImportAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<long>(), Arg.Any<string?>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportWorker_FetchThrowsAtMaxAttempts_MarksFailed()
+    {
+        var h = Build(new MediaJobOptions { MaxAttempts = 2 });
+        var job = ImportJob(attempt: 2);
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(job);
+        h.Source
+            .FetchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImportFetchOptions>(), Arg.Any<CancellationToken>())
+            .Throws(new ImportFetchException("extractor error"));
+
+        await h.Worker.TryProcessOneAsync(CancellationToken.None);
+
+        await h.Store.Received(1).MarkFailedAsync(
+            job.ClipId, job.AttemptNumber, ClipStatuses.Importing, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportWorker_OversizeFile_FailsImmediately()
+    {
+        var h = Build(new MediaJobOptions { MaxAttempts = 3 }, new ClipValidationOptions { MaxUploadSizeMb = 1 });
+        var job = ImportJob();
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(job);
+        h.Source
+            .FetchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImportFetchOptions>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var dest = (string)call[1];
+                // 2 MB > 1 MB cap.
+                File.WriteAllBytes(dest, new byte[2 * 1024 * 1024]);
+                return Task.FromResult(new ImportedMedia(null, null, null, null, null));
+            });
+
+        await h.Worker.TryProcessOneAsync(CancellationToken.None);
+
+        // Oversize is a non-transient rejection — the worker should fail-fast (mark the row
+        // 'failed' with reason='source_too_large') on attempt 1 instead of retrying.
+        await h.Storage.DidNotReceive().PutObjectAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await h.Store.Received(1).MarkFailedAsync(
+            job.ClipId, job.AttemptNumber, ClipStatuses.Importing, Arg.Any<CancellationToken>(),
+            reason: ClipFailureReasons.SourceTooLarge);
+        await h.Store.DidNotReceive().ReleaseLeaseAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportWorker_ProbeRejectsByDuration_FailsImmediately()
+    {
+        var h = Build(new MediaJobOptions { MaxAttempts = 3 });
+        var job = ImportJob();
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(job);
+        h.Source
+            .FetchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ImportFetchOptions>(), Arg.Any<CancellationToken>())
+            .Throws(new ImportSourceRejectedException(
+                ClipFailureReasons.SourceTooLong, "duration 240s > 120s", actualDurationSecs: 240));
+
+        await h.Worker.TryProcessOneAsync(CancellationToken.None);
+
+        // Pre-flight rejection (metadata probe says duration > cap) → no retries, mark 'failed'
+        // with the structured reason. ReleaseLease must not be called.
+        await h.Store.Received(1).MarkFailedAsync(
+            job.ClipId, job.AttemptNumber, ClipStatuses.Importing, Arg.Any<CancellationToken>(),
+            reason: ClipFailureReasons.SourceTooLong);
+        await h.Store.DidNotReceive().ReleaseLeaseAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Media/MediaStageWorkerTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Media/MediaStageWorkerTests.cs
@@ -146,7 +146,11 @@ public class MediaStageWorkerTests
 
         await svc.TryProcessOneAsync(CancellationToken.None);
 
-        await store.Received(1).MarkFailedAsync(job.ClipId, 3, ClipStatuses.Processing, CancellationToken.None);
+        // Terminal failure carries the stage's structured reason so the status endpoint can
+        // surface "we couldn't generate a thumbnail" instead of a generic "failed" message.
+        await store.Received(1).MarkFailedAsync(
+            job.ClipId, 3, ClipStatuses.Processing, CancellationToken.None,
+            reason: ClipFailureReasons.ThumbnailFailed);
     }
 
     [Fact]
@@ -318,7 +322,11 @@ public class MediaStageWorkerTests
 
         await svc.TryProcessOneAsync(CancellationToken.None);
 
-        await store.Received(1).MarkFailedAsync(job.ClipId, 3, ClipStatuses.Transcoding, CancellationToken.None);
+        // Same structured-reason contract as the thumbnail stage — the compress stage uses
+        // 'transcode_failed' so the wizard can render stage-specific copy.
+        await store.Received(1).MarkFailedAsync(
+            job.ClipId, 3, ClipStatuses.Transcoding, CancellationToken.None,
+            reason: ClipFailureReasons.TranscodeFailed);
     }
 
     // --- JIT stream stage ---------------------------------------------------------------

--- a/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
@@ -17,6 +17,7 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
     private readonly string _environment;
     private readonly IReadOnlyList<IOAuthProvider>? _oauthProviders;
     private readonly S3Fixture? _s3Fixture;
+    private readonly Action<IServiceCollection>? _configureServices;
 
     // `oauthProviders`, when non-null, REPLACES the real Discord/Google registrations
     // wholesale (they are not merged). Passing an empty list therefore leaves the registry
@@ -27,12 +28,17 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
     // S3 container by overriding S3Options. This is the end-to-end path used by
     // [Collection("PostgresAndS3")] tests — IObjectStorageService is NOT replaced.
     // Mutually exclusive with `storageOverride` (which substitutes the service wholesale).
+    //
+    // `configureServices`, when non-null, runs LAST inside ConfigureWebHost so tests can
+    // swap arbitrary singletons/scoped services for substitutes (e.g. IClipImportSource)
+    // without growing this constructor every time a new replaceable service appears.
     public AuthApiFactory(
         string connectionString,
         IObjectStorageService? storageOverride = null,
         string environment = "Development",
         IReadOnlyList<IOAuthProvider>? oauthProviders = null,
-        S3Fixture? s3Fixture = null)
+        S3Fixture? s3Fixture = null,
+        Action<IServiceCollection>? configureServices = null)
     {
         if (storageOverride is not null && s3Fixture is not null)
         {
@@ -47,6 +53,7 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
         _environment = environment;
         _oauthProviders = oauthProviders;
         _s3Fixture = s3Fixture;
+        _configureServices = configureServices;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -107,6 +114,11 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
                     services.AddSingleton(provider);
                 }
             }
+
+            // Catch-all extension point — runs last so callers can replace whatever they want
+            // (RemoveAll<T> + AddSingleton/Scoped) without the factory needing a dedicated
+            // constructor parameter per service.
+            _configureServices?.Invoke(services);
         });
     }
 }

--- a/web/src/api/clips.ts
+++ b/web/src/api/clips.ts
@@ -54,6 +54,10 @@ export interface ClipDetail {
   likedByMe: boolean
   visibility: 'public' | 'unlisted'
   shareCode: string
+  // Set when the clip was ingested via POST /clips/import (Medal.tv / YouTube). Null for
+  // direct uploads. The detail page renders a "From {host}" attribution badge linking back
+  // to the original.
+  importSourceUrl: string | null
 }
 
 export interface UpdateClipBody {
@@ -103,6 +107,42 @@ export interface CreateClipBody {
   tags?: string[]
 }
 
+// POST /clips/import body. Url is required; everything else is optional — when title
+// is empty, the server fills it from the source's metadata (yt-dlp --print-json).
+export interface ImportClipBody {
+  url: string
+  title?: string | null
+  description?: string | null
+  gameId?: number | null
+  visibility?: 'public' | 'unlisted'
+  tags?: string[]
+}
+
+export interface ImportClipResult {
+  id: string
+  // 'importing' on submit; the client polls clips.getDetail until status flips to 'ready'
+  // (success) or 'failed' (terminal). Intermediate states ('processing', 'transcoding')
+  // come from the existing pipeline and are surfaced for progress UI.
+  status: string
+}
+
+// Returned by POST /clips/import/preview — metadata-only probe before any clip row exists.
+// Lets the wizard show duration + title in step 1 and gate "Continue" when the source
+// already exceeds maxClipDurationSecs. Fields are nullable because not every extractor
+// reports them; the front-end only gates when durationSecs is known.
+export interface ImportClipPreview {
+  title: string | null
+  durationSecs: number | null
+  width: number | null
+  height: number | null
+  // Best thumbnail URL the platform resolves (Medal CDN, img.youtube.com). Used by the
+  // upload wizard to render a real preview frame for any supported source. Always nullable
+  // because not every extractor exposes one — the YouTube-derived client-side fallback
+  // still works when this is null.
+  thumbnailUrl: string | null
+  maxClipDurationSecs: number
+}
+
 export interface CompleteClipResult {
   id: string
   fileSizeBytes: number
@@ -116,6 +156,19 @@ export interface LikeResult {
 export interface StreamStatus {
   hlsUrl: string | null
   status: 'ready' | 'pending'
+}
+
+// Owner-only status probe — returned by GET /clips/{id}/status while the clip is still
+// moving through the pipeline (importing → processing → transcoding → ready/failed).
+// On failure, failureReason is a short machine-readable code (e.g. 'source_too_long')
+// and durationSecs / maxClipDurationSecs let the UI render specific copy.
+export interface ClipStatus {
+  id: string
+  status: string
+  shareCode: string
+  failureReason: string | null
+  durationSecs: number | null
+  maxClipDurationSecs: number | null
 }
 
 export const clips = {
@@ -146,6 +199,12 @@ export const clips = {
     return api<ClipDetail>(`/clips/${encodeURIComponent(id)}`)
   },
 
+  // Owner-only lightweight status probe. Used by the upload + import wizards to poll for
+  // pipeline transitions before the clip is feed-visible (getDetail 404s in non-ready states).
+  getStatus(id: string): Promise<ClipStatus> {
+    return api<ClipStatus>(`/clips/${encodeURIComponent(id)}/status`)
+  },
+
   getByShareCode(code: string): Promise<ClipDetail> {
     return api<ClipDetail>(`/c/${encodeURIComponent(code)}`)
   },
@@ -158,6 +217,20 @@ export const clips = {
 
   create(body: CreateClipBody): Promise<{ id: string }> {
     return api<{ id: string }>('/clips', { method: 'POST', body })
+  },
+
+  // POST /clips/import — paste a Medal.tv / YouTube URL and the server fetches the source
+  // via yt-dlp, then feeds it into the same thumbnail → compress → ready pipeline as a
+  // direct upload. Returns immediately; caller polls clips.getDetail(id) for status.
+  importFromUrl(body: ImportClipBody): Promise<ImportClipResult> {
+    return api<ImportClipResult>('/clips/import', { method: 'POST', body })
+  },
+
+  // POST /clips/import/preview — metadata-only probe (no download, no clip row). Used by
+  // step 1 of the wizard to surface duration + title and gate "Continue" when the source
+  // is already too long, sparing the user from filling out step 2 for a doomed clip.
+  previewImport(url: string): Promise<ImportClipPreview> {
+    return api<ImportClipPreview>('/clips/import/preview', { method: 'POST', body: { url } })
   },
 
   getUploadUrl(id: string): Promise<UploadUrl> {

--- a/web/src/views/ClipView.vue
+++ b/web/src/views/ClipView.vue
@@ -19,6 +19,7 @@ import CommentsSection from '@/components/CommentsSection.vue'
 import IconHeart from '@/components/icons/IconHeart.vue'
 import IconShare from '@/components/icons/IconShare.vue'
 import IconMoreVertical from '@/components/icons/IconMoreVertical.vue'
+import IconLink from '@/components/icons/IconLink.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -100,6 +101,19 @@ const clipId = computed(() => {
 const shareCode = computed(() => {
   const code = route.params.code
   return Array.isArray(code) ? code[0] : (code as string | undefined)
+})
+
+// Attribution badge for clips ingested via POST /clips/import. The host is shown to the
+// viewer instead of the full URL (which can be long + carries query params); the link still
+// goes to the full original. Null when the clip wasn't imported or the URL is malformed.
+const importSourceHost = computed(() => {
+  const url = clip.value?.importSourceUrl
+  if (!url) return null
+  try {
+    return new URL(url).host.replace(/^www\./, '')
+  } catch {
+    return null
+  }
 })
 
 async function loadClip(isPoll = false) {
@@ -528,6 +542,19 @@ async function onConfirmDelete() {
         <div v-if="clip.tags.length" class="mt-3 flex flex-wrap gap-2">
           <TagChip v-for="t in clip.tags" :key="t.id" :slug="t.slug" :name="t.name" size="md" />
         </div>
+
+        <!-- Source attribution for imported clips. Subtle pill; clicking opens the original
+             in a new tab so reviewers can confirm credit / spot reuploads at a glance. -->
+        <a
+          v-if="clip.importSourceUrl && importSourceHost"
+          :href="clip.importSourceUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mt-3 inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-raised px-3 py-1 font-mono text-[11px] uppercase tracking-[0.06em] text-text-muted transition-colors hover:border-brand-light hover:text-text-primary"
+        >
+          <IconLink :size="12" />
+          <span>Imported from {{ importSourceHost }}</span>
+        </a>
 
         <div class="mt-4 flex flex-wrap items-center gap-3">
           <!-- Author info -->

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -433,7 +433,7 @@ async function pollImportStatus(clipId: string, tick: number): Promise<void> {
     }
     if (status.status === 'failed') {
       stage.value = 'error'
-      errorMsg.value = describeImportFailure(status)
+      errorMsg.value = describePipelineFailure(status)
       return
     }
     // Translate server stages → UI stages for the checklist + progress bar.
@@ -536,7 +536,11 @@ async function continueFromImportStep1() {
   if (ok) step.value = 2
 }
 
-function describeImportFailure(status: ClipStatus): string {
+// Maps the structured failureReason set by the pipeline (any stage — import, thumbnail,
+// compress) to user-facing copy. Currently only consumed by the import wizard's polling,
+// but the codes cover the full post-submit pipeline so this lives at module scope rather
+// than guessing "it was an import error".
+function describePipelineFailure(status: ClipStatus): string {
   switch (status.failureReason) {
     case 'source_too_long': {
       const actual = status.durationSecs ? fmtSeconds(status.durationSecs) : 'too long'
@@ -550,8 +554,14 @@ function describeImportFailure(status: ClipStatus): string {
       return 'The source is unavailable — it may be private, geo-blocked, or removed.'
     case 'fetch_failed':
       return 'The server could not fetch this clip. Double-check the URL or try a different source.'
+    case 'thumbnail_failed':
+      return "We couldn't generate a thumbnail for this clip. Try again — if it persists, the source may be corrupted."
+    case 'transcode_failed':
+      return "We couldn't process this clip's video. Try again — if it persists, the source may be in an unsupported format."
     default:
-      return 'Import failed. Double-check the URL or try a different source.'
+      // No structured code, or one this build doesn't recognise — neutral wording that
+      // doesn't pretend to know whether it was an import or a direct upload.
+      return 'Processing failed. Please try again.'
   }
 }
 

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -472,16 +472,16 @@ function fmtSeconds(s: number): string {
 // user-facing copy and the wizard stays on step 1.
 async function runImportPreview(): Promise<boolean> {
   if (!isImportUrlValid.value) return false
+  // Capture the URL the user clicked Continue on. If they edit the field mid-await, the
+  // response that lands belongs to a stale request — applying its title/poster/error to
+  // the new URL would be wrong. Compare and bail if it changed.
+  const targetUrl = importUrl.value.trim()
   previewLoading.value = true
   previewError.value = null
   previewData.value = null
   try {
-    const preview = await clips.previewImport(importUrl.value.trim())
-    // Surfaced in the browser console so users (and developers) can see exactly what the
-    // server's metadata probe returned. If durationSecs is null here, the extractor didn't
-    // report it — in that case the worker's authoritative ffprobe check (post-download)
-    // is the only enforcement, so a clip over the cap will still fail there.
-    console.log('[import] preview response', preview)
+    const preview = await clips.previewImport(targetUrl)
+    if (importUrl.value.trim() !== targetUrl) return false
     previewData.value = preview
     if (preview.durationSecs != null && preview.durationSecs > preview.maxClipDurationSecs) {
       previewError.value =
@@ -510,6 +510,10 @@ async function runImportPreview(): Promise<boolean> {
     }
     return true
   } catch (err) {
+    // Same stale-request guard as the success path — a 4xx that lands after the user has
+    // already typed a different URL belongs to the previous probe and must not overwrite
+    // the new URL's state.
+    if (importUrl.value.trim() !== targetUrl) return false
     if (err instanceof ApiError) {
       const code = (err.body as { code?: string } | null)?.code
       previewError.value =
@@ -527,7 +531,9 @@ async function runImportPreview(): Promise<boolean> {
     }
     return false
   } finally {
-    previewLoading.value = false
+    // Only clear loading when we're still the current request. Otherwise a stale response
+    // landing AFTER a newer request started would reset the spinner mid-flight.
+    if (importUrl.value.trim() === targetUrl) previewLoading.value = false
   }
 }
 

--- a/web/src/views/UploadView.vue
+++ b/web/src/views/UploadView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, computed, onUnmounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { ApiError } from '@/api/client'
 import { clips } from '@/api/clips'
-import type { GameSummary } from '@/api/clips'
+import type { ClipStatus, GameSummary } from '@/api/clips'
 import GameSelector from '@/components/GameSelector.vue'
 import TagInput from '@/components/TagInput.vue'
 import PageHeader from '@/components/PageHeader.vue'
@@ -25,9 +25,71 @@ const MAX_UPLOAD_MB = (() => {
 })()
 const MAX_UPLOAD_BYTES = MAX_UPLOAD_MB * 1024 * 1024
 
+// 'upload' = the existing 3-step presigned-PUT flow (file picker → metadata → PUT + complete).
+// 'import' = paste a Medal.tv / YouTube URL; the server fetches it and runs the same
+// thumbnail → compress → ready pipeline that an upload would. UI shares the wizard frame.
+type IngestMode = 'upload' | 'import'
+const mode = ref<IngestMode>('upload')
+
 type Step = 1 | 2 | 3
 const step = ref<Step>(1)
 const file = ref<File | null>(null)
+// URL the user pasted in import mode. Client-side allow-list mirrors the server's
+// MediaJobs:Import:AllowedHosts default — the server is still the source of truth (it
+// re-validates and 400s on unsupported hosts), this is just to give immediate feedback.
+const importUrl = ref('')
+const IMPORT_ALLOWED_HOSTS = [
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'youtu.be',
+  'medal.tv',
+  'www.medal.tv',
+]
+const isImportUrlValid = computed(() => {
+  const raw = importUrl.value.trim()
+  if (!raw) return false
+  try {
+    const u = new URL(raw)
+    if (u.protocol !== 'https:') return false
+    return IMPORT_ALLOWED_HOSTS.includes(u.host.toLowerCase())
+  } catch {
+    return false
+  }
+})
+
+// Derives a public YouTube thumbnail URL from a watch / shorts / youtu.be link so the
+// preview card on step 2 isn't empty for import-mode clips. Free + CORS-friendly because
+// img.youtube.com serves these unauthenticated. Medal.tv has no equivalent public pattern
+// — Medal previews stay blank (server fills in the thumbnail post-fetch anyway).
+function extractYoutubeVideoId(raw: string): string | null {
+  try {
+    const u = new URL(raw.trim())
+    const host = u.host.toLowerCase()
+    if (host === 'youtu.be') {
+      return u.pathname.slice(1).split('/')[0] || null
+    }
+    if (host.endsWith('youtube.com')) {
+      // /watch?v=ID, /shorts/ID, /embed/ID.
+      const v = u.searchParams.get('v')
+      if (v) return v
+      const parts = u.pathname.split('/').filter(Boolean)
+      if ((parts[0] === 'shorts' || parts[0] === 'embed' || parts[0] === 'live') && parts[1]) {
+        return parts[1]
+      }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+// Server-side metadata probe for the import URL: title + actual duration. Populated when
+// the user clicks "Continue" in import mode; used to (a) gate the transition to step 2
+// when the source is already too long and (b) prefill the title so step 2 isn't blank.
+const previewLoading = ref(false)
+const previewError = ref<string | null>(null)
+const previewData = ref<import('@/api/clips').ImportClipPreview | null>(null)
+
 // Client-side poster (data URL) captured from the picked file so the Preview card shows a real
 // frame while the user fills in title/game/tags — no server round-trip. Best-effort: stays null
 // if the browser can't decode the source.
@@ -45,15 +107,68 @@ const selectedGame = ref<GameSummary | null>(null)
 const selectedTags = ref<string[]>([])
 
 // Upload state — granular so the checklist can light up step-by-step.
-type UploadStage = 'idle' | 'creating' | 'uploading' | 'completing' | 'done' | 'error'
+// Upload stages: idle → creating → uploading → completing → done. Import stages reuse the
+// same machine: idle → submitting → importing → processing → done. 'error' is shared.
+type UploadStage =
+  | 'idle'
+  | 'creating'
+  | 'uploading'
+  | 'completing'
+  | 'submitting'
+  | 'importing'
+  | 'processing'
+  | 'done'
+  | 'error'
 const stage = ref<UploadStage>('idle')
 const uploadPct = ref(0)
 const errorMsg = ref<string | null>(null)
 const createdClipId = ref<string | null>(null)
+const createdShareCode = ref<string | null>(null)
 let activeXhr: XMLHttpRequest | null = null
+let pollTimer: ReturnType<typeof setTimeout> | null = null
 
 onUnmounted(() => {
   if (activeXhr) activeXhr.abort()
+  if (pollTimer) clearTimeout(pollTimer)
+})
+
+// Toggling between upload / import mid-flow must not carry stale state from the other
+// mode — e.g. the preview card would otherwise show the locally-picked file's poster
+// after switching to URL import, or the URL string lingering after switching back.
+watch(mode, (next) => {
+  errorMsg.value = null
+  if (next === 'import') {
+    // Drop the local file + its derived poster + any in-flight XHR.
+    if (activeXhr) {
+      activeXhr.abort()
+      activeXhr = null
+    }
+    file.value = null
+    posterUrl.value = null
+    posterRequestId++ // invalidate any pending capture
+  } else {
+    importUrl.value = ''
+    posterUrl.value = null
+    previewError.value = null
+    previewData.value = null
+    if (pollTimer) {
+      clearTimeout(pollTimer)
+      pollTimer = null
+    }
+  }
+})
+
+// In import mode, derive a YouTube thumbnail (when the URL parses to a video id) so the
+// preview card mirrors the local-file flow. Non-YouTube URLs (Medal, malformed) leave the
+// preview blank — server fills the real thumbnail in post-fetch.
+watch(importUrl, (next) => {
+  if (mode.value !== 'import') return
+  const id = extractYoutubeVideoId(next)
+  posterUrl.value = id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : null
+  // Stale preview info doesn't apply to a new URL — clear it. The user re-probes on the
+  // next "Continue" click.
+  previewError.value = null
+  previewData.value = null
 })
 
 function pickFile(f: File | null) {
@@ -244,19 +359,251 @@ function friendlyUploadError(err: unknown): string {
   return 'Upload failed.'
 }
 
-const checklistDone = computed(() => ({
-  create: stage.value !== 'idle' && stage.value !== 'creating',
-  upload: stage.value === 'completing' || stage.value === 'done',
-  complete: stage.value === 'done',
-}))
+const progressLabel = computed(() => {
+  switch (stage.value) {
+    case 'uploading':
+      return 'Uploading'
+    case 'submitting':
+      return 'Submitting'
+    case 'importing':
+      return 'Fetching source'
+    case 'processing':
+      return 'Processing'
+    case 'done':
+      return 'Done'
+    case 'error':
+      return 'Failed'
+    default:
+      return 'Preparing'
+  }
+})
+
+const checklistDone = computed(() => {
+  // Two parallel pipelines — upload (current 3-stage XHR flow) and import (submit + poll).
+  // The checklist labels swap based on `mode`, so we expose three booleans either way.
+  if (mode.value === 'import') {
+    const s = stage.value
+    return {
+      create: s !== 'idle' && s !== 'submitting',
+      upload: s === 'processing' || s === 'done',
+      complete: s === 'done',
+    }
+  }
+  return {
+    create: stage.value !== 'idle' && stage.value !== 'creating',
+    upload: stage.value === 'completing' || stage.value === 'done',
+    complete: stage.value === 'done',
+  }
+})
+
+const checklistItems = computed(() => {
+  if (mode.value === 'import') {
+    return [
+      { label: '1. Submit URL', done: checklistDone.value.create },
+      { label: '2. Fetch source', done: checklistDone.value.upload },
+      { label: '3. Process + finalize', done: checklistDone.value.complete },
+    ]
+  }
+  return [
+    { label: '1. Create record', done: checklistDone.value.create },
+    { label: '2. Upload video', done: checklistDone.value.upload },
+    { label: '3. Finalize', done: checklistDone.value.complete },
+  ]
+})
+
+// Polling ceiling — caps total wait at ~5 minutes (60 ticks * 5 s). A clip that hasn't
+// reached 'ready' by then is almost certainly stuck (failed fetch, GPU box outage, etc.);
+// surface an error and let the user retry rather than spinning forever.
+const POLL_INTERVAL_MS = 5_000
+const POLL_MAX_TICKS = 60
+
+async function pollImportStatus(clipId: string, tick: number): Promise<void> {
+  if (tick > POLL_MAX_TICKS) {
+    stage.value = 'error'
+    errorMsg.value = 'Import is taking longer than expected. Try again or check back later.'
+    return
+  }
+  try {
+    const status = await clips.getStatus(clipId)
+    createdShareCode.value = status.shareCode
+    if (status.status === 'ready') {
+      stage.value = 'done'
+      uploadPct.value = 100
+      return
+    }
+    if (status.status === 'failed') {
+      stage.value = 'error'
+      errorMsg.value = describeImportFailure(status)
+      return
+    }
+    // Translate server stages → UI stages for the checklist + progress bar.
+    if (status.status === 'importing') {
+      stage.value = 'importing'
+      uploadPct.value = 25
+    } else {
+      // 'processing' (thumbnail) or 'transcoding' (compress) — both look the same to the user.
+      stage.value = 'processing'
+      uploadPct.value = 75
+    }
+    pollTimer = setTimeout(() => void pollImportStatus(clipId, tick + 1), POLL_INTERVAL_MS)
+  } catch (err) {
+    // 404 right after submit is possible if the row hasn't committed yet — retry once.
+    if (err instanceof ApiError && err.status === 404 && tick < 3) {
+      pollTimer = setTimeout(() => void pollImportStatus(clipId, tick + 1), POLL_INTERVAL_MS)
+      return
+    }
+    stage.value = 'error'
+    errorMsg.value = friendlyUploadError(err)
+  }
+}
+
+// Maps the structured failureReason code returned by GET /clips/{id}/status into copy a
+// user can act on — falls back to a generic message when the worker didn't set a code
+// (older clips, unexpected exceptions). Duration is rendered as "Xm Ys" for readability.
+function fmtSeconds(s: number): string {
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  return r === 0 ? `${m}m` : `${m}m ${r}s`
+}
+
+// Hits POST /clips/import/preview to check duration before the user wastes time in step 2.
+// Returns true → caller can advance to step 2. Returns false → previewError is set with
+// user-facing copy and the wizard stays on step 1.
+async function runImportPreview(): Promise<boolean> {
+  if (!isImportUrlValid.value) return false
+  previewLoading.value = true
+  previewError.value = null
+  previewData.value = null
+  try {
+    const preview = await clips.previewImport(importUrl.value.trim())
+    // Surfaced in the browser console so users (and developers) can see exactly what the
+    // server's metadata probe returned. If durationSecs is null here, the extractor didn't
+    // report it — in that case the worker's authoritative ffprobe check (post-download)
+    // is the only enforcement, so a clip over the cap will still fail there.
+    console.log('[import] preview response', preview)
+    previewData.value = preview
+    if (preview.durationSecs != null && preview.durationSecs > preview.maxClipDurationSecs) {
+      previewError.value =
+        `Clip is ${fmtSeconds(preview.durationSecs)} — max allowed is ${fmtSeconds(preview.maxClipDurationSecs)}. ` +
+        'Pick a shorter clip.'
+      return false
+    }
+    if (preview.durationSecs == null) {
+      // Surface that we couldn't verify the duration so the user knows the cap may still
+      // bite at submit time. Inline note (not blocking) — the worker's ffprobe is the
+      // authoritative gate.
+      previewError.value =
+        `Couldn't read this source's duration up front — max allowed is ${fmtSeconds(preview.maxClipDurationSecs)}. ` +
+        "We'll re-check after fetching; longer clips will be rejected at that point."
+      // Don't block: Medal.tv / niche extractors sometimes omit duration; we still trust
+      // the post-download enforcement.
+    }
+    // Prefill the title from the extractor unless the user has already typed something.
+    if (!title.value.trim() && preview.title) {
+      title.value = preview.title.slice(0, 100)
+    }
+    // Use the platform-resolved thumbnail (works for Medal.tv where the client-side YT
+    // fallback can't help). Wins over any URL-derived guess set by the importUrl watcher.
+    if (preview.thumbnailUrl) {
+      posterUrl.value = preview.thumbnailUrl
+    }
+    return true
+  } catch (err) {
+    if (err instanceof ApiError) {
+      const code = (err.body as { code?: string } | null)?.code
+      previewError.value =
+        code === 'source_unavailable'
+          ? 'The source is unavailable — it may be private, geo-blocked, or removed.'
+          : code === 'unsupported_host'
+            ? 'Only Medal.tv and YouTube URLs are supported right now.'
+            : code === 'invalid_url'
+              ? 'That URL is not valid.'
+              : code === 'import_disabled'
+                ? 'URL imports are temporarily disabled.'
+                : `Could not read clip metadata (server error ${err.status}).`
+    } else {
+      previewError.value = 'Could not read clip metadata. Check your connection and try again.'
+    }
+    return false
+  } finally {
+    previewLoading.value = false
+  }
+}
+
+async function continueFromImportStep1() {
+  const ok = await runImportPreview()
+  if (ok) step.value = 2
+}
+
+function describeImportFailure(status: ClipStatus): string {
+  switch (status.failureReason) {
+    case 'source_too_long': {
+      const actual = status.durationSecs ? fmtSeconds(status.durationSecs) : 'too long'
+      const cap =
+        status.maxClipDurationSecs != null ? fmtSeconds(status.maxClipDurationSecs) : 'the limit'
+      return `Clip is ${actual} — max allowed is ${cap}. Pick a shorter clip.`
+    }
+    case 'source_too_large':
+      return 'The source file is larger than the upload limit. Pick a shorter or lower-quality clip.'
+    case 'source_unavailable':
+      return 'The source is unavailable — it may be private, geo-blocked, or removed.'
+    case 'fetch_failed':
+      return 'The server could not fetch this clip. Double-check the URL or try a different source.'
+    default:
+      return 'Import failed. Double-check the URL or try a different source.'
+  }
+}
+
+async function startImport() {
+  if (!isImportUrlValid.value) return
+  step.value = 3
+  stage.value = 'submitting'
+  uploadPct.value = 5
+  errorMsg.value = null
+  try {
+    const result = await clips.importFromUrl({
+      url: importUrl.value.trim(),
+      title: title.value.trim() || null,
+      description: desc.value.trim() || null,
+      gameId: selectedGame.value?.id ?? null,
+      visibility: visibility.value,
+      ...(selectedTags.value.length ? { tags: selectedTags.value } : {}),
+    })
+    createdClipId.value = result.id
+    stage.value = 'importing'
+    uploadPct.value = 20
+    await pollImportStatus(result.id, 0)
+  } catch (err) {
+    stage.value = 'error'
+    errorMsg.value = friendlyImportError(err)
+  }
+}
+
+function friendlyImportError(err: unknown): string {
+  if (err instanceof ApiError) {
+    const code = (err.body as { code?: string } | null)?.code
+    if (code === 'invalid_url') return 'That URL is not valid.'
+    if (code === 'unsupported_host')
+      return 'Only Medal.tv and YouTube URLs are supported right now.'
+    if (code === 'import_disabled') return 'URL imports are temporarily disabled.'
+    return `Server error (${err.status}). Please try again.`
+  }
+  return friendlyUploadError(err)
+}
 
 function goBackToDetails() {
   // Drop the half-created clip id so the next attempt creates a fresh draft instead
   // of re-using the failed one. The orphaned draft row is cleaned up server-side
   // by the future scheduled-sweep job (Phase 2 maintenance).
+  if (pollTimer) {
+    clearTimeout(pollTimer)
+    pollTimer = null
+  }
   stage.value = 'idle'
   step.value = 2
   createdClipId.value = null
+  createdShareCode.value = null
   uploadPct.value = 0
   errorMsg.value = null
 }
@@ -307,80 +654,189 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
       </div>
     </div>
 
-    <!-- Step 1: File picker -->
+    <!-- Step 1: File picker OR URL import -->
     <div v-if="step === 1">
-      <div
-        @dragover.prevent="dragging = true"
-        @dragleave.prevent="dragging = false"
-        @drop.prevent="handleDrop"
-        :class="[
-          'flex flex-col items-center gap-4 rounded-lg border-2 border-dashed px-6 py-16 text-center transition-[border-color] duration-200',
-          dragging ? 'border-brand-light bg-brand-glow' : 'border-border-strong bg-transparent',
-        ]"
-      >
+      <!-- Mode toggle: upload existing file vs. import from a supported URL host. -->
+      <div class="mb-5 grid grid-cols-2 gap-2.5">
+        <button
+          @click="mode = 'upload'"
+          :class="[
+            'flex cursor-pointer items-center justify-center gap-2 rounded-md border px-4 py-3 font-heading text-sm font-bold uppercase tracking-wider transition-colors',
+            mode === 'upload'
+              ? 'border-brand-light bg-brand-glow text-text-primary'
+              : 'border-border bg-surface-raised text-text-secondary',
+          ]"
+        >
+          <IconUploadCloud :size="16" />
+          Upload file
+        </button>
+        <button
+          @click="mode = 'import'"
+          :class="[
+            'flex cursor-pointer items-center justify-center gap-2 rounded-md border px-4 py-3 font-heading text-sm font-bold uppercase tracking-wider transition-colors',
+            mode === 'import'
+              ? 'border-brand-light bg-brand-glow text-text-primary'
+              : 'border-border bg-surface-raised text-text-secondary',
+          ]"
+        >
+          <IconLink :size="16" />
+          Import from URL
+        </button>
+      </div>
+
+      <!-- File picker (upload mode) -->
+      <div v-if="mode === 'upload'">
         <div
-          class="flex h-16 w-16 items-center justify-center rounded-full border border-border-strong bg-surface-overlay text-brand-light"
+          @dragover.prevent="dragging = true"
+          @dragleave.prevent="dragging = false"
+          @drop.prevent="handleDrop"
+          :class="[
+            'flex flex-col items-center gap-4 rounded-lg border-2 border-dashed px-6 py-16 text-center transition-[border-color] duration-200',
+            dragging ? 'border-brand-light bg-brand-glow' : 'border-border-strong bg-transparent',
+          ]"
         >
-          <IconUploadCloud :size="28" />
-        </div>
-
-        <div>
-          <div class="mb-1.5 font-heading text-[22px] font-bold uppercase text-text-primary">
-            Drop your clip here
-          </div>
-          <div class="font-body text-sm text-text-secondary">
-            MP4 or video — up to {{ MAX_UPLOAD_MB }} MB
-          </div>
-        </div>
-
-        <label
-          class="inline-flex cursor-pointer items-center gap-2 rounded-md bg-brand px-5.5 py-2.5 font-heading text-sm font-bold uppercase tracking-wider text-white"
-        >
-          <IconFile :size="16" />
-          Choose file
-          <input type="file" accept="video/*" class="sr-only" @change="handleFileSelect" />
-        </label>
-
-        <div class="mt-2 flex flex-wrap justify-center gap-2">
-          <span
-            v-for="src in SOURCES"
-            :key="src"
-            class="rounded-sm border border-border bg-surface-overlay px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted"
+          <div
+            class="flex h-16 w-16 items-center justify-center rounded-full border border-border-strong bg-surface-overlay text-brand-light"
           >
-            {{ src }}
-          </span>
+            <IconUploadCloud :size="28" />
+          </div>
+
+          <div>
+            <div class="mb-1.5 font-heading text-[22px] font-bold uppercase text-text-primary">
+              Drop your clip here
+            </div>
+            <div class="font-body text-sm text-text-secondary">
+              MP4 or video — up to {{ MAX_UPLOAD_MB }} MB
+            </div>
+          </div>
+
+          <label
+            class="inline-flex cursor-pointer items-center gap-2 rounded-md bg-brand px-5.5 py-2.5 font-heading text-sm font-bold uppercase tracking-wider text-white"
+          >
+            <IconFile :size="16" />
+            Choose file
+            <input type="file" accept="video/*" class="sr-only" @change="handleFileSelect" />
+          </label>
+
+          <div class="mt-2 flex flex-wrap justify-center gap-2">
+            <span
+              v-for="src in SOURCES"
+              :key="src"
+              class="rounded-sm border border-border bg-surface-overlay px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted"
+            >
+              {{ src }}
+            </span>
+          </div>
+        </div>
+
+        <p
+          v-if="errorMsg"
+          class="mt-4 rounded-md border border-brand bg-surface-overlay px-4 py-2 font-mono text-[12px] text-brand-light"
+        >
+          {{ errorMsg }}
+        </p>
+
+        <div
+          v-if="file"
+          class="mt-5 flex items-center gap-4 rounded-md border border-neon bg-neon-dim px-5 py-4 text-neon"
+        >
+          <IconFileText :size="20" class="shrink-0" />
+          <div class="min-w-0 flex-1">
+            <div
+              class="overflow-hidden font-body text-sm whitespace-nowrap text-ellipsis text-text-primary"
+            >
+              {{ file.name }}
+            </div>
+            <div class="mt-0.5 font-mono text-[11px] text-text-muted">
+              {{ formatSize(file.size) }}
+            </div>
+          </div>
+          <button
+            @click="step = 2"
+            class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md bg-brand-light px-5 py-2.5 font-heading text-sm font-bold whitespace-nowrap uppercase tracking-wider text-white"
+          >
+            Continue
+            <IconArrowRight :size="14" :stroke-width="2.5" />
+          </button>
         </div>
       </div>
 
-      <p
-        v-if="errorMsg"
-        class="mt-4 rounded-md border border-brand bg-surface-overlay px-4 py-2 font-mono text-[12px] text-brand-light"
-      >
-        {{ errorMsg }}
-      </p>
-
-      <div
-        v-if="file"
-        class="mt-5 flex items-center gap-4 rounded-md border border-neon bg-neon-dim px-5 py-4 text-neon"
-      >
-        <IconFileText :size="20" class="shrink-0" />
-        <div class="min-w-0 flex-1">
+      <!-- URL input (import mode) -->
+      <div v-else>
+        <div
+          class="flex flex-col gap-4 rounded-lg border-2 border-dashed border-border-strong bg-transparent px-6 py-12 text-center"
+        >
           <div
-            class="overflow-hidden font-body text-sm whitespace-nowrap text-ellipsis text-text-primary"
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-full border border-border-strong bg-surface-overlay text-brand-light"
           >
-            {{ file.name }}
+            <IconLink :size="28" />
           </div>
-          <div class="mt-0.5 font-mono text-[11px] text-text-muted">
-            {{ formatSize(file.size) }}
+          <div>
+            <div class="mb-1.5 font-heading text-[22px] font-bold uppercase text-text-primary">
+              Paste a clip URL
+            </div>
+            <div class="font-body text-sm text-text-secondary">
+              Medal.tv or YouTube — we fetch + process it for you
+            </div>
+          </div>
+          <input
+            v-model="importUrl"
+            type="url"
+            placeholder="https://medal.tv/clips/... or https://www.youtube.com/watch?v=..."
+            :class="inputClass + ' mx-auto max-w-[28rem]'"
+          />
+          <div class="mt-1 flex flex-wrap justify-center gap-2">
+            <span
+              v-for="host in IMPORT_ALLOWED_HOSTS.filter(
+                (h) => !h.startsWith('www.') && !h.startsWith('m.'),
+              )"
+              :key="host"
+              class="rounded-sm border border-border bg-surface-overlay px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted"
+            >
+              {{ host }}
+            </span>
           </div>
         </div>
-        <button
-          @click="step = 2"
-          class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md bg-brand-light px-5 py-2.5 font-heading text-sm font-bold whitespace-nowrap uppercase tracking-wider text-white"
+
+        <div
+          v-if="importUrl && !isImportUrlValid"
+          class="mt-4 rounded-md border border-brand bg-surface-overlay px-4 py-2 font-mono text-[12px] text-brand-light"
         >
-          Continue
-          <IconArrowRight :size="14" :stroke-width="2.5" />
-        </button>
+          Only Medal.tv and YouTube https links are supported right now.
+        </div>
+
+        <!-- Preview probe surfacing — either the friendly duration-too-long / unavailable
+             error, or a one-line readout so the user can confirm the right clip before
+             filling step 2. -->
+        <div
+          v-if="previewError"
+          class="mt-4 rounded-md border border-brand bg-surface-overlay px-4 py-2 font-mono text-[12px] text-brand-light"
+        >
+          {{ previewError }}
+        </div>
+        <div
+          v-else-if="previewData && previewData.durationSecs != null"
+          class="mt-4 rounded-md border border-border bg-surface-overlay px-4 py-2 font-mono text-[12px] text-text-muted"
+        >
+          <span class="text-neon">{{ fmtSeconds(previewData.durationSecs) }}</span>
+          <template v-if="previewData.title"> · {{ previewData.title }}</template>
+        </div>
+
+        <div class="mt-5 flex justify-end">
+          <button
+            :disabled="!isImportUrlValid || previewLoading"
+            @click="continueFromImportStep1"
+            :class="[
+              'inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 font-heading text-sm font-bold uppercase tracking-wider',
+              isImportUrlValid && !previewLoading
+                ? 'cursor-pointer bg-brand-light text-white'
+                : 'cursor-not-allowed border border-border bg-surface-overlay text-text-muted',
+            ]"
+          >
+            {{ previewLoading ? 'Checking…' : 'Continue' }}
+            <IconArrowRight v-if="!previewLoading" :size="14" :stroke-width="2.5" />
+          </button>
+        </div>
       </div>
     </div>
 
@@ -406,13 +862,22 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
 
           <div>
             <div class="mb-1.5 flex items-baseline justify-between">
-              <label :class="labelClass + ' mb-0'">Title</label>
+              <label :class="labelClass + ' mb-0'"
+                >Title
+                <span v-if="mode === 'import'" class="text-[9px] text-text-muted"
+                  >(optional — we'll fill it from the source)</span
+                >
+              </label>
               <span class="font-mono text-[10px] text-text-muted"> {{ title.length }}/100 </span>
             </div>
             <input
               v-model="title"
               maxlength="100"
-              placeholder="What happened in this clip?"
+              :placeholder="
+                mode === 'import'
+                  ? 'Override the source title (optional)'
+                  : 'What happened in this clip?'
+              "
               :class="inputClass"
             />
           </div>
@@ -470,16 +935,16 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
               Back
             </button>
             <button
-              :disabled="!title.trim()"
-              @click="startUpload"
+              :disabled="mode === 'upload' ? !title.trim() : !isImportUrlValid"
+              @click="mode === 'upload' ? startUpload() : startImport()"
               :class="[
                 'inline-flex flex-1 items-center justify-center gap-2 rounded-md px-5 py-3 font-heading text-[15px] font-bold uppercase tracking-wider transition-all duration-150',
-                title.trim()
+                (mode === 'upload' ? title.trim() : isImportUrlValid)
                   ? 'cursor-pointer border-0 bg-brand-light text-white'
                   : 'cursor-not-allowed border border-border bg-surface-overlay text-text-muted',
               ]"
             >
-              Start upload
+              {{ mode === 'import' ? 'Start import' : 'Start upload' }}
               <IconArrowRight :size="14" :stroke-width="2.5" />
             </button>
           </div>
@@ -531,17 +996,19 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
         >
           <div class="min-w-0 flex-1 p-4">
             <div class="mb-2 font-heading text-base font-bold leading-[1.3] text-text-primary">
-              {{ title }}
+              {{ title || (mode === 'import' ? 'Importing from URL…' : '') }}
             </div>
             <div class="font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted">
-              {{ visibility }} · {{ file ? formatSize(file.size) : '' }}
+              {{ visibility }}
+              <template v-if="mode === 'upload' && file"> · {{ formatSize(file.size) }}</template>
+              <template v-else-if="mode === 'import'"> · {{ importUrl }}</template>
             </div>
           </div>
         </div>
 
         <div class="mb-2 flex items-baseline justify-between">
           <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-text-muted">
-            {{ stage === 'uploading' ? 'Uploading' : stage === 'done' ? 'Done' : 'Preparing' }}
+            {{ progressLabel }}
           </span>
           <span class="font-mono text-[11px] text-neon"> {{ Math.round(uploadPct) }}% </span>
         </div>
@@ -553,15 +1020,7 @@ const labelClass = 'mb-1.5 block font-mono text-[10px] uppercase tracking-widest
         </div>
 
         <div class="mb-9 flex flex-col gap-3.5">
-          <div
-            v-for="item in [
-              { label: '1. Create record', done: checklistDone.create },
-              { label: '2. Upload video', done: checklistDone.upload },
-              { label: '3. Finalize', done: checklistDone.complete },
-            ]"
-            :key="item.label"
-            class="flex items-center gap-3"
-          >
+          <div v-for="item in checklistItems" :key="item.label" class="flex items-center gap-3">
             <div
               :class="[
                 'h-2 w-2 shrink-0 rounded-full transition-[background,box-shadow] duration-300',


### PR DESCRIPTION
Closes #106.

## Summary

Adds URL-import as a second clip-ingestion path alongside the existing presigned-upload flow. Paste a Medal.tv or YouTube URL → server fetches via yt-dlp → feeds the file into the same thumbnail → compress → ready pipeline as a direct upload. Zero downstream changes; the new `importing` lifecycle stage slots in before `processing`.

## Server

- New `Importing` clip status; `ImportSourceUrl` + `FailureReason` columns on `clips` (two migrations).
- `ImportWorker` extends `MediaStageWorker<TJob>` — reuses the SKIP LOCKED + lease + retry machinery. Two-pass yt-dlp: cheap metadata probe (`--print` field-subset → ~100B JSON, avoids the 256KB stdout buffer overflow that bit `--dump-single-json`), then download. Authoritative ffprobe check on the downloaded file enforces the duration cap regardless of what the extractor reported.
- `POST /clips/import` (submit) + `POST /clips/import/preview` (metadata probe, no download) + `GET /clips/{id}/status` (owner-only polling probe).
- Structured `ClipFailureReasons` codes (`source_too_long`, `source_too_large`, `source_unavailable`, `fetch_failed`, `thumbnail_failed`, `transcode_failed`) persisted to `clips.failure_reason`. All pipeline stages now write a code so the wizard can render stage-specific copy.
- Operator kill-switches: `MEDIA_IMPORT_ENABLED` (pipeline-level → 503) + `MEDIA_IMPORT_WORKER_ENABLED` (per-instance, GPU-split friendly). yt-dlp boot-probe surfaces a missing binary as a single startup warning.

## Web

- New "Import from URL" tab on `UploadView`. Step 1 runs the preview probe to gate "Continue" when the source already exceeds the duration cap (saves filling out step 2 for a doomed clip). Falls back to a non-blocking warning when the extractor doesn't report duration; the worker's ffprobe still catches it.
- Server-resolved thumbnail (Medal CDN / img.youtube.com) populates the preview poster card.
- Clip detail page shows an "Imported from {host}" attribution pill linking back to the original — credit + reduces reupload friction.

## Tests

- 100+ new tests across `YtDlpImportSourceTests`, `ImportWorkerTests`, `ClipImportServiceTests`, `ClipImportUrlValidatorTests`, `ClipsImportEndpointsTests`, extensions to `ClipMediaJobStoreIntegrationTests` + `ClipsReadEndpointsTests`.
- Regression test asserts yt-dlp args carry the compact `--print` template and **don't** carry `--dump-single-json` / `--print-json` — protects the 256 KB buffer fix from silent regression.

## Host requirements

`yt-dlp` is required on every host running the `ImportWorker`. Added to `CLAUDE.md` (pacman/apt/brew) and bundled into `server/Dockerfile.api`.

## Test plan

- [x] Apply migrations: \`cd server && dotnet ef database update --project src/GankedTV.Api\`
- [x] Install yt-dlp on the host (\`sudo pacman -S yt-dlp\` / \`brew install yt-dlp\`)
- [x] Paste a Medal.tv or YouTube URL ≤ 120s into the import tab → clip lands \`ready\`, attribution badge shows on detail page
- [x] Paste a URL > 120s → step 1 gate shows "Clip is Xm Ys — max allowed is 2m"
- [x] Toggle \`MEDIA_IMPORT_ENABLED=false\` → \`/clips/import\` returns 503 \`import_disabled\`
- [x] Run \`make ci-server\` + \`make ci-web\` (85/85 coverage gates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Import clips from external URLs with automatic metadata extraction
  * Preview imported clip metadata before finalizing
  * Track import status and view failure details for problematic imports
  * See attribution link to original clip source in clip details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->