### PR TITLE
[server][web] Leaderboards + trending follow-ups (#117)

### DIFF
--- a/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardWindow.cs
+++ b/server/src/GankedTV.Api/Contracts/Leaderboards/LeaderboardWindow.cs
@@ -39,4 +39,24 @@ public static class LeaderboardWindow
                 return false;
         }
     }
+
+    // Bundles the window-default-and-parse + limit-clamp that every leaderboard handler
+    // does up-front. `windowKey` is the resolved string (defaulted when null) so callers
+    // can echo it back in the response payload; `since` is the parsed cutoff; `clampedLimit`
+    // is the input limit clamped to [1, maxLimit] with the default applied when null.
+    // Returns false only when an explicit, non-null window string doesn't match a known
+    // value — the caller should turn that into a 400.
+    public static bool TryParseRequest(
+        string? window,
+        int? limit,
+        int defaultLimit,
+        int maxLimit,
+        out string windowKey,
+        out DateTimeOffset since,
+        out int clampedLimit)
+    {
+        windowKey = window ?? Default;
+        clampedLimit = Math.Clamp(limit ?? defaultLimit, 1, maxLimit);
+        return TryParse(windowKey, out since);
+    }
 }

--- a/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/ClipsReadEndpoints.cs
@@ -10,6 +10,7 @@ using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Pagination;
 using GankedTV.Api.Problems;
 using GankedTV.Api.Services.Caching;
+using GankedTV.Api.Services.Feeds;
 using GankedTV.Api.Services.Media;
 using GankedTV.Api.Validation;
 using GankedTV.Api.Services.ObjectStorage;
@@ -294,35 +295,14 @@ public static class ClipsReadEndpoints
             .Select(r => r.Clip.Id)
             .ToList();
 
-        if (topIds.Count == 0)
-        {
-            return new CachedFeedPage([], NextCursor: null);
-        }
-
-        // Re-hydrate with feed Includes (the candidate Select dropped them) and preserve
-        // ranking order. EF's Contains() generates IN (...) which doesn't preserve order, so
-        // we re-sort in C# after fetch using the topIds index.
-        //
-        // Visibility/status filters from `baseQuery` aren't reapplied here because `topIds` was
-        // already derived from the filtered candidate set. The micro-race window — a clip
-        // flipping to unlisted or back to processing between scoring and rehydration — could
-        // surface one stale row in a trending response; accepted as bounded and self-healing
-        // on the next request. A clip *deleted* between scoring and rehydration just drops
-        // out of the result (TryGetValue skip) rather than 500ing.
-        var ordered = await db.Clips.AsNoTracking()
-            .Where(c => topIds.Contains(c.Id))
-            .IncludeFeedRelations()
-            .ToListAsync(ct);
-
-        var byId = ordered.ToDictionary(c => c.Id);
-        var ranked = new List<Clip>(topIds.Count);
-        foreach (var id in topIds)
-        {
-            if (byId.TryGetValue(id, out var clip))
-            {
-                ranked.Add(clip);
-            }
-        }
+        // Visibility/status filters from `baseQuery` aren't reapplied at hydrate because
+        // `topIds` was already derived from the filtered candidate set. The micro-race window
+        // — a clip flipping to unlisted or back to processing between scoring and rehydration —
+        // could surface one stale row in a trending response; accepted as bounded and
+        // self-healing on the next request. A clip *deleted* between scoring and rehydration
+        // just drops out of the result rather than 500ing.
+        var ranked = await RankedFeedBuilder.HydrateOrderedAsync(
+            topIds, db, reapplyPublicReadyFilter: false, ct);
 
         var items = ProjectAnonymousFeedItems(ranked, storage, s3);
         return new CachedFeedPage(items, NextCursor: null);

--- a/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/GamesEndpoints.cs
@@ -171,10 +171,13 @@ public static class GamesEndpoints
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
+        IFeedCache feedCache,
         CancellationToken ct)
     {
-        var windowKey = window ?? LeaderboardWindow.Default;
-        if (!LeaderboardWindow.TryParse(windowKey, out var since))
+        if (!LeaderboardWindow.TryParseRequest(
+                window, limit,
+                LeaderboardsEndpoints.DefaultClipsLimit, LeaderboardsEndpoints.MaxClipsLimit,
+                out var windowKey, out var since, out var cap))
         {
             return ProblemResults.BadRequest("invalid_window");
         }
@@ -191,13 +194,22 @@ public static class GamesEndpoints
         if (game is null)
             return ProblemResults.NotFound("not_found");
 
-        var cap = Math.Clamp(limit ?? LeaderboardsEndpoints.DefaultClipsLimit, 1, LeaderboardsEndpoints.MaxClipsLimit);
-        var baseQuery = db.Clips.AsNoTracking()
-            .Where(c => c.GameId == game.Id && c.Visibility == "public" && c.Status == "ready");
+        // Cache the anonymous entry list keyed by slug+window+cap; stamp LikedByMe post-cache.
+        // Same TTL-only contract as the global board and trending — likes don't bust the cache.
+        var gameId = game.Id;
+        var anonymousEntries = await feedCache.GetOrCreateLeaderboardAsync(
+            $"lb:game:{slug}:{windowKey}:{cap}",
+            c =>
+            {
+                var baseQuery = db.Clips.AsNoTracking()
+                    .Where(cl => cl.GameId == gameId && cl.Visibility == "public" && cl.Status == "ready");
+                return new ValueTask<List<LeaderboardEntry>>(
+                    LeaderboardsEndpoints.BuildAnonymousEntriesAsync(baseQuery, since, cap, db, storage, s3, c));
+            },
+            ct);
 
-        var entries = await LeaderboardsEndpoints.BuildEntriesAsync(
-            baseQuery, since, cap, principal, db, storage, s3, ct);
-
-        return Results.Ok(new GameLeaderboardResponse(windowKey, game.Summary, entries));
+        var stamped = await LeaderboardsEndpoints.StampLikedByMeOnEntriesAsync(
+            anonymousEntries, principal, db, ct);
+        return Results.Ok(new GameLeaderboardResponse(windowKey, game.Summary, stamped));
     }
 }

--- a/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/LeaderboardsEndpoints.cs
@@ -5,6 +5,8 @@ using GankedTV.Api.Contracts.Leaderboards;
 using GankedTV.Api.Data;
 using GankedTV.Api.Data.Entities;
 using GankedTV.Api.Problems;
+using GankedTV.Api.Services.Caching;
+using GankedTV.Api.Services.Feeds;
 using GankedTV.Api.Services.ObjectStorage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -32,41 +34,54 @@ public static class LeaderboardsEndpoints
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
+        IFeedCache feedCache,
         CancellationToken ct)
     {
         // Default to "week" when the caller omits window — the standalone /leaderboards
         // landing page renders week-first; explicit-but-unknown values still 400 so a UI
         // typo (`?window=mounth`) surfaces immediately instead of being silently coerced.
-        var windowKey = window ?? LeaderboardWindow.Default;
-        if (!LeaderboardWindow.TryParse(windowKey, out var since))
+        if (!LeaderboardWindow.TryParseRequest(
+                window, clipsLimit, DefaultClipsLimit, MaxClipsLimit,
+                out var windowKey, out var since, out var clipsCap))
         {
             return ProblemResults.BadRequest("invalid_window");
         }
 
-        var clipsCap = Math.Clamp(clipsLimit ?? DefaultClipsLimit, 1, MaxClipsLimit);
         var gamesCap = Math.Clamp(gamesLimit ?? DefaultGamesLimit, 1, MaxGamesLimit);
 
-        var clipsBase = db.Clips.AsNoTracking()
-            .Where(c => c.Visibility == "public" && c.Status == "ready");
-        var topClips = await BuildEntriesAsync(clipsBase, since, clipsCap, principal, db, storage, s3, ct);
+        // Cache the anonymous shape (LikedByMe=false on every entry); the per-caller stamp
+        // happens post-cache via StampLikedByMeOnEntriesAsync, the same pattern trending uses.
+        // TTL-only invalidation matches trending: likes are too high-frequency to bust the
+        // cache on each one, and a window-bounded board is inherently approximate.
+        var cached = await feedCache.GetOrCreateLeaderboardAsync(
+            $"lb:global:{windowKey}:{clipsCap}:{gamesCap}",
+            async c =>
+            {
+                var clipsBase = db.Clips.AsNoTracking()
+                    .Where(cl => cl.Visibility == "public" && cl.Status == "ready");
+                var topClips = await BuildAnonymousEntriesAsync(clipsBase, since, clipsCap, db, storage, s3, c);
+                var topGames = await BuildTopGamesAsync(since, gamesCap, db, c);
+                return new GlobalLeaderboardResponse(windowKey, topClips, topGames);
+            },
+            ct);
 
-        var topGames = await BuildTopGamesAsync(since, gamesCap, db, ct);
-
-        return Results.Ok(new GlobalLeaderboardResponse(windowKey, topClips, topGames));
+        var stampedClips = await StampLikedByMeOnEntriesAsync(cached.TopClips, principal, db, ct);
+        return Results.Ok(cached with { TopClips = stampedClips });
     }
 
     // Shared helper: turn a pre-filtered Clip IQueryable into a ranked list of leaderboard
     // entries scoped to a window. Owns the windowed-count query, deterministic tiebreak,
     // hydration with feed includes, and the rank-numbering pass.
     //
-    // Tie-breaking goes (likes desc, clip.created_at desc, clip.id asc): newer clips with
-    // equal likes outrank older ones (rewards momentum); equal createdAt falls back to a
-    // total ordering on Guid so the ranking is stable across requests.
-    internal static async Task<List<LeaderboardEntry>> BuildEntriesAsync(
+    // Anonymous half (no LikedByMe stamp) — the per-caller stamp is added post-cache by
+    // <see cref="StampLikedByMeOnEntriesAsync"/>, so this output is safe to share via the
+    // leaderboard cache. Tie-breaking goes (likes desc, clip.created_at desc, clip.id asc):
+    // newer clips with equal likes outrank older ones (rewards momentum); equal createdAt
+    // falls back to a total ordering on Guid so the ranking is stable across requests.
+    internal static async Task<List<LeaderboardEntry>> BuildAnonymousEntriesAsync(
         IQueryable<Clip> baseQuery,
         DateTimeOffset since,
         int limit,
-        ClaimsPrincipal principal,
         GankedTvDbContext db,
         IObjectStorageService storage,
         IOptions<S3Options> s3,
@@ -98,35 +113,41 @@ public static class LeaderboardsEndpoints
             .Take(limit)
             .ToList();
 
+        // Hydrate ranked IDs through the shared builder with the belt-and-braces re-filter
+        // turned on: a leaderboard surfacing a clip that flipped to private/unlisted between
+        // candidate fetch and hydration is more user-visible than the same race on trending,
+        // which self-heals via TTL.
         var topIds = ranked.Select(r => r.ClipId).ToList();
-        // Re-apply the public+ready predicate as a belt-and-braces guard: a clip can flip
-        // to private/unlisted or out of `ready` between the candidate fetch above and this
-        // hydrate. Trending tolerates that race ("self-healing on the next request"), but
-        // a leaderboard surfacing an unlisted clip in a "Most Liked This Week" board is
-        // more user-visible/confusing, and the extra WHERE clause is free.
-        var hydrated = await db.Clips.AsNoTracking()
-            .Where(c => topIds.Contains(c.Id) && c.Visibility == "public" && c.Status == "ready")
-            .IncludeFeedRelations()
-            .ToListAsync(ct);
-        var byId = hydrated.ToDictionary(c => c.Id);
+        var hydratedOrdered = await RankedFeedBuilder.HydrateOrderedAsync(
+            topIds, db, reapplyPublicReadyFilter: true, ct);
 
-        var feedItems = await ClipsReadEndpoints.ProjectFeedItemsAsync(
-            [.. ranked.Where(r => byId.ContainsKey(r.ClipId)).Select(r => byId[r.ClipId])],
-            principal, db, storage, s3, ct);
+        var feedItems = ClipsReadEndpoints.ProjectAnonymousFeedItems(hydratedOrdered, storage, s3);
 
-        // Walk ranked + feedItems in lockstep: feedItems was built from ranked-ordered
-        // clips, so index i corresponds to the same clip in both lists. A clip dropped
-        // between candidate fetch and hydrate (mid-delete, or filtered out by the
-        // re-applied visibility/status guard above) just falls out of both lists together.
-        // `entries.Count` doubles as both the next rank (1-based after +1) and the next
-        // feedItems index, since each addition increments them together.
+        // hydratedOrdered/feedItems are in `ranked` order with dropped IDs already removed,
+        // so we walk a parallel index into the windowed-like counts kept on `ranked`.
+        var windowLikesById = ranked.ToDictionary(r => r.ClipId, r => r.WindowLikes);
         var entries = new List<LeaderboardEntry>(feedItems.Count);
-        foreach (var r in ranked)
+        for (var i = 0; i < feedItems.Count; i++)
         {
-            if (!byId.ContainsKey(r.ClipId)) continue;
-            entries.Add(feedItems[entries.Count].ToEntry(entries.Count + 1, r.WindowLikes));
+            var item = feedItems[i];
+            entries.Add(item.ToEntry(i + 1, windowLikesById[item.Id]));
         }
         return entries;
+    }
+
+    // Re-stamp LikedByMe on the inner ClipFeedItem of each cached leaderboard entry, the
+    // same way trending re-stamps cached anonymous feed items. Preserves rank + windowLikes
+    // by zipping the stamped clips back into a fresh entry list.
+    internal static async Task<List<LeaderboardEntry>> StampLikedByMeOnEntriesAsync(
+        IReadOnlyList<LeaderboardEntry> anonymousEntries,
+        ClaimsPrincipal principal,
+        GankedTvDbContext db,
+        CancellationToken ct)
+    {
+        if (anonymousEntries.Count == 0) return [];
+        var clips = anonymousEntries.Select(e => e.Clip).ToList();
+        var stamped = await ClipsReadEndpoints.ApplyLikedByMeAsync(clips, principal, db, ct);
+        return [.. anonymousEntries.Zip(stamped, (entry, clip) => entry with { Clip = clip })];
     }
 
     // Top games for a window: sum windowed likes across each game's public+ready clips.
@@ -134,12 +155,20 @@ public static class LeaderboardsEndpoints
     // actually have activity. ClipCount counts public+ready clips for the whole catalog
     // (not just clips with likes in the window) so the number matches what GameView's
     // header shows — otherwise the same game would display two different counts.
+    //
+    // Ordering is hybrid: SQL applies the cheap part of the sort (likes desc, clip-count
+    // desc) and trims to a bounded candidate set, then the in-memory pass appends the
+    // Ordinal name tiebreak for determinism. Without this, ranking the whole catalog meant
+    // materialising every game with ≥1 windowed like just to sort + Take(limit) in memory.
     private static async Task<List<TopGameEntry>> BuildTopGamesAsync(
         DateTimeOffset since,
         int limit,
         GankedTvDbContext db,
         CancellationToken ct)
     {
+        // 4× headroom absorbs any plausible tie cluster on (likes, clipCount) at the cut.
+        // EF requires Take to be a constant or a captured variable for the parameter.
+        var candidateCap = limit * 4;
         var rows = await db.Games.AsNoTracking()
             .Select(g => new
             {
@@ -153,6 +182,9 @@ public static class LeaderboardsEndpoints
                     c.GameId == g.Id && c.Visibility == "public" && c.Status == "ready"),
             })
             .Where(x => x.WindowLikes > 0)
+            .OrderByDescending(x => x.WindowLikes)
+            .ThenByDescending(x => x.ClipCount)
+            .Take(candidateCap)
             .ToListAsync(ct);
 
         return [.. rows

--- a/server/src/GankedTV.Api/Services/Caching/FeedCache.cs
+++ b/server/src/GankedTV.Api/Services/Caching/FeedCache.cs
@@ -24,6 +24,15 @@ public interface IFeedCache
     ValueTask<CachedFeedPage> GetOrCreateTrendingAsync(
         string key, Func<CancellationToken, ValueTask<CachedFeedPage>> factory, CancellationToken ct);
 
+    /// <summary>
+    /// Cache a leaderboard payload (TTL-governed; not invalidated on writes). Generic on
+    /// <typeparamref name="T"/> so the same surface handles global and per-game responses;
+    /// callers store the anonymous shape (LikedByMe=false) and re-stamp per request after
+    /// a cache hit, the same way <see cref="GetOrCreateTrendingAsync"/> is used.
+    /// </summary>
+    ValueTask<T> GetOrCreateLeaderboardAsync<T>(
+        string key, Func<CancellationToken, ValueTask<T>> factory, CancellationToken ct);
+
     /// <summary>Drop every cached feed page (called best-effort on clip mutations).</summary>
     ValueTask InvalidateFeedsAsync(CancellationToken ct);
 }
@@ -44,6 +53,11 @@ public sealed class FeedCache(HybridCache cache) : IFeedCache
     /// so it's not invalidated on writes — only the short expiration governs freshness.</summary>
     public const string TrendingTag = "trending";
 
+    /// <summary>Tag on leaderboard payloads (global + per-game). Same TTL-only contract as
+    /// trending: short expiration governs freshness; likes don't bust the cache, matching the
+    /// same accepted staleness as cached feed cards.</summary>
+    public const string LeaderboardTag = "leaderboards";
+
     // Short TTL with write-time invalidation. L1 (LocalCacheExpiration) is intentionally
     // shorter than L2 (Expiration): with no cross-pod L1 backplane, RemoveByTagAsync clears
     // L2 immediately but a sibling pod's L1 can serve stale until its local copy lapses —
@@ -56,6 +70,7 @@ public sealed class FeedCache(HybridCache cache) : IFeedCache
 
     private static readonly string[] FeedTags = [FeedTag];
     private static readonly string[] TrendingTags = [TrendingTag];
+    private static readonly string[] LeaderboardTags = [LeaderboardTag];
 
     /// <summary>Cache a feed page (latest or per-game) under the <see cref="FeedTag"/>.</summary>
     public ValueTask<CachedFeedPage> GetOrCreateFeedAsync(
@@ -70,6 +85,13 @@ public sealed class FeedCache(HybridCache cache) : IFeedCache
         Func<CancellationToken, ValueTask<CachedFeedPage>> factory,
         CancellationToken ct) =>
         cache.GetOrCreateAsync(key, factory, Entry, TrendingTags, ct);
+
+    /// <summary>Cache a leaderboard payload under the <see cref="LeaderboardTag"/> (TTL-governed).</summary>
+    public ValueTask<T> GetOrCreateLeaderboardAsync<T>(
+        string key,
+        Func<CancellationToken, ValueTask<T>> factory,
+        CancellationToken ct) =>
+        cache.GetOrCreateAsync(key, factory, Entry, LeaderboardTags, ct);
 
     /// <summary>
     /// Drop every cached feed page. Called best-effort on clip create/complete/delete and on

--- a/server/src/GankedTV.Api/Services/Feeds/RankedFeedBuilder.cs
+++ b/server/src/GankedTV.Api/Services/Feeds/RankedFeedBuilder.cs
@@ -1,0 +1,53 @@
+using GankedTV.Api.Data;
+using GankedTV.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Services.Feeds;
+
+/// <summary>
+/// Shared post-candidate pipeline for ranked clip feeds (leaderboards + trending). Both
+/// callers share the same shape: materialise a candidate set, rank in memory, hydrate the
+/// top IDs with feed includes, preserve the rank order. The differences (candidate query,
+/// scoring expression, projection) stay at the call site where they're visible.
+/// </summary>
+internal static class RankedFeedBuilder
+{
+    /// <summary>
+    /// Hydrates a pre-ranked list of clip IDs with feed includes, preserving the input
+    /// order and dropping any IDs that don't come back (deleted mid-flight, or filtered
+    /// out by the optional re-applied predicate).
+    /// </summary>
+    /// <param name="orderedIds">Clip IDs in rank order — the result follows this order.</param>
+    /// <param name="reapplyPublicReadyFilter">
+    /// True for leaderboards: re-checks <c>visibility='public' AND status='ready'</c> at
+    /// hydrate time as a belt-and-braces guard against the micro-race between candidate
+    /// selection and hydration (a leaderboard surfacing a private clip is more confusing
+    /// than a trending page doing the same — trending self-heals on the next request via
+    /// its short TTL, so it opts out).
+    /// </param>
+    public static async Task<List<Clip>> HydrateOrderedAsync(
+        IReadOnlyList<Guid> orderedIds,
+        GankedTvDbContext db,
+        bool reapplyPublicReadyFilter,
+        CancellationToken ct)
+    {
+        if (orderedIds.Count == 0) return [];
+
+        IQueryable<Clip> query = db.Clips.AsNoTracking().Where(c => orderedIds.Contains(c.Id));
+        if (reapplyPublicReadyFilter)
+        {
+            query = query.Where(c => c.Visibility == "public" && c.Status == "ready");
+        }
+        var hydrated = await query.IncludeFeedRelations().ToListAsync(ct);
+
+        // EF's IN(...) doesn't preserve input order, so re-sort by walking orderedIds.
+        // TryGetValue silently skips IDs that lost their row mid-flight.
+        var byId = hydrated.ToDictionary(c => c.Id);
+        var ordered = new List<Clip>(orderedIds.Count);
+        foreach (var id in orderedIds)
+        {
+            if (byId.TryGetValue(id, out var clip)) ordered.Add(clip);
+        }
+        return ordered;
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LeaderboardsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LeaderboardsEndpointsTests.cs
@@ -286,8 +286,9 @@ public class LeaderboardsEndpointsTests : IAsyncLifetime
     {
         // The leaderboard payload is cached anonymously and re-stamped per caller, mirroring
         // the trending cache. The high-risk regression is the cache leaking one caller's
-        // likedByMe to another. Anonymous warms the cache → authenticated liker must still
-        // see likedByMe=true on the same cached entry.
+        // likedByMe to another. Exercise both directions: anonymous-warms-then-authed and
+        // authed-warms-then-anonymous, since per-caller stamping must hold regardless of
+        // which request populated the cache.
         await _fx.ResetAsync();
         var (likerId, likerToken) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "liker");
         var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
@@ -299,7 +300,17 @@ public class LeaderboardsEndpointsTests : IAsyncLifetime
             await db.SaveChangesAsync();
         }
 
-        // Anonymous request warms the cache with likedByMe=false everywhere.
+        // Authed request warms the cache; the stamped result must NOT leak likedByMe=true
+        // back into the shared cache entry.
+        using (var likerClient = AuthTestHelpers.CreateBearerClient(_factory!, likerToken))
+        {
+            var body = await (await likerClient.GetAsync("/leaderboards?window=week")).Content.ReadFromJsonAsync<JsonElement>();
+            var entry = body.GetProperty("topClips").EnumerateArray().Single();
+            entry.GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clipId);
+            entry.GetProperty("clip").GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+        }
+
+        // Anonymous request hits the same cached entry within TTL and must see false.
         using (var anon = _factory!.CreateClient())
         {
             var body = await (await anon.GetAsync("/leaderboards?window=week")).Content.ReadFromJsonAsync<JsonElement>();
@@ -308,7 +319,7 @@ public class LeaderboardsEndpointsTests : IAsyncLifetime
                 .Should().OnlyContain(l => l == false);
         }
 
-        // Liker hits the same cached entry within TTL but must see their own like.
+        // And the original direction: liker hits the cache after anon and still sees their like.
         using (var likerClient = AuthTestHelpers.CreateBearerClient(_factory!, likerToken))
         {
             var body = await (await likerClient.GetAsync("/leaderboards?window=week")).Content.ReadFromJsonAsync<JsonElement>();
@@ -322,7 +333,8 @@ public class LeaderboardsEndpointsTests : IAsyncLifetime
     public async Task GameLeaderboard_Cached_LikedByMeStaysPerCaller()
     {
         // Same isolation guarantee for the per-game endpoint. Different code path (different
-        // handler, different cache key), so test it separately.
+        // handler, different cache key), so test it separately. Cover both warm directions
+        // so an authed warm can't leak likedByMe=true into the cache.
         await _fx.ResetAsync();
         var (likerId, likerToken) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "liker");
         var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
@@ -334,6 +346,16 @@ public class LeaderboardsEndpointsTests : IAsyncLifetime
             await db.SaveChangesAsync();
         }
 
+        // Authed warms the cache first.
+        using (var likerClient = AuthTestHelpers.CreateBearerClient(_factory!, likerToken))
+        {
+            var body = await (await likerClient.GetAsync("/games/valorant/leaderboard?window=week")).Content.ReadFromJsonAsync<JsonElement>();
+            var entry = body.GetProperty("entries").EnumerateArray().Single();
+            entry.GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clipId);
+            entry.GetProperty("clip").GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+        }
+
+        // Anonymous must still see false on the same cached entry.
         using (var anon = _factory!.CreateClient())
         {
             var body = await (await anon.GetAsync("/games/valorant/leaderboard?window=week")).Content.ReadFromJsonAsync<JsonElement>();
@@ -342,6 +364,7 @@ public class LeaderboardsEndpointsTests : IAsyncLifetime
                 .Should().OnlyContain(l => l == false);
         }
 
+        // And the original direction still holds.
         using (var likerClient = AuthTestHelpers.CreateBearerClient(_factory!, likerToken))
         {
             var body = await (await likerClient.GetAsync("/games/valorant/leaderboard?window=week")).Content.ReadFromJsonAsync<JsonElement>();

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LeaderboardsEndpointsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/LeaderboardsEndpointsTests.cs
@@ -282,6 +282,76 @@ public class LeaderboardsEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Global_Cached_LikedByMeStaysPerCaller()
+    {
+        // The leaderboard payload is cached anonymously and re-stamped per caller, mirroring
+        // the trending cache. The high-risk regression is the cache leaking one caller's
+        // likedByMe to another. Anonymous warms the cache → authenticated liker must still
+        // see likedByMe=true on the same cached entry.
+        await _fx.ResetAsync();
+        var (likerId, likerToken) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "liker");
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        var (clipId, _) = await SeedClipAsync(authorId, DateTimeOffset.UtcNow, gameId, "lb-cached");
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = likerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow.AddHours(-1) });
+            await db.SaveChangesAsync();
+        }
+
+        // Anonymous request warms the cache with likedByMe=false everywhere.
+        using (var anon = _factory!.CreateClient())
+        {
+            var body = await (await anon.GetAsync("/leaderboards?window=week")).Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("topClips").EnumerateArray()
+                .Select(e => e.GetProperty("clip").GetProperty("likedByMe").GetBoolean())
+                .Should().OnlyContain(l => l == false);
+        }
+
+        // Liker hits the same cached entry within TTL but must see their own like.
+        using (var likerClient = AuthTestHelpers.CreateBearerClient(_factory!, likerToken))
+        {
+            var body = await (await likerClient.GetAsync("/leaderboards?window=week")).Content.ReadFromJsonAsync<JsonElement>();
+            var entry = body.GetProperty("topClips").EnumerateArray().Single();
+            entry.GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clipId);
+            entry.GetProperty("clip").GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task GameLeaderboard_Cached_LikedByMeStaysPerCaller()
+    {
+        // Same isolation guarantee for the per-game endpoint. Different code path (different
+        // handler, different cache key), so test it separately.
+        await _fx.ResetAsync();
+        var (likerId, likerToken) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "liker");
+        var (authorId, _) = await AuthTestHelpers.SeedUserAndIssueTokenAsync(_fx, _factory!, "author");
+        var gameId = await GetGameIdBySlugAsync("valorant");
+        var (clipId, _) = await SeedClipAsync(authorId, DateTimeOffset.UtcNow, gameId, "game-lb-cached");
+        await using (var db = _fx.CreateContext())
+        {
+            db.Likes.Add(new Like { UserId = likerId, ClipId = clipId, CreatedAt = DateTimeOffset.UtcNow.AddHours(-1) });
+            await db.SaveChangesAsync();
+        }
+
+        using (var anon = _factory!.CreateClient())
+        {
+            var body = await (await anon.GetAsync("/games/valorant/leaderboard?window=week")).Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("entries").EnumerateArray()
+                .Select(e => e.GetProperty("clip").GetProperty("likedByMe").GetBoolean())
+                .Should().OnlyContain(l => l == false);
+        }
+
+        using (var likerClient = AuthTestHelpers.CreateBearerClient(_factory!, likerToken))
+        {
+            var body = await (await likerClient.GetAsync("/games/valorant/leaderboard?window=week")).Content.ReadFromJsonAsync<JsonElement>();
+            var entry = body.GetProperty("entries").EnumerateArray().Single();
+            entry.GetProperty("clip").GetProperty("id").GetGuid().Should().Be(clipId);
+            entry.GetProperty("clip").GetProperty("likedByMe").GetBoolean().Should().BeTrue();
+        }
+    }
+
+    [Fact]
     public async Task GameLeaderboard_LimitClampedAndRanksAssigned()
     {
         await _fx.ResetAsync();

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/FeedCacheTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/FeedCacheTests.cs
@@ -80,4 +80,44 @@ public class FeedCacheTests
 
         trendingCalls.Should().Be(1, "the feed tag must not evict trending entries");
     }
+
+    [Fact]
+    public async Task GetOrCreateLeaderboardAsync_SecondCall_ServedFromCache()
+    {
+        var (cache, sp) = Build();
+        await using var _ = sp;
+        var calls = 0;
+        ValueTask<int> Factory(CancellationToken _)
+        {
+            calls++;
+            return new ValueTask<int>(42);
+        }
+
+        var first = await cache.GetOrCreateLeaderboardAsync("lb:global:week:10:10", Factory, default);
+        var second = await cache.GetOrCreateLeaderboardAsync("lb:global:week:10:10", Factory, default);
+
+        calls.Should().Be(1, "the second call must hit the cache, not the factory");
+        first.Should().Be(42);
+        second.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task InvalidateFeedsAsync_DoesNotEvictLeaderboards()
+    {
+        // Leaderboards live under their own tag and are TTL-governed; a feed invalidation must leave them.
+        var (cache, sp) = Build();
+        await using var _ = sp;
+        var calls = 0;
+        ValueTask<int> Factory(CancellationToken _)
+        {
+            calls++;
+            return new ValueTask<int>(1);
+        }
+
+        await cache.GetOrCreateLeaderboardAsync("lb:global:week:10:10", Factory, default);
+        await cache.InvalidateFeedsAsync(default);
+        await cache.GetOrCreateLeaderboardAsync("lb:global:week:10:10", Factory, default);
+
+        calls.Should().Be(1, "the feed tag must not evict leaderboard entries");
+    }
 }

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -14,6 +14,8 @@ import IconSun from './icons/IconSun.vue'
 import IconMoon from './icons/IconMoon.vue'
 import IconPlus from './icons/IconPlus.vue'
 import IconBell from './icons/IconBell.vue'
+import IconMenu from './icons/IconMenu.vue'
+import MobileNavDrawer from './MobileNavDrawer.vue'
 
 const auth = useAuthStore()
 const theme = useThemeStore()
@@ -248,6 +250,20 @@ onBeforeUnmount(() => {
   document.removeEventListener('mousedown', onDocumentMouseDown)
   document.removeEventListener('keydown', onDocumentKeyDown)
 })
+
+// --- Mobile nav drawer --------------------------------------------------------
+//
+// Below the `tablet` breakpoint (720px), Games/Trending/Leaderboards are hidden via
+// max-tablet:hidden on the desktop nav links. The hamburger + drawer surface them on
+// mobile so two top-level features aren't unreachable. Drawer owns its own escape /
+// route-change / backdrop close handling; we just track open-state here and return
+// focus to the hamburger when it closes.
+const hamburgerRef = useTemplateRef<HTMLButtonElement>('hamburgerRef')
+const isDrawerOpen = ref(false)
+
+watch(isDrawerOpen, (open) => {
+  if (!open) nextTick(() => hamburgerRef.value?.focus())
+})
 </script>
 
 <template>
@@ -263,6 +279,19 @@ onBeforeUnmount(() => {
         <span class="logo__mark"></span>
         GANKED<span class="logo__tv">.TV</span>
       </RouterLink>
+
+      <!-- Hamburger trigger (mobile only). Below the tablet breakpoint, Games / Trending /
+           Leaderboards collapse into the drawer below. -->
+      <button
+        ref="hamburgerRef"
+        type="button"
+        class="hidden h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary max-tablet:inline-flex"
+        aria-label="Open menu"
+        :aria-expanded="isDrawerOpen"
+        @click="isDrawerOpen = true"
+      >
+        <IconMenu :size="16" />
+      </button>
 
       <!-- Nav links -->
       <nav class="flex flex-1 items-center gap-1" aria-label="Main navigation">
@@ -483,5 +512,7 @@ onBeforeUnmount(() => {
         <NotificationsDropdown @close="closeBell" />
       </div>
     </Teleport>
+
+    <MobileNavDrawer v-model:open="isDrawerOpen" />
   </header>
 </template>

--- a/web/src/components/GameLeaderboardBlock.vue
+++ b/web/src/components/GameLeaderboardBlock.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
-import { leaderboards, type LeaderboardEntry, type LeaderboardWindow } from '@/api/leaderboards'
+import { computed, onMounted, watch } from 'vue'
+import { leaderboards, type LeaderboardWindow } from '@/api/leaderboards'
+import { useLatestRequest } from '@/composables/useLatestRequest'
 import LeaderboardRow from '@/components/LeaderboardRow.vue'
 
 const props = withDefaults(
@@ -14,34 +15,15 @@ const props = withDefaults(
   { window: 'week', limit: 5 },
 )
 
-const entries = ref<LeaderboardEntry[]>([])
-const loading = ref(false)
-const errored = ref(false)
-let latestLoadId = 0
+const { data, loading, errored, run } = useLatestRequest(
+  () => leaderboards.forGame(props.slug, { window: props.window, limit: props.limit }),
+  { label: 'game leaderboard' },
+)
+const entries = computed(() => data.value?.entries ?? [])
 
-async function load() {
-  const id = ++latestLoadId
-  loading.value = true
-  errored.value = false
-  try {
-    const resp = await leaderboards.forGame(props.slug, {
-      window: props.window,
-      limit: props.limit,
-    })
-    if (id !== latestLoadId) return
-    entries.value = resp.entries
-  } catch (err) {
-    if (id !== latestLoadId) return
-    console.error('game leaderboard: load failed', err)
-    errored.value = true
-  } finally {
-    if (id === latestLoadId) loading.value = false
-  }
-}
-
-onMounted(load)
+onMounted(run)
 // Refetch when the parent navigates between games (slug changes) without unmounting.
-watch(() => [props.slug, props.window], load)
+watch(() => [props.slug, props.window], run)
 
 const windowLabel = {
   week: 'This Week',

--- a/web/src/components/GameLeaderboardBlock.vue
+++ b/web/src/components/GameLeaderboardBlock.vue
@@ -23,7 +23,7 @@ const entries = computed(() => data.value?.entries ?? [])
 
 onMounted(run)
 // Refetch when the parent navigates between games (slug changes) without unmounting.
-watch(() => [props.slug, props.window], run)
+watch(() => [props.slug, props.window, props.limit], run)
 
 const windowLabel = {
   week: 'This Week',

--- a/web/src/components/MobileNavDrawer.vue
+++ b/web/src/components/MobileNavDrawer.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { nextTick, onMounted, onUnmounted, ref, useId, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{ 'update:open': [boolean] }>()
+
+const titleId = useId()
+const firstLinkRef = ref<HTMLAnchorElement | null>(null)
+
+function close() {
+  emit('update:open', false)
+}
+
+// Focus the first nav item on open so keyboard users land inside the drawer instead of
+// staying on the (now-offscreen) hamburger trigger. Re-focus on every open transition.
+watch(
+  () => props.open,
+  (open) => {
+    if (open) nextTick(() => firstLinkRef.value?.focus())
+  },
+)
+
+// Close on route change so navigating from the drawer doesn't leave it hanging open
+// over the destination page.
+const route = useRoute()
+watch(
+  () => route.fullPath,
+  () => {
+    if (props.open) close()
+  },
+)
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && props.open) close()
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+
+// Active-link styling mirrors AppNav's desktop nav so the drawer reads as the same
+// navigation surface — the brand-light underline cue is the only "you are here" signal
+// users have learned, so don't reinvent it here.
+const linkBase =
+  'relative block px-5 py-3 font-heading text-base font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary'
+const linkActive =
+  "text-text-primary after:content-[''] after:absolute after:left-5 after:right-5 after:bottom-1.5 after:h-0.5 after:bg-brand-light"
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      leave-active-class="transition-opacity duration-150"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+      >
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/70" @click="close" />
+
+        <!-- Drawer panel: slides in from the left so it doesn't fight the bell/avatar
+             dropdowns that anchor to the right edge. -->
+        <Transition
+          enter-active-class="transition-transform duration-200 ease-out"
+          enter-from-class="-translate-x-full"
+          leave-active-class="transition-transform duration-150 ease-in"
+          leave-to-class="-translate-x-full"
+        >
+          <aside
+            v-if="open"
+            class="absolute inset-y-0 left-0 z-10 flex w-72 max-w-[80vw] flex-col border-r border-border bg-surface-raised shadow-[0_0_40px_var(--color-brand-glow)]"
+            @click.stop
+          >
+            <div class="flex items-center justify-between border-b border-border px-5 py-4">
+              <h2
+                :id="titleId"
+                class="font-heading text-base font-bold uppercase tracking-[0.04em] text-text-primary"
+              >
+                Menu
+              </h2>
+              <button
+                type="button"
+                aria-label="Close menu"
+                class="cursor-pointer font-mono text-xl leading-none text-text-muted transition-colors duration-150 hover:text-text-primary"
+                @click="close"
+              >
+                ×
+              </button>
+            </div>
+
+            <nav class="flex flex-col py-2" aria-label="Mobile main navigation">
+              <RouterLink
+                ref="firstLinkRef"
+                to="/"
+                :class="linkBase"
+                :exact-active-class="linkActive"
+              >
+                Feed
+              </RouterLink>
+              <RouterLink to="/games" :class="linkBase" :active-class="linkActive">
+                Games
+              </RouterLink>
+              <RouterLink to="/trending" :class="linkBase" :active-class="linkActive">
+                Trending
+              </RouterLink>
+              <RouterLink to="/leaderboards" :class="linkBase" :active-class="linkActive">
+                Leaderboards
+              </RouterLink>
+            </nav>
+          </aside>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/web/src/components/MobileNavDrawer.vue
+++ b/web/src/components/MobileNavDrawer.vue
@@ -57,7 +57,7 @@ const linkActive =
     >
       <div
         v-if="open"
-        class="fixed inset-0 z-50"
+        class="fixed inset-0 z-[60]"
         role="dialog"
         aria-modal="true"
         :aria-labelledby="titleId"

--- a/web/src/components/icons/IconMenu.vue
+++ b/web/src/components/icons/IconMenu.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number; strokeWidth?: number }>(), {
+  size: 16,
+  strokeWidth: 2,
+})
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    :stroke-width="strokeWidth"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+</template>

--- a/web/src/composables/__tests__/useLatestRequest.spec.ts
+++ b/web/src/composables/__tests__/useLatestRequest.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useLatestRequest } from '../useLatestRequest'
+
+describe('useLatestRequest', () => {
+  beforeEach(() => {
+    // The composable's error path logs to console.error; silence the noise for the cases
+    // that exercise it so the test runner output stays clean.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exposes data, loading, errored, run with sensible defaults', () => {
+    const { data, loading, errored } = useLatestRequest(() => Promise.resolve('x'))
+    expect(data.value).toBeUndefined()
+    expect(loading.value).toBe(false)
+    expect(errored.value).toBe(false)
+  })
+
+  it('uses the initial value before run() completes', async () => {
+    const { data } = useLatestRequest(() => Promise.resolve('next'), { initial: 'seed' })
+    expect(data.value).toBe('seed')
+  })
+
+  it('sets data and clears loading on success', async () => {
+    const { data, loading, errored, run } = useLatestRequest(() => Promise.resolve(42))
+    await run()
+    expect(data.value).toBe(42)
+    expect(loading.value).toBe(false)
+    expect(errored.value).toBe(false)
+  })
+
+  it('sets errored=true and leaves data alone on failure', async () => {
+    const { data, loading, errored, run } = useLatestRequest(
+      () => Promise.reject(new Error('boom')),
+      { initial: 'kept' },
+    )
+    await run()
+    expect(errored.value).toBe(true)
+    expect(loading.value).toBe(false)
+    expect(data.value).toBe('kept')
+  })
+
+  it('discards an older response when a newer call has already resolved', async () => {
+    // The point of the composable: out-of-order resolutions must not stomp a newer result.
+    // Use deferred promises so we can control resolve order independently of call order.
+    let resolveFirst!: (v: string) => void
+    let resolveSecond!: (v: string) => void
+    const first = new Promise<string>((r) => (resolveFirst = r))
+    const second = new Promise<string>((r) => (resolveSecond = r))
+    const calls: Array<Promise<string>> = [first, second]
+    let i = 0
+
+    const { data, run } = useLatestRequest(() => calls[i++])
+
+    const p1 = run()
+    const p2 = run()
+    resolveSecond('new')
+    await p2
+    expect(data.value).toBe('new')
+    resolveFirst('old')
+    await p1
+    // Stale resolution must NOT overwrite the newer winner.
+    expect(data.value).toBe('new')
+  })
+
+  it('discards an older rejection so errored does not flip after a newer success', async () => {
+    let rejectFirst!: (e: unknown) => void
+    let resolveSecond!: (v: string) => void
+    const first = new Promise<string>((_, r) => (rejectFirst = r))
+    const second = new Promise<string>((r) => (resolveSecond = r))
+    const calls: Array<Promise<string>> = [first, second]
+    let i = 0
+
+    const { data, errored, run } = useLatestRequest(() => calls[i++])
+
+    const p1 = run()
+    const p2 = run()
+    resolveSecond('ok')
+    await p2
+    rejectFirst(new Error('stale'))
+    await p1
+    expect(data.value).toBe('ok')
+    expect(errored.value).toBe(false)
+  })
+
+  it('flips loading=true while a fetch is in flight', async () => {
+    let resolve!: (v: string) => void
+    const pending = new Promise<string>((r) => (resolve = r))
+    const { loading, run } = useLatestRequest(() => pending)
+    const p = run()
+    expect(loading.value).toBe(true)
+    resolve('done')
+    await p
+    expect(loading.value).toBe(false)
+  })
+
+  it('uses the provided label as the console.error prefix', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { run } = useLatestRequest(() => Promise.reject(new Error('x')), { label: 'trending' })
+    await run()
+    expect(spy).toHaveBeenCalled()
+    expect(String(spy.mock.calls[0][0])).toContain('trending')
+  })
+})

--- a/web/src/composables/useLatestRequest.ts
+++ b/web/src/composables/useLatestRequest.ts
@@ -1,0 +1,53 @@
+import { ref, type Ref } from 'vue'
+
+// Wraps an async fetcher with the monotonic-token stale-check our list views need: rapid
+// argument changes (e.g. clicking a time-window tab three times in 200ms) trigger overlapping
+// fetches, and we want the latest one to win regardless of resolve order. v1 has no
+// AbortController cancellation — none of the current call sites cancelled before, and adding
+// it would change semantics (in-flight requests would reject rather than silently discard).
+export interface UseLatestRequestOptions<T> {
+  /** Seed value for `data` before the first run completes. */
+  initial?: T
+  /**
+   * Prefix for console.error when the fetcher throws — keeps logs attributable to the
+   * specific view (e.g. `"trending"`) instead of a generic helper name.
+   */
+  label?: string
+}
+
+export interface UseLatestRequestResult<T> {
+  data: Ref<T | undefined>
+  loading: Ref<boolean>
+  errored: Ref<boolean>
+  /** Trigger a new fetch. Concurrent calls are tolerated; only the last-started wins. */
+  run: () => Promise<void>
+}
+
+export function useLatestRequest<T>(
+  fetcher: () => Promise<T>,
+  options: UseLatestRequestOptions<T> = {},
+): UseLatestRequestResult<T> {
+  const data = ref<T | undefined>(options.initial) as Ref<T | undefined>
+  const loading = ref(false)
+  const errored = ref(false)
+  let latestLoadId = 0
+
+  async function run() {
+    const id = ++latestLoadId
+    loading.value = true
+    errored.value = false
+    try {
+      const result = await fetcher()
+      if (id !== latestLoadId) return
+      data.value = result
+    } catch (err) {
+      if (id !== latestLoadId) return
+      console.error(`${options.label ?? 'useLatestRequest'}: load failed`, err)
+      errored.value = true
+    } finally {
+      if (id === latestLoadId) loading.value = false
+    }
+  }
+
+  return { data, loading, errored, run }
+}

--- a/web/src/views/LeaderboardsView.vue
+++ b/web/src/views/LeaderboardsView.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
-import {
-  leaderboards,
-  type GlobalLeaderboardResponse,
-  type LeaderboardWindow,
-} from '@/api/leaderboards'
+import { leaderboards, type LeaderboardWindow } from '@/api/leaderboards'
+import { useLatestRequest } from '@/composables/useLatestRequest'
 import { formatNum } from '@/lib/format'
 import LeaderboardRow from '@/components/LeaderboardRow.vue'
 import PageHeader from '@/components/PageHeader.vue'
@@ -19,37 +16,13 @@ const WINDOWS: { key: LeaderboardWindow; label: string }[] = [
 ]
 
 const activeWindow = ref<LeaderboardWindow>('week')
-const data = ref<GlobalLeaderboardResponse | null>(null)
-const loading = ref(false)
-const errored = ref(false)
+const { data, loading, errored, run } = useLatestRequest(
+  () => leaderboards.global({ window: activeWindow.value, clipsLimit: 10, gamesLimit: 10 }),
+  { label: 'leaderboards' },
+)
 
-// Monotonic load token: rapid tab toggles (week → month → week) shouldn't let a slow
-// earlier response overwrite a newer one. Same pattern as TrendingView.
-let latestLoadId = 0
-
-async function load() {
-  const id = ++latestLoadId
-  loading.value = true
-  errored.value = false
-  try {
-    const resp = await leaderboards.global({
-      window: activeWindow.value,
-      clipsLimit: 10,
-      gamesLimit: 10,
-    })
-    if (id !== latestLoadId) return
-    data.value = resp
-  } catch (err) {
-    if (id !== latestLoadId) return
-    console.error('leaderboards: load failed', err)
-    errored.value = true
-  } finally {
-    if (id === latestLoadId) loading.value = false
-  }
-}
-
-onMounted(load)
-watch(activeWindow, load)
+onMounted(run)
+watch(activeWindow, run)
 
 function selectWindow(key: LeaderboardWindow) {
   if (key === activeWindow.value) return
@@ -90,7 +63,7 @@ const timeBtnInactive = `${timeBtnBase} bg-transparent text-text-secondary curso
     <StatusPanel v-if="errored" kind="error" message="Couldn't load leaderboards.">
       <button
         class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
-        @click="load"
+        @click="run"
       >
         Retry
       </button>

--- a/web/src/views/TrendingView.vue
+++ b/web/src/views/TrendingView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import { clips, type ClipFeedItem } from '@/api/clips'
 import { games as gamesApi, type GameListItem } from '@/api/games'
+import { useLatestRequest } from '@/composables/useLatestRequest'
 import { formatNum } from '@/lib/format'
 import GameTag from '@/components/GameTag.vue'
 import DurationBadge from '@/components/DurationBadge.vue'
@@ -24,43 +25,28 @@ const TIME_WINDOWS = [
 
 const timeWindow = ref<TrendingWindow>('24h')
 
-const topClips = ref<ClipFeedItem[]>([])
-const loading = ref(false)
-const errored = ref(false)
-
-const hotGames = ref<GameListItem[]>([])
-
-// Monotonic token so rapid `timeWindow` toggles (24h → 7d → 24h …) don't let a slow
-// earlier response overwrite a newer one. Without this, the user can land on `7d` and
-// see `24h` results blink in a moment later.
-let latestLoadId = 0
-
-async function load() {
-  const loadId = ++latestLoadId
-  loading.value = true
-  errored.value = false
-  try {
+// Hot games don't depend on the window, so reloading them on each toggle is wasted work
+// but the simplicity wins (and they're cheap). One composable covers both so a rapid
+// window flip still gets a single loading/errored signal.
+const { data, loading, errored, run } = useLatestRequest<{
+  topClips: ClipFeedItem[]
+  hotGames: GameListItem[]
+}>(
+  async () => {
     const [feed, games] = await Promise.all([
       clips.feed({ sort: 'trending', window: timeWindow.value, limit: 50 }),
       gamesApi.list(8),
     ])
-    if (loadId !== latestLoadId) return
-    topClips.value = feed.items.slice(0, 10)
-    hotGames.value = games
-  } catch (err) {
-    if (loadId !== latestLoadId) return
-    console.error('trending: load failed', err)
-    errored.value = true
-  } finally {
-    if (loadId === latestLoadId) loading.value = false
-  }
-}
+    return { topClips: feed.items.slice(0, 10), hotGames: games }
+  },
+  { label: 'trending' },
+)
 
-onMounted(load)
+const topClips = computed(() => data.value?.topClips ?? [])
+const hotGames = computed(() => data.value?.hotGames ?? [])
 
-// Window change → re-fetch. Hot games don't depend on the window, so reloading them is
-// wasted work but the simplicity wins; the request is cheap and small.
-watch(timeWindow, load)
+onMounted(run)
+watch(timeWindow, run)
 
 function selectWindow(key: string, enabled: boolean) {
   if (!enabled || key === timeWindow.value) return
@@ -115,7 +101,7 @@ const rankRest = `${rankBase} text-text-muted`
     <StatusPanel v-if="errored" kind="error" message="Couldn't load trending.">
       <button
         class="cursor-pointer rounded-sm border border-border bg-surface-overlay px-4 py-2 font-mono text-xs uppercase tracking-widest text-text-primary"
-        @click="load"
+        @click="run"
       >
         Retry
       </button>


### PR DESCRIPTION
Closes #117 — the deferred refactors from PR #114.

## Summary

**Server**
- TTL-only `IFeedCache.GetOrCreateLeaderboardAsync<T>` wraps both `/leaderboards` and `/games/{slug}/leaderboard`. Entries are cached anonymously and re-stamped with `LikedByMe` per request (same pattern trending already uses) so the cache can't leak likes across users.
- `BuildEntriesAsync` split into `BuildAnonymousEntriesAsync` + `StampLikedByMeOnEntriesAsync`.
- New `RankedFeedBuilder.HydrateOrderedAsync` extracts the shared hydrate-and-preserve-order step from leaderboards + trending, with an optional `public+ready` re-filter (leaderboards opts in to guard the candidate→hydrate micro-race; trending opts out and self-heals via TTL).
- `BuildTopGamesAsync` now pushes `(WindowLikes desc, ClipCount desc)` into SQL with `Take(limit*4)`; the `StringComparer.Ordinal` name tiebreak runs in-memory on the bounded candidate set.
- `LeaderboardWindow.TryParseRequest` bundles window-parse + limit-clamp; `GetGlobal` and `GetLeaderboardForGame` adopt it.

**Web**
- `useLatestRequest<T>` composable replaces the open-coded `latestLoadId` stale-check in `TrendingView`, `LeaderboardsView`, and `GameLeaderboardBlock`.
- `MobileNavDrawer` + hamburger in `AppNav` (visible below the 720px tablet breakpoint) so Games / Trending / Leaderboards are reachable on mobile. Escape / backdrop / route-change close; focus returns to the hamburger.

## Decisions

- **Cache invalidation:** TTL-only (like trending), not invalidated on like writes. Likes are too high-frequency to bust the cache on every one; the 60s/30s window matches the staleness already accepted on cached feed cards.
- **Top-games tiebreak:** kept `StringComparer.Ordinal` via the hybrid SQL+in-memory sort, so existing tests stay green.
- **No `AbortController` in `useLatestRequest` v1:** current call sites don't cancel, and adding it would change semantics (in-flight requests would reject rather than silently discard).

## Test plan

- [x] `make ci-server` — 959 passed, 94.7% line / 85.3% branch (above the 85/85 gate).
- [x] `make ci-web` — 245 passed, 93.5% statements / 94.2% branch on the gated scope.
- [x] New unit tests: 8 for `useLatestRequest`, 2 for `IFeedCache.GetOrCreateLeaderboardAsync` (cache-hit + tag isolation).
- [x] New integration tests: `Global_Cached_LikedByMeStaysPerCaller` + `GameLeaderboard_Cached_LikedByMeStaysPerCaller` — anonymous request warms the cache, then an authenticated liker hits the same entry and still sees their own `likedByMe=true`.
- [x] Manual smoke at 390×800: hamburger appears, drawer opens with all four routes, Esc + backdrop + route-change all close it, focus returns to the hamburger.
- [x] Manual smoke at 1280×800: desktop nav unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation drawer for improved mobile experience

* **Performance Improvements**
  * Implemented leaderboard caching to reduce load times
  * Optimized trending feed hydration logic

* **Bug Fixes**
  * Ensured user-specific "liked by me" status remains accurate across cached leaderboards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->