### PR TITLE
[server][web] Production hardening: health checks, startup migrations, prod config, secret validation & GA4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ REDIS_URL=redis://localhost:6379
 # API
 API_PORT=5050
 ASPNETCORE_ENVIRONMENT=Development
+# Apply EF migrations on boot. Default off — locally migrations are manual (`make migrate`).
+# Set to true on the migrating instance in production so a fresh DB self-migrates before
+# /health/ready goes green. See DEPLOYMENT.md.
+RUN_MIGRATIONS_ON_STARTUP=false
 
 # JWT + refresh tokens
 # JWT_SECRET must be >= 32 bytes (generate with: openssl rand -hex 32)
@@ -39,6 +43,10 @@ REFRESH_TOKEN_EXPIRY_DAYS=30
 # (generate with: openssl rand -hex 32).
 OAUTH_STATE_SECRET=
 WEB_ORIGIN=http://localhost:5173
+# CORS_ORIGINS — comma-separated allowlist of browser origins permitted to call the API.
+# WEB_ORIGIN is always allowed implicitly; list any additional origins here. REQUIRED in
+# production (the API refuses to boot without it). In dev any localhost origin is allowed.
+# CORS_ORIGINS=https://ganked.tv
 
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
@@ -51,6 +59,15 @@ GOOGLE_REDIRECT_URI=http://localhost:5050/auth/google/callback
 # Clip upload limits
 MAX_UPLOAD_SIZE_MB=500
 MAX_CLIP_DURATION_SECS=120
+
+# Web build-time vars (VITE_*) — read by Vite at BUILD time (envDir: '../'), baked into the
+# static bundle. They are NOT runtime server config. Leave unset locally (the web app falls
+# back to http://localhost:5050 for the API and skips analytics).
+# VITE_API_BASE_URL — base URL of the API the built frontend talks to (e.g. https://api.ganked.tv).
+VITE_API_BASE_URL=
+# VITE_GA_MEASUREMENT_ID — GA4 measurement id (e.g. G-XXXXXXX). Set only for production builds;
+# analytics is a no-op (no script, no cookies) when empty.
+VITE_GA_MEASUREMENT_ID=
 
 # IGDB game metadata — OPTIONAL. Only needed to run `make import-games`, which backfills the
 # games catalog + cover art from IGDB. A fresh dev DB renders placeholder covers via `make seed`

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,86 @@
+# Deployment
+
+Production runtime requirements and configuration for GankedTV. This covers the **API server**
+and the **web frontend**; container build/publish and the auto-deploy pipeline are tracked
+separately in issue #123.
+
+> **Secrets are never committed.** Everything below is provided via environment variables (or
+> your orchestrator's secret store) at runtime — there are no secrets in `appsettings*.json` or
+> any checked-in file.
+
+## Hard requirements
+
+- **`ASPNETCORE_ENVIRONMENT=Production` is mandatory.** It activates `appsettings.Production.json`,
+  the fail-fast secret validation, strict CORS, HTTPS redirection, and disables the dev-only
+  `POST /dev/token` and OpenAPI endpoints. A deploy that forgets this runs with dev affordances exposed.
+- **PostgreSQL ≥ 15** (the dev stack and CI run PG18).
+- The API image ([server/Dockerfile.api](server/Dockerfile.api)) ships `ffmpeg` + `yt-dlp` for the
+  media/import workers.
+
+## Fail-fast secret validation
+
+On boot in Production the API validates required configuration and **refuses to start** with an
+aggregated error if anything is missing or still set to a dev default (logic in
+[ProductionStartupValidator](server/src/GankedTV.Api/Configuration/ProductionStartupValidator.cs)).
+Required:
+
+| Var | Requirement |
+|---|---|
+| `DATABASE_URL` | Postgres connection string (dotnet/Npgsql form). |
+| `JWT_SECRET` | ≥ 32 bytes. Generate: `openssl rand -hex 32`. |
+| `WEB_ORIGIN` | Public origin of the web app (e.g. `https://ganked.tv`). |
+| `CORS_ORIGINS` | Comma-separated browser-origin allowlist. `WEB_ORIGIN` is always allowed implicitly. |
+| `S3_ENDPOINT` | Object-storage endpoint. |
+| `S3_ACCESS_KEY` / `S3_SECRET_KEY` | Non-default credentials (literal `minioadmin` is rejected). |
+| `S3_PUBLIC_URL` | Public base URL for stored objects / presigned-URL host rewrite. |
+
+Also recommended in production: `OAUTH_STATE_SECRET` (≥ 32 bytes; required once any OAuth provider
+is configured) and the provider client credentials (`DISCORD_*`, `GOOGLE_*`).
+
+## Startup database migrations
+
+Migrations are **manual locally** (`make migrate`). In production, set
+`RUN_MIGRATIONS_ON_STARTUP=true` on the migrating instance so a fresh DB self-migrates at boot,
+before serving requests. `/health/ready` only reports healthy once all migrations are applied
+(see [DatabaseMigrator](server/src/GankedTV.Api/Data/DatabaseMigrator.cs) and
+[ReadinessHealthCheck](server/src/GankedTV.Api/Services/Health/ReadinessHealthCheck.cs)). If you run
+more than one API replica, enable the flag on exactly one (or run migrations as a separate
+init step) to avoid concurrent migration races.
+
+## Health endpoints
+
+| Endpoint | Meaning | Use |
+|---|---|---|
+| `GET /health/live` | Process is up (no dependency checks). | Liveness probe / restart signal. |
+| `GET /health/ready` | DB reachable **and** migrations applied. | Readiness gate, load-balancer membership, the #123 deploy smoke test. |
+
+## Worker toggles (media pipeline)
+
+The media pipeline can be split across hosts (see the table in [CLAUDE.md](CLAUDE.md) under
+"Media pipeline"). `appsettings.Production.json` defaults to the **main API server** role
+(thumbnail worker on, transcode worker off, transcode pipeline on). Override per host via env vars
+to move GPU work to a separate box:
+
+| Instance | `MEDIA_THUMBNAIL_WORKER_ENABLED` | `MEDIA_TRANSCODE_WORKER_ENABLED` | encoder vars |
+|---|---|---|---|
+| Main API server | `true` | `false` | — |
+| GPU box (NVENC) | `false` | `true` | `MEDIA_VIDEO_ENCODER=av1_nvenc`, `MEDIA_VIDEO_CODEC=av1`, `MEDIA_JIT_VIDEO_ENCODER=h264_nvenc` |
+
+## Web frontend (build-time config)
+
+The web app is a static bundle; its config is baked in **at build time** by Vite (Vite reads the
+repo-root `.env` via `envDir: '../'`). These must be set when running `bun run build`, not at
+runtime:
+
+| Var | Purpose |
+|---|---|
+| `VITE_API_BASE_URL` | API base URL the built frontend calls (e.g. `https://api.ganked.tv`). Falls back to `http://localhost:5050` if unset — so it **must** be set for prod builds. |
+| `VITE_GA_MEASUREMENT_ID` | GA4 measurement id (`G-XXXXXXX`). Analytics is a complete no-op (no script, no cookies) when empty, so it stays off in dev/preview. |
+
+> The Dockerfile build-arg wiring that feeds these into the production web image is part of
+> issue #123. **Cookie-consent gating for analytics is a known follow-up** — GA currently loads
+> whenever the measurement id is present.
+
+## Reference
+
+A full annotated list of every variable lives in [.env.example](.env.example).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -43,9 +43,11 @@ Migrations are **manual locally** (`make migrate`). In production, set
 `RUN_MIGRATIONS_ON_STARTUP=true` on the migrating instance so a fresh DB self-migrates at boot,
 before serving requests. `/health/ready` only reports healthy once all migrations are applied
 (see [DatabaseMigrator](server/src/GankedTV.Api/Data/DatabaseMigrator.cs) and
-[ReadinessHealthCheck](server/src/GankedTV.Api/Services/Health/ReadinessHealthCheck.cs)). If you run
-more than one API replica, enable the flag on exactly one (or run migrations as a separate
-init step) to avoid concurrent migration races.
+[ReadinessHealthCheck](server/src/GankedTV.Api/Services/Health/ReadinessHealthCheck.cs)). EF Core
+serialises migration runs via a `__EFMigrationsHistory` lock, so multiple replicas booting with the
+flag enabled apply migrations safely (they wait, they don't race). For clarity you may still prefer
+to gate the flag to one replica or run migrations as a separate init step, but it isn't required for
+correctness. The flag accepts `true`/`1`/`yes`/`on`.
 
 ## Health endpoints
 

--- a/server/src/GankedTV.Api/Configuration/ProductionStartupValidator.cs
+++ b/server/src/GankedTV.Api/Configuration/ProductionStartupValidator.cs
@@ -9,6 +9,15 @@ namespace GankedTV.Api.Configuration;
 /// host refuses to boot with a clear, aggregated error rather than running misconfigured and
 /// failing later on the first request. Pure (no I/O) so it is unit-tested directly.
 /// </summary>
+/// <remarks>
+/// The caller in <c>Program.cs</c> passes values read straight from <c>Environment.GetEnvironmentVariable</c>,
+/// deliberately bypassing the DI options binding (which falls back to <c>appsettings</c>/config and
+/// dev defaults like <c>minioadmin</c> or <c>localhost:5173</c>). This enforces an <b>env-only secret
+/// contract</b>: required secrets must arrive via environment variables, per <c>DEPLOYMENT.md</c>.
+/// If a future deployment wires secrets through a config provider instead (Azure Key Vault, AWS
+/// Parameter Store, etc.), this env-only check will report them "missing" — update both the call
+/// site (to read the bound options) and this contract before integrating a vault.
+/// </remarks>
 public static class ProductionStartupValidator
 {
     /// <summary>Dev-default object-storage credentials that must never reach Production.</summary>

--- a/server/src/GankedTV.Api/Configuration/ProductionStartupValidator.cs
+++ b/server/src/GankedTV.Api/Configuration/ProductionStartupValidator.cs
@@ -1,0 +1,76 @@
+using GankedTV.Api.Auth;
+using GankedTV.Api.Services.ObjectStorage;
+
+namespace GankedTV.Api.Configuration;
+
+/// <summary>
+/// Fail-fast validation of required secrets/config when running in Production. Called from
+/// <c>Program.cs</c> after options binding; if <see cref="Validate"/> returns any problems the
+/// host refuses to boot with a clear, aggregated error rather than running misconfigured and
+/// failing later on the first request. Pure (no I/O) so it is unit-tested directly.
+/// </summary>
+public static class ProductionStartupValidator
+{
+    /// <summary>Dev-default object-storage credentials that must never reach Production.</summary>
+    private const string DevDefaultCredential = "minioadmin";
+
+    private const int MinJwtSecretBytes = 32;
+
+    public static IReadOnlyList<string> Validate(
+        string? connectionString,
+        JwtOptions jwt,
+        OAuthOptions oauth,
+        S3Options s3,
+        string? corsOrigins)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            errors.Add("DATABASE_URL must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(jwt.Secret))
+        {
+            errors.Add("JWT_SECRET must be set.");
+        }
+        else if (System.Text.Encoding.UTF8.GetByteCount(jwt.Secret) < MinJwtSecretBytes)
+        {
+            errors.Add($"JWT_SECRET must be at least {MinJwtSecretBytes} bytes.");
+        }
+
+        if (string.IsNullOrWhiteSpace(oauth.WebOrigin))
+        {
+            errors.Add("WEB_ORIGIN must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(corsOrigins))
+        {
+            errors.Add("CORS_ORIGINS must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(s3.Endpoint))
+        {
+            errors.Add("S3_ENDPOINT must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(s3.AccessKey)
+            || string.Equals(s3.AccessKey, DevDefaultCredential, StringComparison.Ordinal))
+        {
+            errors.Add("S3_ACCESS_KEY must be set to a non-default value.");
+        }
+
+        if (string.IsNullOrWhiteSpace(s3.SecretKey)
+            || string.Equals(s3.SecretKey, DevDefaultCredential, StringComparison.Ordinal))
+        {
+            errors.Add("S3_SECRET_KEY must be set to a non-default value.");
+        }
+
+        if (string.IsNullOrWhiteSpace(s3.PublicUrl))
+        {
+            errors.Add("S3_PUBLIC_URL must be set.");
+        }
+
+        return errors;
+    }
+}

--- a/server/src/GankedTV.Api/Data/DatabaseMigrator.cs
+++ b/server/src/GankedTV.Api/Data/DatabaseMigrator.cs
@@ -10,11 +10,19 @@ namespace GankedTV.Api.Data;
 /// </summary>
 public static class DatabaseMigrator
 {
-    /// <summary>Env-var name that gates startup migration. Set to <c>"true"</c> to enable.</summary>
+    /// <summary>Env-var name that gates startup migration. Set to a truthy value to enable.</summary>
     public const string EnableEnvVar = "RUN_MIGRATIONS_ON_STARTUP";
 
+    // Deliberately more lenient than the bool.TryParse-based MEDIA_* toggles in Program.cs:
+    // K8s ConfigMaps and many CI systems use "1"/"yes"/"on" by convention, and the failure mode
+    // of a silently-skipped migration (a fresh prod DB that boots but never migrates, leaving
+    // /health/ready red with a "migrations pending" message) is confusing to debug. Accepting
+    // the common truthy spellings here avoids that foot-gun.
+    private static readonly HashSet<string> TruthyValues =
+        new(StringComparer.OrdinalIgnoreCase) { "true", "1", "yes", "on" };
+
     public static bool IsEnabled(string? envValue) =>
-        string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+        envValue is not null && TruthyValues.Contains(envValue.Trim());
 
     public static async Task ApplyMigrationsAsync(
         GankedTvDbContext db,

--- a/server/src/GankedTV.Api/Data/DatabaseMigrator.cs
+++ b/server/src/GankedTV.Api/Data/DatabaseMigrator.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace GankedTV.Api.Data;
+
+/// <summary>
+/// Applies pending EF Core migrations at boot. Wired in <c>Program.cs</c> behind the
+/// <c>RUN_MIGRATIONS_ON_STARTUP</c> env flag (default off) so a fresh production DB
+/// self-migrates before the API serves its first request — locally migrations stay manual
+/// (<c>make migrate</c>). Idempotent: a re-run with no pending migrations is a no-op.
+/// </summary>
+public static class DatabaseMigrator
+{
+    /// <summary>Env-var name that gates startup migration. Set to <c>"true"</c> to enable.</summary>
+    public const string EnableEnvVar = "RUN_MIGRATIONS_ON_STARTUP";
+
+    public static bool IsEnabled(string? envValue) =>
+        string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+
+    public static async Task ApplyMigrationsAsync(
+        GankedTvDbContext db,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        var pending = (await db.Database.GetPendingMigrationsAsync(ct)).ToList();
+        if (pending.Count == 0)
+        {
+            logger.LogInformation("Startup migrations: database already up to date.");
+            return;
+        }
+
+        logger.LogInformation(
+            "Startup migrations: applying {Count} pending migration(s): {Migrations}",
+            pending.Count,
+            string.Join(", ", pending));
+        await db.Database.MigrateAsync(ct);
+        logger.LogInformation("Startup migrations: applied {Count} migration(s).", pending.Count);
+    }
+}

--- a/server/src/GankedTV.Api/Endpoints/DevAuthEndpoints.cs
+++ b/server/src/GankedTV.Api/Endpoints/DevAuthEndpoints.cs
@@ -32,8 +32,17 @@ public static class DevAuthEndpoints
         GankedTvDbContext db,
         IJwtService jwt,
         IRefreshTokenService refreshTokens,
+        IHostEnvironment env,
         CancellationToken ct)
     {
+        // Defense-in-depth: the route is only mapped in Development (see Program.cs), but guard
+        // the handler too so it can never mint a token if it's ever mapped by mistake. Returns
+        // 404 (not 403) so the endpoint is indistinguishable from "not present" outside dev.
+        if (!env.IsDevelopment())
+        {
+            return Results.NotFound();
+        }
+
         var raw = req?.Username ?? "dev-user";
         var username = UsernameGenerator.Slugify(raw);
         // Unknown role values silently fall back to "user" so a typo in the request body

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -18,12 +18,14 @@ using GankedTV.Api.Services.Igdb;
 using GankedTV.Api.Services.Maintenance;
 using GankedTV.Api.Services.Media;
 using GankedTV.Api.Services.Moderation;
+using GankedTV.Api.Services.Health;
 using GankedTV.Api.Services.ObjectStorage;
 using GankedTV.Api.Services.Tags;
 using GankedTV.Api.Tools;
 using GankedTV.Api.Validation;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using System.Text;
@@ -53,6 +55,11 @@ builder.Services.AddTransient<BannedUserMiddleware>();
 builder.Services.AddScoped<SeedCommand>();
 builder.Services.AddScoped<IReportService, ReportService>();
 builder.Services.AddHostedService<AdminBootstrap>();
+
+// Readiness probe: DB reachable + migrations applied (logic in ReadinessHealthCheck so it
+// stays in the coverage denominator). Liveness needs no checks — mapped with an empty predicate.
+builder.Services.AddHealthChecks()
+    .AddCheck<ReadinessHealthCheck>("ready", tags: ["ready"]);
 
 var connectionString = Environment.GetEnvironmentVariable("DATABASE_URL")
     ?? builder.Configuration.GetConnectionString("DefaultConnection")
@@ -425,6 +432,39 @@ builder.Services
     });
 builder.Services.AddCors();
 
+// Fail-fast secret validation: in Production, refuse to boot when required secrets are missing
+// (or still set to dev defaults) instead of running misconfigured and failing on the first
+// request. Reads raw env vars — not the DI-bound options — so dev fallbacks (localhost WebOrigin,
+// minioadmin S3 creds) can't mask an unset secret. Aggregation logic lives in
+// ProductionStartupValidator to stay inside the coverage denominator.
+if (builder.Environment.IsProduction())
+{
+    var secretErrors = ProductionStartupValidator.Validate(
+        connectionString,
+        new JwtOptions
+        {
+            Secret = Environment.GetEnvironmentVariable("JWT_SECRET") ?? "",
+            Issuer = "n/a",
+            Audience = "n/a",
+        },
+        new OAuthOptions { WebOrigin = Environment.GetEnvironmentVariable("WEB_ORIGIN") ?? "" },
+        new S3Options
+        {
+            Endpoint = Environment.GetEnvironmentVariable("S3_ENDPOINT") ?? "",
+            AccessKey = Environment.GetEnvironmentVariable("S3_ACCESS_KEY") ?? "",
+            SecretKey = Environment.GetEnvironmentVariable("S3_SECRET_KEY") ?? "",
+            PublicUrl = Environment.GetEnvironmentVariable("S3_PUBLIC_URL"),
+        },
+        Environment.GetEnvironmentVariable("CORS_ORIGINS"));
+    if (secretErrors.Count > 0)
+    {
+        throw new InvalidOperationException(
+            "Refusing to start in Production — required configuration is missing or invalid:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, secretErrors.Select(e => "  - " + e)));
+    }
+}
+
 var app = builder.Build();
 
 // --seed short-circuit: runs the dev seed against the configured DB and exits. We still build
@@ -448,6 +488,16 @@ if (ImportGamesCommand.ShouldRun(args))
     return;
 }
 
+// Startup migrations (gated by RUN_MIGRATIONS_ON_STARTUP, default off). Runs synchronously
+// before the app serves so a fresh prod DB self-migrates and /health/ready only goes green
+// once the schema exists. Locally migrations stay manual (`make migrate`).
+if (DatabaseMigrator.IsEnabled(Environment.GetEnvironmentVariable(DatabaseMigrator.EnableEnvVar)))
+{
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<GankedTvDbContext>();
+    await DatabaseMigrator.ApplyMigrationsAsync(db, app.Logger, CancellationToken.None);
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
@@ -459,6 +509,16 @@ app.UseMiddleware<ErrorHandlingMiddleware>();
 // 404 for unmatched routes, 415 for unsupported media types) into ProblemDetails so every
 // error response from the API has the same JSON envelope regardless of origin.
 app.UseStatusCodePages();
+
+// Health probes as terminal middleware placed BEFORE UseHttpsRedirection so an HTTP probe
+// (container HEALTHCHECK, k8s probe, the #123 deploy smoke-test) short-circuits with 200/503
+// instead of getting a 307 redirect to https. Liveness: process up, no dependency checks.
+// Readiness: DB reachable + migrations applied (the "ready"-tagged ReadinessHealthCheck).
+app.UseHealthChecks("/health/live", new HealthCheckOptions { Predicate = _ => false });
+app.UseHealthChecks(
+    "/health/ready",
+    new HealthCheckOptions { Predicate = check => check.Tags.Contains("ready") });
+
 // Skip in dev — :5050 is plain HTTP and the redirect emits CORS-less 307s.
 if (!app.Environment.IsDevelopment())
 {

--- a/server/src/GankedTV.Api/Services/Health/ReadinessHealthCheck.cs
+++ b/server/src/GankedTV.Api/Services/Health/ReadinessHealthCheck.cs
@@ -1,0 +1,42 @@
+using GankedTV.Api.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace GankedTV.Api.Services.Health;
+
+/// <summary>
+/// Readiness probe backing <c>GET /health/ready</c>. The instance is only "ready" once the
+/// database is reachable AND all EF migrations have been applied — a fresh prod DB that has
+/// not yet self-migrated (see <see cref="DatabaseMigrator"/>) reports Unhealthy so an
+/// orchestrator / deploy smoke-test holds traffic until the schema exists. Liveness
+/// (<c>/health/live</c>) is intentionally dependency-free and handled by an empty predicate.
+/// </summary>
+public sealed class ReadinessHealthCheck(GankedTvDbContext db) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!await db.Database.CanConnectAsync(cancellationToken))
+            {
+                return HealthCheckResult.Unhealthy("Database is not reachable.");
+            }
+
+            var pending = await db.Database.GetPendingMigrationsAsync(cancellationToken);
+            var pendingList = pending as IReadOnlyList<string> ?? pending.ToList();
+            if (pendingList.Count > 0)
+            {
+                return HealthCheckResult.Unhealthy(
+                    $"Database is reachable but {pendingList.Count} migration(s) are pending.");
+            }
+
+            return HealthCheckResult.Healthy("Database reachable and migrations applied.");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Readiness check failed.", ex);
+        }
+    }
+}

--- a/server/src/GankedTV.Api/appsettings.Production.json
+++ b/server/src/GankedTV.Api/appsettings.Production.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "GankedTV.Api": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    }
+  },
+  "MediaJobs": {
+    "TranscodeEnabled": true,
+    "ThumbnailWorkerEnabled": true,
+    "TranscodeWorkerEnabled": false
+  }
+}

--- a/server/tests/GankedTV.Api.Tests/Configuration/ProductionStartupValidatorTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Configuration/ProductionStartupValidatorTests.cs
@@ -1,0 +1,128 @@
+using FluentAssertions;
+using GankedTV.Api.Auth;
+using GankedTV.Api.Configuration;
+using GankedTV.Api.Services.ObjectStorage;
+
+namespace GankedTV.Api.Tests.Configuration;
+
+public class ProductionStartupValidatorTests
+{
+    private static JwtOptions ValidJwt() => new()
+    {
+        Secret = "a-production-jwt-secret-at-least-32b!",
+        Issuer = "gankedtv",
+        Audience = "gankedtv-web",
+    };
+
+    private static S3Options ValidS3() => new()
+    {
+        Endpoint = "https://s3.example.com",
+        AccessKey = "prod-access-key",
+        SecretKey = "prod-secret-key",
+        PublicUrl = "https://cdn.example.com",
+    };
+
+    private static IReadOnlyList<string> Validate(
+        string? connectionString = "Host=db;Database=gankedtv",
+        JwtOptions? jwt = null,
+        OAuthOptions? oauth = null,
+        S3Options? s3 = null,
+        string? corsOrigins = "https://ganked.tv")
+        => ProductionStartupValidator.Validate(
+            connectionString,
+            jwt ?? ValidJwt(),
+            oauth ?? new OAuthOptions { WebOrigin = "https://ganked.tv" },
+            s3 ?? ValidS3(),
+            corsOrigins);
+
+    [Fact]
+    public void Validate_AllPresent_ReturnsNoErrors()
+    {
+        Validate().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_MissingConnectionString_Flags()
+    {
+        Validate(connectionString: "  ").Should().ContainSingle(e => e.Contains("DATABASE_URL"));
+    }
+
+    [Fact]
+    public void Validate_MissingJwtSecret_Flags()
+    {
+        var jwt = ValidJwt();
+        jwt.Secret = "";
+        Validate(jwt: jwt).Should().ContainSingle(e => e.Contains("JWT_SECRET"));
+    }
+
+    [Fact]
+    public void Validate_ShortJwtSecret_Flags()
+    {
+        var jwt = ValidJwt();
+        jwt.Secret = "too-short";
+        Validate(jwt: jwt).Should().ContainSingle(e => e.Contains("at least 32 bytes"));
+    }
+
+    [Fact]
+    public void Validate_MissingWebOrigin_Flags()
+    {
+        Validate(oauth: new OAuthOptions { WebOrigin = "" })
+            .Should().ContainSingle(e => e.Contains("WEB_ORIGIN"));
+    }
+
+    [Fact]
+    public void Validate_MissingCorsOrigins_Flags()
+    {
+        Validate(corsOrigins: null).Should().ContainSingle(e => e.Contains("CORS_ORIGINS"));
+    }
+
+    [Fact]
+    public void Validate_MissingS3Endpoint_Flags()
+    {
+        var s3 = ValidS3();
+        s3.Endpoint = "";
+        Validate(s3: s3).Should().ContainSingle(e => e.Contains("S3_ENDPOINT"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("minioadmin")]
+    public void Validate_MissingOrDefaultS3AccessKey_Flags(string accessKey)
+    {
+        var s3 = ValidS3();
+        s3.AccessKey = accessKey;
+        Validate(s3: s3).Should().ContainSingle(e => e.Contains("S3_ACCESS_KEY"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("minioadmin")]
+    public void Validate_MissingOrDefaultS3SecretKey_Flags(string secretKey)
+    {
+        var s3 = ValidS3();
+        s3.SecretKey = secretKey;
+        Validate(s3: s3).Should().ContainSingle(e => e.Contains("S3_SECRET_KEY"));
+    }
+
+    [Fact]
+    public void Validate_MissingS3PublicUrl_Flags()
+    {
+        var s3 = ValidS3();
+        s3.PublicUrl = null;
+        Validate(s3: s3).Should().ContainSingle(e => e.Contains("S3_PUBLIC_URL"));
+    }
+
+    [Fact]
+    public void Validate_AllMissing_AggregatesEveryError()
+    {
+        var errors = ProductionStartupValidator.Validate(
+            connectionString: null,
+            new JwtOptions { Secret = "", Issuer = "x", Audience = "x" },
+            new OAuthOptions { WebOrigin = "" },
+            new S3Options(),
+            corsOrigins: null);
+
+        // connection, jwt, weborigin, cors, s3 endpoint, s3 access, s3 secret, s3 public url
+        errors.Should().HaveCount(8);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Data/DatabaseMigratorTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Data/DatabaseMigratorTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using GankedTV.Api.Data;
+using GankedTV.Api.Services.Health;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace GankedTV.Api.Tests.Data;
+
+// Own container (not the shared, already-migrated PostgresFixture) so we can exercise the
+// "applies pending migrations" branch against a fresh DB and then the "already up to date"
+// no-op branch on the second call.
+public class DatabaseMigratorTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("gankedtv_migrate_test")
+        .WithUsername("gankedtv")
+        .WithPassword("gankedtv_test")
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "CREATE EXTENSION IF NOT EXISTS pgcrypto;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task DisposeAsync() => await _container.DisposeAsync();
+
+    private GankedTvDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<GankedTvDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new GankedTvDbContext(options);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("True", true)]
+    [InlineData("false", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("1", false)]
+    public void IsEnabled_OnlyTrueIsEnabled(string? value, bool expected)
+    {
+        DatabaseMigrator.IsEnabled(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ApplyMigrationsAsync_FreshDb_AppliesThenSecondCallIsNoOp()
+    {
+        await using var db = CreateContext();
+
+        (await db.Database.GetAppliedMigrationsAsync()).Should().BeEmpty();
+
+        await DatabaseMigrator.ApplyMigrationsAsync(db, NullLogger.Instance);
+
+        (await db.Database.GetAppliedMigrationsAsync()).Should().NotBeEmpty();
+        (await db.Database.GetPendingMigrationsAsync()).Should().BeEmpty();
+
+        // Second call: nothing pending → no-op branch, must not throw.
+        await DatabaseMigrator.ApplyMigrationsAsync(db, NullLogger.Instance);
+        (await db.Database.GetPendingMigrationsAsync()).Should().BeEmpty();
+    }
+
+    // Exercises ReadinessHealthCheck against this owned container: Unhealthy while migrations
+    // are pending, Healthy once applied. (The shared fixture is always migrated, so the
+    // "pending" branch can only be covered with a fresh DB.)
+    [Fact]
+    public async Task Readiness_ReportsUnhealthyUntilMigrated_ThenHealthy()
+    {
+        await using var db = CreateContext();
+        var check = new ReadinessHealthCheck(db);
+        var context = new HealthCheckContext();
+
+        var beforeMigrate = await check.CheckHealthAsync(context);
+        beforeMigrate.Status.Should().Be(HealthStatus.Unhealthy);
+        beforeMigrate.Description.Should().Contain("pending");
+
+        await DatabaseMigrator.ApplyMigrationsAsync(db, NullLogger.Instance);
+
+        var afterMigrate = await check.CheckHealthAsync(context);
+        afterMigrate.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Readiness_ReportsUnhealthy_WhenDatabaseUnreachable()
+    {
+        var options = new DbContextOptionsBuilder<GankedTvDbContext>()
+            .UseNpgsql("Host=127.0.0.1;Port=1;Database=nope;Username=nope;Password=nope;Timeout=1;Command Timeout=1")
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        await using var db = new GankedTvDbContext(options);
+
+        var result = await new ReadinessHealthCheck(db).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("not reachable");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Data/DatabaseMigratorTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Data/DatabaseMigratorTests.cs
@@ -45,11 +45,15 @@ public class DatabaseMigratorTests : IAsyncLifetime
     [InlineData("true", true)]
     [InlineData("TRUE", true)]
     [InlineData("True", true)]
+    [InlineData("1", true)]
+    [InlineData("yes", true)]
+    [InlineData("on", true)]
+    [InlineData(" true ", true)] // tolerate surrounding whitespace from env/ConfigMap values
     [InlineData("false", false)]
+    [InlineData("0", false)]
     [InlineData("", false)]
     [InlineData(null, false)]
-    [InlineData("1", false)]
-    public void IsEnabled_OnlyTrueIsEnabled(string? value, bool expected)
+    public void IsEnabled_AcceptsCommonTruthyValues(string? value, bool expected)
     {
         DatabaseMigrator.IsEnabled(value).Should().Be(expected);
     }

--- a/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ProductionEnvironmentTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Integration/Endpoints/ProductionEnvironmentTests.cs
@@ -45,4 +45,27 @@ public class ProductionEnvironmentTests : IAsyncLifetime
 
         resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    [Fact]
+    public async Task Production_HealthLive_ReturnsOk()
+    {
+        // Liveness has no dependency checks, so it's 200 as soon as the process is up.
+        // Also proves the Production secret validation passed (the app booted at all).
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/health/live");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Production_HealthReady_ReturnsOk_WhenDbMigrated()
+    {
+        // The PostgresFixture migrates the test DB, so readiness reports healthy.
+        using var client = _factory!.CreateClient();
+
+        var resp = await client.GetAsync("/health/ready");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
 }

--- a/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/AuthApiFactory.cs
@@ -62,6 +62,19 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("JWT_SECRET", "smoke-test-jwt-secret-at-least-32-bytes-xx");
         Environment.SetEnvironmentVariable("OAUTH_STATE_SECRET", "smoke-test-state-secret-at-least-32-bytes");
         Environment.SetEnvironmentVariable("WEB_ORIGIN", "http://localhost:5173");
+        // Required by ProductionStartupValidator when environment == Production. Harmless in
+        // Development runs (the validator only fires in Production). Non-default S3 creds + a
+        // PublicUrl satisfy the "no dev defaults in prod" checks. CORS_ORIGINS must be present
+        // for the validator, but CorsOriginsTests set their own value before constructing the
+        // factory — only default it when unset so their assertions still win.
+        if (Environment.GetEnvironmentVariable("CORS_ORIGINS") is null)
+        {
+            Environment.SetEnvironmentVariable("CORS_ORIGINS", "http://localhost:5173");
+        }
+        Environment.SetEnvironmentVariable("S3_ENDPOINT", "http://localhost:9000");
+        Environment.SetEnvironmentVariable("S3_ACCESS_KEY", "test-s3-access-key");
+        Environment.SetEnvironmentVariable("S3_SECRET_KEY", "test-s3-secret-key");
+        Environment.SetEnvironmentVariable("S3_PUBLIC_URL", "http://localhost:9000");
         Environment.SetEnvironmentVariable("DISCORD_CLIENT_ID", "test-discord-client");
         Environment.SetEnvironmentVariable("DISCORD_CLIENT_SECRET", "test-discord-secret");
         Environment.SetEnvironmentVariable("DISCORD_REDIRECT_URI", "http://localhost:5000/auth/discord/callback");

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -1,5 +1,20 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  /** Base URL of the API. Injected at build time; falls back to localhost:5050 in dev. */
+  readonly VITE_API_BASE_URL?: string
+  /** GA4 measurement id (e.g. "G-XXXXXXX"). Present only in production builds; gates analytics. */
+  readonly VITE_GA_MEASUREMENT_ID?: string
+  /** When "true", skip localStorage token persistence (HttpOnly-cookie strategy). */
+  readonly VITE_USE_SECURE_COOKIES?: string
+  /** Max upload size in MB shown in the upload UI. */
+  readonly VITE_MAX_UPLOAD_SIZE_MB?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any

--- a/web/src/lib/__tests__/analytics.spec.ts
+++ b/web/src/lib/__tests__/analytics.spec.ts
@@ -3,6 +3,7 @@ import {
   initAnalytics,
   isAnalyticsEnabled,
   setAnalyticsProvider,
+  stripSensitiveParams,
   trackEvent,
   trackPageView,
 } from '../analytics'
@@ -65,10 +66,35 @@ describe('analytics wrapper', () => {
     expect(gtag).toHaveBeenCalledWith('event', 'share', { clipId: '42' })
   })
 
-  it('does not inject the script twice when gtag already exists', () => {
-    window.gtag = vi.fn()
+  it('does not inject the script twice but still configures on re-init', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
     initAnalytics('G-TEST123')
+
     const scripts = document.head.querySelectorAll('script[src*="googletagmanager"]')
     expect(scripts).toHaveLength(0)
+    // config must still run even though the gtag stub already existed.
+    expect(gtag).toHaveBeenCalledWith('config', 'G-TEST123', { send_page_view: false })
+  })
+})
+
+describe('stripSensitiveParams', () => {
+  it('returns the path unchanged when there is no query string', () => {
+    expect(stripSensitiveParams('/feed')).toBe('/feed')
+  })
+
+  it('drops OAuth credential params but keeps the rest', () => {
+    const out = stripSensitiveParams(
+      '/auth/callback?token=jwt&refresh=rt&code=c&state=s&access_token=a&id_token=i&returnTo=/feed',
+    )
+    expect(out).toBe('/auth/callback?returnTo=%2Ffeed')
+  })
+
+  it('collapses to the bare path when every param is sensitive', () => {
+    expect(stripSensitiveParams('/auth/callback?token=jwt&refresh=rt')).toBe('/auth/callback')
+  })
+
+  it('leaves non-sensitive query strings intact', () => {
+    expect(stripSensitiveParams('/trending?sort=week&page=2')).toBe('/trending?sort=week&page=2')
   })
 })

--- a/web/src/lib/__tests__/analytics.spec.ts
+++ b/web/src/lib/__tests__/analytics.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  initAnalytics,
+  isAnalyticsEnabled,
+  setAnalyticsProvider,
+  trackEvent,
+  trackPageView,
+} from '../analytics'
+
+describe('analytics wrapper', () => {
+  beforeEach(() => {
+    // Reset module-level state and any injected gtag between tests.
+    setAnalyticsProvider({ trackPageView() {}, trackEvent() {} })
+    delete window.gtag
+    delete window.dataLayer
+    document.head.querySelectorAll('script').forEach((s) => s.remove())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('is a no-op when no measurement id is provided', () => {
+    initAnalytics(undefined)
+    expect(isAnalyticsEnabled()).toBe(false)
+    // Must not throw or touch window.gtag.
+    trackPageView('/x')
+    trackEvent('click', { a: 1 })
+    expect(window.gtag).toBeUndefined()
+  })
+
+  it('treats a blank/whitespace id as disabled', () => {
+    initAnalytics('   ')
+    expect(isAnalyticsEnabled()).toBe(false)
+    expect(window.gtag).toBeUndefined()
+  })
+
+  it('loads gtag.js and configures GA4 when an id is provided', () => {
+    initAnalytics('G-TEST123')
+    expect(isAnalyticsEnabled()).toBe(true)
+
+    const script = document.head.querySelector<HTMLScriptElement>('script[src*="googletagmanager"]')
+    expect(script).not.toBeNull()
+    expect(script!.src).toContain('id=G-TEST123')
+    expect(typeof window.gtag).toBe('function')
+  })
+
+  it('forwards page views and events to gtag', () => {
+    initAnalytics('G-TEST123')
+    const gtag = vi.fn()
+    window.gtag = gtag
+
+    trackPageView('/feed', 'Feed')
+    trackEvent('share', { clipId: '42' })
+
+    expect(gtag).toHaveBeenCalledWith(
+      'event',
+      'page_view',
+      expect.objectContaining({
+        page_path: '/feed',
+        page_location: `${window.location.origin}/feed`,
+        page_title: 'Feed',
+      }),
+    )
+    expect(gtag).toHaveBeenCalledWith('event', 'share', { clipId: '42' })
+  })
+
+  it('does not inject the script twice when gtag already exists', () => {
+    window.gtag = vi.fn()
+    initAnalytics('G-TEST123')
+    const scripts = document.head.querySelectorAll('script[src*="googletagmanager"]')
+    expect(scripts).toHaveLength(0)
+  })
+})

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,90 @@
+// Thin, swappable analytics wrapper. The app talks to `trackPageView` / `trackEvent`; the
+// concrete backend (Google Analytics 4 today, e.g. PostHog later) sits behind an
+// `AnalyticsProvider` so swapping vendors is a one-file change. Loading is gated on the
+// presence of `VITE_GA_MEASUREMENT_ID`, so without the env var everything is a no-op and
+// dev/local stays clean (no network, no cookies). Consent gating is a documented follow-up.
+
+export interface AnalyticsProvider {
+  trackPageView(path: string, title?: string): void
+  trackEvent(name: string, params?: Record<string, unknown>): void
+}
+
+const noopProvider: AnalyticsProvider = {
+  trackPageView() {},
+  trackEvent() {},
+}
+
+let provider: AnalyticsProvider = noopProvider
+
+/** Replace the active provider — used by `initAnalytics` and by tests. */
+export function setAnalyticsProvider(next: AnalyticsProvider): void {
+  provider = next
+}
+
+/** True once a real (non-noop) provider is active. */
+export function isAnalyticsEnabled(): boolean {
+  return provider !== noopProvider
+}
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+/** Loads gtag.js once and returns a GA4-backed provider. */
+function createGtagProvider(measurementId: string): AnalyticsProvider {
+  if (typeof document !== 'undefined' && !window.gtag) {
+    const script = document.createElement('script')
+    script.async = true
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`
+    document.head.appendChild(script)
+
+    window.dataLayer = window.dataLayer || []
+    window.gtag = function gtag(...args: unknown[]) {
+      window.dataLayer!.push(args)
+    }
+    window.gtag('js', new Date())
+    // send_page_view:false — SPA page views are emitted by the router (see router/index.ts),
+    // otherwise the initial automatic hit double-counts the first navigation.
+    window.gtag('config', measurementId, { send_page_view: false })
+  }
+
+  return {
+    trackPageView(path, title) {
+      // GA4 reads page_location (absolute URL) + page_title; page_path is kept for reports
+      // that still key off it. Resolve location/title from the document when not supplied.
+      const origin = typeof window !== 'undefined' ? window.location.origin : ''
+      window.gtag?.('event', 'page_view', {
+        page_path: path,
+        page_location: origin + path,
+        page_title: title ?? (typeof document !== 'undefined' ? document.title : undefined),
+      })
+    },
+    trackEvent(name, params) {
+      window.gtag?.('event', name, params)
+    },
+  }
+}
+
+/**
+ * Wires up analytics from the build-time measurement id. No id (undefined/empty) ⇒ no-op,
+ * so production is the only place GA actually loads. Idempotent enough for app bootstrap.
+ */
+export function initAnalytics(measurementId: string | undefined): void {
+  const id = measurementId?.trim()
+  if (!id) {
+    setAnalyticsProvider(noopProvider)
+    return
+  }
+  setAnalyticsProvider(createGtagProvider(id))
+}
+
+export function trackPageView(path: string, title?: string): void {
+  provider.trackPageView(path, title)
+}
+
+export function trackEvent(name: string, params?: Record<string, unknown>): void {
+  provider.trackEvent(name, params)
+}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -9,6 +9,32 @@ export interface AnalyticsProvider {
   trackEvent(name: string, params?: Record<string, unknown>): void
 }
 
+// Query keys that can carry credentials/secrets and must never be shipped to a third-party
+// analytics provider. The OAuth callback lands on /auth/callback?token=<JWT>&refresh=<token>,
+// so a naive `trackPageView(to.fullPath)` would leak a 30-day refresh token to GA.
+const SENSITIVE_QUERY_KEYS = new Set([
+  'token',
+  'refresh',
+  'code',
+  'state',
+  'access_token',
+  'id_token',
+])
+
+/** Removes sensitive query params from a router fullPath before it reaches analytics. */
+export function stripSensitiveParams(fullPath: string): string {
+  const [path, query = ''] = fullPath.split('?')
+  if (!query) return path
+  // Rebuild from only the non-sensitive entries (rather than deleting in place, which would
+  // mutate the live iterator) — preserves original order and is straightforward to read.
+  const kept = new URLSearchParams()
+  for (const [key, value] of new URLSearchParams(query)) {
+    if (!SENSITIVE_QUERY_KEYS.has(key)) kept.append(key, value)
+  }
+  const qs = kept.toString()
+  return qs ? `${path}?${qs}` : path
+}
+
 const noopProvider: AnalyticsProvider = {
   trackPageView() {},
   trackEvent() {},
@@ -35,19 +61,23 @@ declare global {
 
 /** Loads gtag.js once and returns a GA4-backed provider. */
 function createGtagProvider(measurementId: string): AnalyticsProvider {
-  if (typeof document !== 'undefined' && !window.gtag) {
-    const script = document.createElement('script')
-    script.async = true
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`
-    document.head.appendChild(script)
+  if (typeof document !== 'undefined') {
+    // The script + dataLayer/gtag stub bootstrap exactly once; re-init must not inject twice.
+    if (!window.gtag) {
+      const script = document.createElement('script')
+      script.async = true
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`
+      document.head.appendChild(script)
 
-    window.dataLayer = window.dataLayer || []
-    window.gtag = function gtag(...args: unknown[]) {
-      window.dataLayer!.push(args)
+      window.dataLayer = window.dataLayer || []
+      window.gtag = function gtag(...args: unknown[]) {
+        window.dataLayer!.push(args)
+      }
+      window.gtag('js', new Date())
     }
-    window.gtag('js', new Date())
-    // send_page_view:false — SPA page views are emitted by the router (see router/index.ts),
-    // otherwise the initial automatic hit double-counts the first navigation.
+    // config runs on every init (outside the bootstrap guard) so a re-init with a new
+    // measurement id still configures it. send_page_view:false — SPA page views are emitted by
+    // the router (see router/index.ts); the initial automatic hit would double-count otherwise.
     window.gtag('config', measurementId, { send_page_view: false })
   }
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -6,6 +6,7 @@ import router from './router'
 import { useThemeStore } from './stores/theme'
 import { useAuthStore } from './stores/auth'
 import { configureAuth } from './api/client'
+import { initAnalytics } from './lib/analytics'
 import './assets/main.css'
 
 const app = createApp(App)
@@ -27,6 +28,9 @@ configureAuth({
 })
 
 await auth.bootstrap()
+
+// No-op unless VITE_GA_MEASUREMENT_ID is set at build time (production only).
+initAnalytics(import.meta.env.VITE_GA_MEASUREMENT_ID)
 
 app.use(router)
 app.mount('#app')

--- a/web/src/router/__tests__/index.spec.ts
+++ b/web/src/router/__tests__/index.spec.ts
@@ -4,7 +4,12 @@ import { useAuthStore } from '@/stores/auth'
 import { trackPageView } from '@/lib/analytics'
 import type { Router } from 'vue-router'
 
-vi.mock('@/lib/analytics', () => ({ trackPageView: vi.fn() }))
+// Keep the real stripSensitiveParams (so the redaction is exercised end-to-end) but spy on
+// the sink so we can assert exactly what would be shipped to analytics.
+vi.mock('@/lib/analytics', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/analytics')>('@/lib/analytics')
+  return { ...actual, trackPageView: vi.fn() }
+})
 
 // Swap createWebHistory → createMemoryHistory in the router module so navigation doesn't
 // depend on the jsdom window.location. This lets router.isReady() resolve deterministically
@@ -140,6 +145,20 @@ describe('analytics page-view hook', () => {
     vi.mocked(trackPageView).mockClear()
     await router.push('/clip/clp_7?ref=feed')
     expect(trackPageView).toHaveBeenCalledWith('/clip/clp_7?ref=feed')
+  })
+
+  it('strips OAuth credentials from the tracked path on /auth/callback', async () => {
+    vi.mocked(trackPageView).mockClear()
+    await router.push('/auth/callback?token=fake-jwt&refresh=fake-refresh&returnTo=/feed')
+
+    expect(trackPageView).toHaveBeenCalledTimes(1)
+    const tracked = vi.mocked(trackPageView).mock.calls[0][0]
+    expect(tracked).not.toContain('token')
+    expect(tracked).not.toContain('fake-jwt')
+    expect(tracked).not.toContain('refresh')
+    expect(tracked).not.toContain('fake-refresh')
+    // Non-sensitive params are preserved.
+    expect(tracked).toContain('returnTo=%2Ffeed')
   })
 })
 

--- a/web/src/router/__tests__/index.spec.ts
+++ b/web/src/router/__tests__/index.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
+import { trackPageView } from '@/lib/analytics'
 import type { Router } from 'vue-router'
+
+vi.mock('@/lib/analytics', () => ({ trackPageView: vi.fn() }))
 
 // Swap createWebHistory → createMemoryHistory in the router module so navigation doesn't
 // depend on the jsdom window.location. This lets router.isReady() resolve deterministically
@@ -129,6 +132,14 @@ describe('router beforeEach guard', () => {
     })
     await router.push('/admin')
     expect(router.currentRoute.value.name).toBe('admin')
+  })
+})
+
+describe('analytics page-view hook', () => {
+  it('emits a page view with the full path after each navigation', async () => {
+    vi.mocked(trackPageView).mockClear()
+    await router.push('/clip/clp_7?ref=feed')
+    expect(trackPageView).toHaveBeenCalledWith('/clip/clp_7?ref=feed')
   })
 })
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { trackPageView } from '@/lib/analytics'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -142,6 +143,12 @@ router.beforeEach((to) => {
   if (required === 'moderator' && !auth.isModerator) {
     return { name: 'home' }
   }
+})
+
+// Emit SPA page views after each successful navigation. No-op until analytics is initialised
+// with a measurement id (production only), so this is inert in dev and tests.
+router.afterEach((to) => {
+  trackPageView(to.fullPath)
 })
 
 export default router

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { trackPageView } from '@/lib/analytics'
+import { stripSensitiveParams, trackPageView } from '@/lib/analytics'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -146,9 +146,10 @@ router.beforeEach((to) => {
 })
 
 // Emit SPA page views after each successful navigation. No-op until analytics is initialised
-// with a measurement id (production only), so this is inert in dev and tests.
+// with a measurement id (production only), so this is inert in dev and tests. Sensitive query
+// params (OAuth token/refresh on /auth/callback, etc.) are stripped before they reach analytics.
 router.afterEach((to) => {
-  trackPageView(to.fullPath)
+  trackPageView(stripSensitiveParams(to.fullPath))
 })
 
 export default router


### PR DESCRIPTION
Closes #122 — the blocker for the CI/CD deploy work (#123).

## Server
- **Health endpoints** — `GET /health/live` (liveness, no deps) and `GET /health/ready` (DB reachable + migrations applied). Mapped as **terminal middleware before `UseHttpsRedirection`** so HTTP probes (container `HEALTHCHECK`, k8s, the #123 smoke-test) get `200`/`503` instead of a `307` redirect. Logic lives in `ReadinessHealthCheck`.
- **Startup migrations** — `DatabaseMigrator` runs `Database.MigrateAsync()` at boot, gated by `RUN_MIGRATIONS_ON_STARTUP` (default off; locally migrations stay manual). `/health/ready` only greens once migrations are applied.
- **`appsettings.Production.json`** — prod logging levels + main-API media-worker toggles. No secrets.
- **Fail-fast secret validation** — `ProductionStartupValidator` refuses to boot in Production when `DATABASE_URL`, `JWT_SECRET` (≥32B), `WEB_ORIGIN`, `CORS_ORIGINS`, or `S3_*` are missing/dev-default, with a clear aggregated error.
- **Dev-endpoint lockdown** — defense-in-depth runtime `IsDevelopment()` guard inside `POST /dev/token` (already unmapped by default outside dev).

## Web
- **GA4 analytics** behind a swappable wrapper (`src/lib/analytics.ts`), gated on `VITE_GA_MEASUREMENT_ID` — a complete no-op (no script, no cookies) when unset. SPA page views via `router.afterEach` (sends GA4 `page_location`/`page_title`). Env types added to `env.d.ts`.

## Docs
- New `DEPLOYMENT.md` (required prod env vars, secret handling, health endpoints, worker toggles, web build-time vars) + `.env.example` entries.

## Scope / follow-ups
- Containerization (`web/Dockerfile`, `docker-compose.prod.yml`, `release.yml`, deploy job) is **#123**, not here — the web build task here is docs + `.env.example` only.
- **Cookie-consent gating for GA is a documented follow-up** (GA currently loads whenever the measurement id is present).

## Verification
- Server: `make ci-server` green — 980 tests pass, coverage **94.71% line / 85.44% branch** (gate 85/85).
- Web: `make ci-web` green — type-check, lint, 244 tests, coverage gate met, prod build succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fail-fast production startup validation for missing/invalid config.
  * Readiness and liveness health endpoints for monitoring.
  * Optional automatic DB migrations on startup (env-controlled).
  * Client analytics with GA4 support, safer page-view tracking that strips sensitive OAuth params.
  * Dev-only token endpoint now blocked outside development.

* **Documentation**
  * Added detailed production deployment guide and updated example env file.

* **Tests**
  * Added tests for startup validation, migrations, health checks, and analytics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->