### PR TITLE
[server][web][discord][ci] Fetch secrets from self-hosted Vaultwarden-API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Build context for the discord bot image is the repo ROOT (docker-compose.dev.yml) so it can COPY
+# the shared/ module. Send only what that image needs — allowlist discord/ + shared/, drop the rest.
+# (The .NET API image uses its own server/-scoped build, so this allowlist doesn't affect it.)
+*
+!discord
+!shared
+
+# ...but never ship local build artifacts, even from the allowlisted dirs.
+**/node_modules
+**/coverage
+**/dist
+**/*.local

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,16 @@ ASPNETCORE_ENVIRONMENT=Development
 # /health/ready goes green. See DEPLOYMENT.md.
 RUN_MIGRATIONS_ON_STARTUP=false
 
+# Vaultwarden secret bootstrap — OPTIONAL in development. When set, the API, the Discord bot and the
+# web build fetch their secrets from the self-hosted Vaultwarden-API instead of this file. A value
+# already set here / in the shell always wins (the vault only fills unset keys); leave empty to run
+# from this file. Collection from ASPNETCORE_ENVIRONMENT: Production -> "Secrets - PROD", else
+# "Secrets - DEV". The API key belongs to the `secrets@` user. See DEPLOYMENT.md for the manifest.
+# VAULTWARDEN_API_URL=https://vault.internal
+# VAULTWARDEN_API_KEY=
+# VAULTWARDEN_ORG=GankedTV
+# VAULTWARDEN_COLLECTION=        # optional explicit override of the env-derived collection
+
 # JWT + refresh tokens
 # JWT_SECRET must be >= 32 bytes (generate with: openssl rand -hex 32)
 JWT_SECRET=

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'discord/**'
+      - 'shared/**'
       - '.github/workflows/discord.yml'
   pull_request:
     branches: [main]
     paths:
       - 'discord/**'
+      - 'shared/**'
       - '.github/workflows/discord.yml'
 
 concurrency:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: this workflow only reads source and builds/tests.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'web/**'
+      - 'shared/**'
       - '.github/workflows/web.yml'
   pull_request:
     branches: [main]
     paths:
       - 'web/**'
+      - 'shared/**'
       - '.github/workflows/web.yml'
 
 concurrency:
@@ -35,6 +37,13 @@ jobs:
 
       - name: Build
         run: bun run build
+        env:
+          # On push to main, the prebuild pulls VITE_* from Vaultwarden's PROD collection; on PRs
+          # these are blank so it no-ops and the committed .env is used (PR CI stays independent of
+          # the vault). Needs ENABLE_GITHUB_IP_RANGES on the API to whitelist runner IPs.
+          VAULTWARDEN_API_URL: ${{ github.event_name == 'push' && secrets.VAULTWARDEN_API_URL || '' }}
+          VAULTWARDEN_API_KEY: ${{ github.event_name == 'push' && secrets.VAULTWARDEN_API_KEY || '' }}
+          ASPNETCORE_ENVIRONMENT: ${{ github.event_name == 'push' && 'Production' || '' }}
 
   format:
     needs: build

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,9 +4,10 @@ Production runtime requirements and configuration for GankedTV. This covers the 
 and the **web frontend**; container build/publish and the auto-deploy pipeline are tracked
 separately in issue #123.
 
-> **Secrets are never committed.** Everything below is provided via environment variables (or
-> your orchestrator's secret store) at runtime — there are no secrets in `appsettings*.json` or
-> any checked-in file.
+> **Secrets are never committed.** In production they come from the self-hosted Vaultwarden-API
+> (see [Secret management](#secret-management-vaultwarden)) or your orchestrator's secret store, fed
+> in via environment variables at runtime — there are no secrets in `appsettings*.json` or any
+> checked-in file.
 
 ## Hard requirements
 
@@ -36,6 +37,53 @@ Required:
 
 Also recommended in production: `OAUTH_STATE_SECRET` (≥ 32 bytes; required once any OAuth provider
 is configured) and the provider client credentials (`DISCORD_*`, `GOOGLE_*`).
+
+## Secret management (Vaultwarden)
+
+Secrets are sourced from the self-hosted [Vaultwarden-API](https://github.com/Turbootzz/Vaultwarden-API)
+rather than hand-placed per environment. Each app fetches its secrets at startup (API,
+bot) or build (web) and layers them into the environment; **a value already set in the environment
+always wins**, so the vault is the source of truth without removing per-key overrides. The same TS
+client (`shared/vaultwarden/`) backs the bot and the web build; the API has an equivalent in
+[VaultwardenSecretsLoader](server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs).
+
+**Bootstrap vars** (the only secrets that stay in the environment — you can't fetch secrets without
+one):
+
+| Var | Purpose |
+|---|---|
+| `VAULTWARDEN_API_URL` | Base URL of the Vaultwarden-API. Unset → the whole integration no-ops and apps fall back to `.env`/env. |
+| `VAULTWARDEN_API_KEY` | Bearer token of the dedicated `secrets@` Vaultwarden user (a member of the `GankedTV` org with access to both collections). |
+| `VAULTWARDEN_ORG` | Organization. Defaults to `GankedTV`. |
+| `VAULTWARDEN_COLLECTION` | Optional explicit collection override (else env-derived). |
+
+**Collection per environment.** `ASPNETCORE_ENVIRONMENT` (the bot also falls back to `NODE_ENV`)
+selects the collection: `Production` → **`Secrets - PROD`**, anything else → **`Secrets - DEV`**.
+Vault items are named exactly like the env keys, scoped by org + collection so the same key can hold
+different values in DEV vs PROD without colliding.
+
+**Resilience.** Fetches are sequential (the API rate-limits 30 req/min/IP) and one-shot at
+startup/build — rotate a secret by restarting/rebuilding. In **Production** a required secret that
+can't be fetched **fails the boot** with a clear, Vaultwarden-specific error; in development a
+missing/unreachable vault falls back to `.env`. The API's fetch runs **before** the fail-fast
+validation above, so a prod boot supplied with only the two bootstrap vars has the vault populate
+`DATABASE_URL` / `JWT_SECRET` / `S3_*` / … and then passes validation.
+
+**Per-app manifest** (the keys each app fetches):
+
+| App | Keys |
+|---|---|
+| API | `DATABASE_URL`, `JWT_SECRET`, `OAUTH_STATE_SECRET`, `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_PUBLIC_URL`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`, `REDIS_URL`, `WEB_ORIGIN`, `CORS_ORIGINS` |
+| Discord bot | `DISCORD_BOT_TOKEN`, `DISCORD_BOT_APP_ID`, `DISCORD_DATABASE_URL` |
+| Web build | `VITE_API_BASE_URL`, `VITE_GA_MEASUREMENT_ID`, `VITE_USE_SECURE_COOKIES`, `VITE_MAX_UPLOAD_SIZE_MB` (baked into the public bundle — single source of truth, not secrecy) |
+
+`SENTRY_DSN` is intentionally **absent** — there's no Sentry integration yet (tracked in #124); add
+it to the manifests when that lands.
+
+**CI.** The web build workflow pulls `VITE_*` from the PROD collection on pushes to `main` (using a
+`VAULTWARDEN_API_KEY` GitHub secret and the API's `ENABLE_GITHUB_IP_RANGES` to whitelist runner IPs);
+PR builds skip the fetch and use the committed `.env`, so PR CI doesn't depend on vault availability.
+Sourcing the **deploy** job's secrets from Vaultwarden is part of #123.
 
 ## Startup database migrations
 

--- a/discord/.env.example
+++ b/discord/.env.example
@@ -9,6 +9,14 @@
 DISCORD_BOT_TOKEN=
 DISCORD_BOT_APP_ID=
 
+# Vaultwarden secret bootstrap — OPTIONAL. When set (usually at the repo-root .env), the bot fetches
+# DISCORD_BOT_TOKEN, DISCORD_BOT_APP_ID and DISCORD_DATABASE_URL from Vaultwarden at startup. A value
+# already set here / in the shell wins. See DEPLOYMENT.md for the full contract.
+# VAULTWARDEN_API_URL=https://vault.internal
+# VAULTWARDEN_API_KEY=
+# VAULTWARDEN_ORG=GankedTV
+# VAULTWARDEN_COLLECTION=
+
 # Optional: a guild id to register slash commands against during development.
 # Guild-scoped registration propagates within seconds; global registration can
 # take up to an hour. Leave empty in production.

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -1,18 +1,21 @@
 FROM oven/bun:1.3.13-alpine
 
+# Build context is the repo ROOT (see docker-compose.dev.yml) so the image can include the shared
+# shared/ TypeScript module the bot imports. We keep the repo-relative layout (/app/discord +
+# /app/shared) so the bot's `../../shared/...` import resolves identically in dev and in the image.
 WORKDIR /app
 
-# Install + copy as root so the working tree ends up owned by root (cached layer
-# stays small), then chown to a dedicated unprivileged user for runtime. The bot
-# only needs read access to its own files + outbound network — no reason for it
-# to run as uid 0.
-COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production
+# Install + copy as root so the working tree ends up owned by root (cached layer stays small), then
+# chown to a dedicated unprivileged user for runtime. The bot only needs read access to its own
+# files + outbound network — no reason for it to run as uid 0.
+COPY discord/package.json discord/bun.lock ./discord/
+RUN cd discord && bun install --frozen-lockfile --production
 
-COPY src ./src
-COPY tsconfig.json bunfig.toml ./
+COPY shared ./shared
+COPY discord/src ./discord/src
+COPY discord/tsconfig.json discord/bunfig.toml ./discord/
 
 RUN addgroup -S bot && adduser -S bot -G bot && chown -R bot:bot /app
 USER bot
 
-CMD ["bun", "run", "src/index.ts"]
+CMD ["bun", "run", "discord/src/index.ts"]

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -1,6 +1,6 @@
-// Side-effect import — merges the repo-root .env into process.env BEFORE
-// loadConfig reads it. Mirrors web/vite.config.ts's `envDir: '../'`.
-import './loadEnv.ts';
+// Importing loadEnv runs its side effect (merging the repo-root .env into process.env) and exposes
+// loadVaultwardenSecrets, which main() awaits before loadConfig().
+import { loadVaultwardenSecrets } from './loadEnv.ts';
 
 import { Client, GatewayIntentBits, REST, Routes, type Interaction } from 'discord.js';
 import { loadConfig } from './config.ts';
@@ -28,6 +28,8 @@ const log: PollerLogger = {
 };
 
 async function main(): Promise<void> {
+  // Pull secrets from Vaultwarden (no-op unless the bootstrap vars are set) before reading config.
+  await loadVaultwardenSecrets(process.env);
   const config = loadConfig();
 
   if (!config.enabled) {

--- a/discord/src/loadEnv.ts
+++ b/discord/src/loadEnv.ts
@@ -71,9 +71,9 @@ export async function loadVaultwardenSecrets(
   target: Record<string, string | undefined> = process.env,
   opts: { manifest?: readonly string[]; fetchImpl?: typeof fetch; timeoutMs?: number } = {},
 ): Promise<void> {
-  const apiUrl = target.VAULTWARDEN_API_URL;
-  const apiKey = target.VAULTWARDEN_API_KEY;
-  if (!apiUrl?.trim() || !apiKey?.trim()) return; // opt-in: no bootstrap vars → no-op
+  const apiUrl = target.VAULTWARDEN_API_URL?.trim();
+  const apiKey = target.VAULTWARDEN_API_KEY?.trim();
+  if (!apiUrl || !apiKey) return; // opt-in: no bootstrap vars → no-op
 
   const environment = target.ASPNETCORE_ENVIRONMENT ?? target.NODE_ENV;
   const failFast = environment?.toLowerCase() === 'production';
@@ -90,7 +90,11 @@ export async function loadVaultwardenSecrets(
     fetchImpl: opts.fetchImpl,
     timeoutMs: opts.timeoutMs,
   });
-  mergeFirstWins(target, fetched);
+  // Fill keys that are unset OR a blank placeholder (matching the server's IsNullOrWhiteSpace skip);
+  // a non-empty value still wins. mergeFirstWins (presence-based) stays for the .env layering above.
+  for (const [key, value] of Object.entries(fetched)) {
+    if (!target[key]?.trim()) target[key] = value;
+  }
 }
 
 // Side effect at import time. Tests of the helpers above pass an explicit

--- a/discord/src/loadEnv.ts
+++ b/discord/src/loadEnv.ts
@@ -14,6 +14,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { fetchSecrets, resolveCollection } from '../../shared/vaultwarden/client.ts';
 
 export function parseEnvFile(contents: string): Record<string, string> {
   const out: Record<string, string> = {};
@@ -53,6 +54,43 @@ export function loadRootEnv(
 ): void {
   if (!existsSync(envPath)) return;
   mergeFirstWins(target, parseEnvFile(readFileSync(envPath, 'utf8')));
+}
+
+// The bot's required secrets, fetched from Vaultwarden by these exact names. No SENTRY_DSN — no
+// Sentry integration yet.
+export const vaultwardenManifest = [
+  'DISCORD_BOT_TOKEN',
+  'DISCORD_BOT_APP_ID',
+  'DISCORD_DATABASE_URL',
+] as const;
+
+// Fetches the bot's secrets from Vaultwarden and layers them into `target` via mergeFirstWins, so a
+// shell/.env value still beats the vault. No-op when the bootstrap vars are unset. Production fails
+// fast on a missing/errored secret; dev falls back to .env.
+export async function loadVaultwardenSecrets(
+  target: Record<string, string | undefined> = process.env,
+  opts: { manifest?: readonly string[]; fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<void> {
+  const apiUrl = target.VAULTWARDEN_API_URL;
+  const apiKey = target.VAULTWARDEN_API_KEY;
+  if (!apiUrl?.trim() || !apiKey?.trim()) return; // opt-in: no bootstrap vars → no-op
+
+  const environment = target.ASPNETCORE_ENVIRONMENT ?? target.NODE_ENV;
+  const failFast = environment?.toLowerCase() === 'production';
+  const fetched = await fetchSecrets({
+    apiUrl,
+    apiKey,
+    collection: resolveCollection(target),
+    manifest: opts.manifest ?? vaultwardenManifest,
+    organization: target.VAULTWARDEN_ORG?.trim() || undefined,
+    // Production fails fast on anything missing or errored; dev falls back to .env on both.
+    throwIfMissing: failFast,
+    throwOnError: failFast,
+    alreadySet: (key) => Boolean(target[key]?.trim()),
+    fetchImpl: opts.fetchImpl,
+    timeoutMs: opts.timeoutMs,
+  });
+  mergeFirstWins(target, fetched);
 }
 
 // Side effect at import time. Tests of the helpers above pass an explicit

--- a/discord/tests/loadEnv.test.ts
+++ b/discord/tests/loadEnv.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from 'bun:test';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadRootEnv, mergeFirstWins, parseEnvFile } from '../src/loadEnv.ts';
+import {
+  loadRootEnv,
+  loadVaultwardenSecrets,
+  mergeFirstWins,
+  parseEnvFile,
+} from '../src/loadEnv.ts';
 
 describe('parseEnvFile', () => {
   test('parses KEY=value pairs', () => {
@@ -85,5 +90,51 @@ describe('loadRootEnv', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('loadVaultwardenSecrets', () => {
+  const throwingFetch = (async () => {
+    throw new Error('fetch should not have been called');
+  }) as unknown as typeof fetch;
+
+  test('no-ops when the bootstrap vars are unset', async () => {
+    const target: Record<string, string | undefined> = { DISCORD_BOT_TOKEN: undefined };
+    await loadVaultwardenSecrets(target, { fetchImpl: throwingFetch });
+    expect(target).toEqual({ DISCORD_BOT_TOKEN: undefined });
+  });
+
+  test('fills unset keys but never overwrites an already-set one (env wins)', async () => {
+    const target: Record<string, string | undefined> = {
+      VAULTWARDEN_API_URL: 'https://vault.test',
+      VAULTWARDEN_API_KEY: 'k',
+      DISCORD_BOT_TOKEN: 'from-shell',
+    };
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const key = decodeURIComponent(String(input).split('/secret/')[1]!.split('?')[0]!);
+      return new Response(JSON.stringify({ name: key, value: `vault-${key}` }), { status: 200 });
+    }) as typeof fetch;
+
+    await loadVaultwardenSecrets(target, {
+      fetchImpl,
+      manifest: ['DISCORD_BOT_TOKEN', 'DISCORD_BOT_APP_ID'],
+    });
+
+    expect(target.DISCORD_BOT_TOKEN).toBe('from-shell'); // already set → not overwritten
+    expect(target.DISCORD_BOT_APP_ID).toBe('vault-DISCORD_BOT_APP_ID'); // filled from vault
+  });
+
+  test('production fails fast when a required secret is missing', async () => {
+    const target: Record<string, string | undefined> = {
+      VAULTWARDEN_API_URL: 'https://vault.test',
+      VAULTWARDEN_API_KEY: 'k',
+      ASPNETCORE_ENVIRONMENT: 'Production',
+    };
+    const fetchImpl = (async () =>
+      new Response('{"error":"secret not found"}', { status: 404 })) as unknown as typeof fetch;
+
+    await expect(
+      loadVaultwardenSecrets(target, { fetchImpl, manifest: ['DISCORD_BOT_TOKEN'] }),
+    ).rejects.toThrow(/not found/);
   });
 });

--- a/discord/tests/loadEnv.test.ts
+++ b/discord/tests/loadEnv.test.ts
@@ -124,6 +124,27 @@ describe('loadVaultwardenSecrets', () => {
     expect(target.DISCORD_BOT_APP_ID).toBe('vault-DISCORD_BOT_APP_ID'); // filled from vault
   });
 
+  test('fills a blank placeholder from the vault (blank counts as unset, matching the server)', async () => {
+    const target: Record<string, string | undefined> = {
+      VAULTWARDEN_API_URL: 'https://vault.test',
+      VAULTWARDEN_API_KEY: 'k',
+      DISCORD_BOT_TOKEN: '', // blank placeholder → should be filled from the vault
+      DISCORD_BOT_APP_ID: 'set-app', // genuinely set → preserved
+    };
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const key = decodeURIComponent(String(input).split('/secret/')[1]!.split('?')[0]!);
+      return new Response(JSON.stringify({ name: key, value: `vault-${key}` }), { status: 200 });
+    }) as typeof fetch;
+
+    await loadVaultwardenSecrets(target, {
+      fetchImpl,
+      manifest: ['DISCORD_BOT_TOKEN', 'DISCORD_BOT_APP_ID'],
+    });
+
+    expect(target.DISCORD_BOT_TOKEN).toBe('vault-DISCORD_BOT_TOKEN'); // blank filled
+    expect(target.DISCORD_BOT_APP_ID).toBe('set-app'); // non-empty preserved
+  });
+
   test('production fails fast when a required secret is missing', async () => {
     const target: Record<string, string | undefined> = {
       VAULTWARDEN_API_URL: 'https://vault.test',

--- a/discord/tests/vaultwarden.test.ts
+++ b/discord/tests/vaultwarden.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import { fetchSecrets, resolveCollection } from '../../shared/vaultwarden/client.ts';
+
+// Captures requests and returns canned responses so no real network is hit.
+function fakeFetch(responder: (url: string) => { status: number; body?: unknown } | 'throw') {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    calls.push({ url, init });
+    const r = responder(url);
+    if (r === 'throw') throw new Error('network down');
+    return new Response(r.body === undefined ? null : JSON.stringify(r.body), { status: r.status });
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const base = {
+  apiUrl: 'https://vault.test',
+  apiKey: 'test-key',
+  collection: 'Secrets - DEV',
+  manifest: ['DATABASE_URL'] as const,
+};
+
+describe('resolveCollection', () => {
+  test('Production maps to PROD (via ASPNETCORE_ENVIRONMENT or NODE_ENV)', () => {
+    expect(resolveCollection({ ASPNETCORE_ENVIRONMENT: 'Production' })).toBe('Secrets - PROD');
+    expect(resolveCollection({ NODE_ENV: 'production' })).toBe('Secrets - PROD');
+  });
+
+  test('non-production / unset maps to DEV', () => {
+    expect(resolveCollection({ ASPNETCORE_ENVIRONMENT: 'Development' })).toBe('Secrets - DEV');
+    expect(resolveCollection({ NODE_ENV: 'staging' })).toBe('Secrets - DEV');
+    expect(resolveCollection({})).toBe('Secrets - DEV');
+  });
+
+  test('explicit VAULTWARDEN_COLLECTION always wins', () => {
+    expect(
+      resolveCollection({
+        VAULTWARDEN_COLLECTION: 'Secrets - CUSTOM',
+        ASPNETCORE_ENVIRONMENT: 'Production',
+      }),
+    ).toBe('Secrets - CUSTOM');
+  });
+});
+
+describe('fetchSecrets', () => {
+  test('returns values and scopes the request by org + collection with a bearer token', async () => {
+    const { fetchImpl, calls } = fakeFetch(() => ({
+      status: 200,
+      body: { name: 'DATABASE_URL', value: 'pg://x' },
+    }));
+
+    const got = await fetchSecrets({ ...base, fetchImpl });
+
+    expect(got).toEqual({ DATABASE_URL: 'pg://x' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toContain('/secret/DATABASE_URL');
+    expect(calls[0]!.url).toContain('organization_name=GankedTV');
+    expect(calls[0]!.url).toContain('collection_name=Secrets%20-%20DEV');
+    const headers = (calls[0]!.init?.headers ?? {}) as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer test-key');
+  });
+
+  test('honours an organization override', async () => {
+    const { fetchImpl, calls } = fakeFetch(() => ({ status: 200, body: { value: 'v' } }));
+    await fetchSecrets({ ...base, organization: 'OtherOrg', fetchImpl });
+    expect(calls[0]!.url).toContain('organization_name=OtherOrg');
+  });
+
+  test('skips a key whose value is empty', async () => {
+    const { fetchImpl } = fakeFetch(() => ({ status: 200, body: { value: '' } }));
+    expect(await fetchSecrets({ ...base, fetchImpl })).toEqual({});
+  });
+
+  test('skips already-set keys without a request', async () => {
+    const { fetchImpl, calls } = fakeFetch(() => ({ status: 200, body: { value: 'v' } }));
+    const got = await fetchSecrets({ ...base, alreadySet: () => true, fetchImpl });
+    expect(got).toEqual({});
+    expect(calls).toHaveLength(0);
+  });
+
+  test('dev: 404, non-2xx and transport errors are skipped', async () => {
+    expect(
+      await fetchSecrets({ ...base, fetchImpl: fakeFetch(() => ({ status: 404 })).fetchImpl }),
+    ).toEqual({});
+    expect(
+      await fetchSecrets({ ...base, fetchImpl: fakeFetch(() => ({ status: 500 })).fetchImpl }),
+    ).toEqual({});
+    expect(await fetchSecrets({ ...base, fetchImpl: fakeFetch(() => 'throw').fetchImpl })).toEqual(
+      {},
+    );
+  });
+
+  test('throwIfMissing: throws on a 404', async () => {
+    await expect(
+      fetchSecrets({
+        ...base,
+        throwIfMissing: true,
+        fetchImpl: fakeFetch(() => ({ status: 404 })).fetchImpl,
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  test('throwOnError: throws on non-2xx and transport errors, but a 404 is still skipped', async () => {
+    await expect(
+      fetchSecrets({
+        ...base,
+        throwOnError: true,
+        fetchImpl: fakeFetch(() => ({ status: 500 })).fetchImpl,
+      }),
+    ).rejects.toThrow(/500/);
+    await expect(
+      fetchSecrets({ ...base, throwOnError: true, fetchImpl: fakeFetch(() => 'throw').fetchImpl }),
+    ).rejects.toThrow(/failed to fetch/);
+    // throwOnError does NOT escalate a 404 — this is the web build's "GA id is optional" mode.
+    expect(
+      await fetchSecrets({
+        ...base,
+        throwOnError: true,
+        fetchImpl: fakeFetch(() => ({ status: 404 })).fetchImpl,
+      }),
+    ).toEqual({});
+  });
+
+  test('fetches multiple manifest keys sequentially', async () => {
+    const { fetchImpl, calls } = fakeFetch((url) => {
+      const key = decodeURIComponent(url.split('/secret/')[1]!.split('?')[0]!);
+      return { status: 200, body: { value: `v-${key}` } };
+    });
+    const got = await fetchSecrets({ ...base, manifest: ['A', 'B'], fetchImpl });
+    expect(got).toEqual({ A: 'v-A', B: 'v-B' });
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/discord/tests/vaultwarden.test.ts
+++ b/discord/tests/vaultwarden.test.ts
@@ -122,6 +122,15 @@ describe('fetchSecrets', () => {
     ).toEqual({});
   });
 
+  test('treats a malformed 200 body like an error (skipped, or thrown with throwOnError)', async () => {
+    const badBody = (async () =>
+      new Response('<html>not json', { status: 200 })) as unknown as typeof fetch;
+    expect(await fetchSecrets({ ...base, fetchImpl: badBody })).toEqual({});
+    await expect(fetchSecrets({ ...base, throwOnError: true, fetchImpl: badBody })).rejects.toThrow(
+      /invalid JSON/,
+    );
+  });
+
   test('fetches multiple manifest keys sequentially', async () => {
     const { fetchImpl, calls } = fakeFetch((url) => {
       const key = decodeURIComponent(url.split('/secret/')[1]!.split('?')[0]!);

--- a/discord/tsconfig.json
+++ b/discord/tsconfig.json
@@ -18,5 +18,5 @@
     "verbatimModuleSyntax": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts", "../shared/**/*.ts"]
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,8 +52,10 @@ services:
   discord:
     profiles: ["discord"]
     build:
-      context: ./discord
-      dockerfile: Dockerfile
+      # Repo-root context so the image can COPY the shared/ module the bot imports (see
+      # discord/Dockerfile). A repo-root .dockerignore keeps the context lean.
+      context: .
+      dockerfile: discord/Dockerfile
     environment:
       # Distinct from the API's DATABASE_URL because the API uses dotnet
       # semicolon form, which porsager's `postgres` driver can't parse.

--- a/server/src/GankedTV.Api/Configuration/ProductionStartupValidator.cs
+++ b/server/src/GankedTV.Api/Configuration/ProductionStartupValidator.cs
@@ -17,6 +17,9 @@ namespace GankedTV.Api.Configuration;
 /// If a future deployment wires secrets through a config provider instead (Azure Key Vault, AWS
 /// Parameter Store, etc.), this env-only check will report them "missing" — update both the call
 /// site (to read the bound options) and this contract before integrating a vault.
+/// The Vaultwarden integration preserves this contract: it injects fetched secrets into the
+/// environment (not a config provider) before this validator runs, so the env-only check sees them
+/// as ordinary env vars.
 /// </remarks>
 public static class ProductionStartupValidator
 {

--- a/server/src/GankedTV.Api/Configuration/VaultwardenOptions.cs
+++ b/server/src/GankedTV.Api/Configuration/VaultwardenOptions.cs
@@ -35,7 +35,7 @@ public sealed class VaultwardenOptions
     {
         if (!string.IsNullOrWhiteSpace(explicitCollection))
         {
-            return explicitCollection;
+            return explicitCollection.Trim();
         }
 
         return string.Equals(aspnetEnvironment, "Production", StringComparison.OrdinalIgnoreCase)

--- a/server/src/GankedTV.Api/Configuration/VaultwardenOptions.cs
+++ b/server/src/GankedTV.Api/Configuration/VaultwardenOptions.cs
@@ -1,0 +1,49 @@
+namespace GankedTV.Api.Configuration;
+
+/// <summary>
+/// Bootstrap config for fetching secrets from the self-hosted Vaultwarden-API. Only
+/// <see cref="ApiUrl"/> + <see cref="ApiKey"/> live in the environment; everything else is pulled
+/// from the vault at startup. When not <see cref="IsConfigured"/> the loader no-ops and the app
+/// falls back to env/.env (same opt-in style as <c>IgdbOptions.IsConfigured</c>).
+/// </summary>
+public sealed class VaultwardenOptions
+{
+    /// <summary>Base URL of the Vaultwarden-API service (e.g. <c>https://vault.internal</c>).</summary>
+    public string? ApiUrl { get; set; }
+
+    /// <summary>Bearer token for the API (the <c>secrets@</c> service user's API key).</summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>Vaultwarden organization the collections live under. Defaults to GankedTV.</summary>
+    public string Organization { get; set; } = "GankedTV";
+
+    /// <summary>
+    /// Explicit collection override. When unset the collection is derived from the environment
+    /// (see <see cref="ResolveCollection"/>).
+    /// </summary>
+    public string? Collection { get; set; }
+
+    /// <summary>Both bootstrap vars present → the loader runs; otherwise it no-ops.</summary>
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(ApiUrl) && !string.IsNullOrWhiteSpace(ApiKey);
+
+    /// <summary>
+    /// Explicit collection wins; otherwise Production (case-insensitive) maps to
+    /// <c>"Secrets - PROD"</c> and anything else to <c>"Secrets - DEV"</c>.
+    /// </summary>
+    public static string ResolveCollection(string? explicitCollection, string? aspnetEnvironment)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitCollection))
+        {
+            return explicitCollection;
+        }
+
+        return string.Equals(aspnetEnvironment, "Production", StringComparison.OrdinalIgnoreCase)
+            ? "Secrets - PROD"
+            : "Secrets - DEV";
+    }
+
+    /// <summary>The collection this instance resolves to for the given environment.</summary>
+    public string EffectiveCollection(string? aspnetEnvironment) =>
+        ResolveCollection(Collection, aspnetEnvironment);
+}

--- a/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
+++ b/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
@@ -111,6 +111,10 @@ public sealed class VaultwardenSecretsLoader
             {
                 value = await FetchSecretAsync(key, ct);
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // caller cancelled — propagate, don't swallow as a fetch failure
+            }
             catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
             {
                 if (failFast)

--- a/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
+++ b/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GankedTV.Api.Configuration;
+
+/// <summary>
+/// Fetches the server's required secrets from the Vaultwarden-API at startup and sets each as an
+/// env var when unset (like <c>DotNetEnv.Env.NoClobber()</c>), so a real env var still wins and
+/// existing <c>Environment.GetEnvironmentVariable(...)</c> read sites pick the values up unchanged.
+/// </summary>
+public sealed class VaultwardenSecretsLoader
+{
+    /// <summary>
+    /// The server's required secrets, fetched by these exact names. No <c>SENTRY_DSN</c> — there's
+    /// no Sentry integration yet.
+    /// </summary>
+    public static readonly IReadOnlyList<string> Manifest =
+    [
+        "DATABASE_URL",
+        "JWT_SECRET",
+        "OAUTH_STATE_SECRET",
+        "S3_ENDPOINT",
+        "S3_ACCESS_KEY",
+        "S3_SECRET_KEY",
+        "S3_PUBLIC_URL",
+        "DISCORD_CLIENT_ID",
+        "DISCORD_CLIENT_SECRET",
+        "DISCORD_REDIRECT_URI",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_REDIRECT_URI",
+        "IGDB_CLIENT_ID",
+        "IGDB_CLIENT_SECRET",
+        "REDIS_URL",
+        "WEB_ORIGIN",
+        "CORS_ORIGINS",
+    ];
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly VaultwardenOptions _options;
+    private readonly string _collection;
+    private readonly ILogger<VaultwardenSecretsLoader> _logger;
+
+    public VaultwardenSecretsLoader(
+        HttpClient httpClient,
+        VaultwardenOptions options,
+        string collection,
+        ILogger<VaultwardenSecretsLoader> logger)
+    {
+        _httpClient = httpClient;
+        _options = options;
+        _collection = collection;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Fetches one secret, scoped to the org + collection. Returns the value, or <c>null</c> on 404;
+    /// any other non-success status throws <see cref="HttpRequestException"/>.
+    /// </summary>
+    public async Task<string?> FetchSecretAsync(string name, CancellationToken ct)
+    {
+        var requestUri =
+            $"{_options.ApiUrl!.TrimEnd('/')}/secret/{Uri.EscapeDataString(name)}"
+            + $"?organization_name={Uri.EscapeDataString(_options.Organization)}"
+            + $"&collection_name={Uri.EscapeDataString(_collection)}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.ApiKey);
+
+        using var response = await _httpClient.SendAsync(request, ct);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return JsonSerializer.Deserialize<SecretResponse>(json, JsonOpts)?.Value;
+    }
+
+    /// <summary>
+    /// Fetches the manifest sequentially and applies each value via the injected
+    /// <paramref name="get"/>/<paramref name="set"/> (real env in <c>Program.cs</c>, a fake map in
+    /// tests). Keys already set are skipped (env wins). With <paramref name="failFast"/> a missing
+    /// or errored key throws; otherwise it logs and continues. Returns the keys applied.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> LoadAsync(
+        bool failFast,
+        Func<string, string?> get,
+        Action<string, string> set,
+        IReadOnlyList<string>? manifest = null,
+        CancellationToken ct = default)
+    {
+        var applied = new List<string>();
+
+        foreach (var key in manifest ?? Manifest)
+        {
+            if (!string.IsNullOrWhiteSpace(get(key)))
+            {
+                continue; // already set → env wins, no request needed
+            }
+
+            string? value;
+            try
+            {
+                value = await FetchSecretAsync(key, ct);
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+            {
+                if (failFast)
+                {
+                    throw new InvalidOperationException(
+                        $"Vaultwarden: failed to fetch required secret '{key}' from collection "
+                        + $"'{_collection}': {ex.Message}", ex);
+                }
+
+                _logger.LogWarning(ex, "Vaultwarden: fetch of {Key} failed; falling back to env/.env.", key);
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(value))
+            {
+                if (failFast)
+                {
+                    throw new InvalidOperationException(
+                        $"Vaultwarden: required secret '{key}' not found in collection '{_collection}'.");
+                }
+
+                _logger.LogWarning(
+                    "Vaultwarden: secret {Key} not found in {Collection}; falling back to env/.env.",
+                    key, _collection);
+                continue;
+            }
+
+            set(key, value);
+            applied.Add(key);
+        }
+
+        if (applied.Count > 0)
+        {
+            _logger.LogInformation(
+                "Vaultwarden: loaded {Count} secret(s) from collection '{Collection}'.",
+                applied.Count, _collection);
+        }
+
+        return applied;
+    }
+
+    private sealed record SecretResponse(
+        [property: JsonPropertyName("name")] string? Name,
+        [property: JsonPropertyName("value")] string? Value);
+}

--- a/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
+++ b/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
@@ -51,6 +51,8 @@ public sealed class VaultwardenSecretsLoader
         string collection,
         ILogger<VaultwardenSecretsLoader> logger)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.ApiUrl);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.ApiKey);
         _httpClient = httpClient;
         _options = options;
         _collection = collection;
@@ -109,7 +111,7 @@ public sealed class VaultwardenSecretsLoader
             {
                 value = await FetchSecretAsync(key, ct);
             }
-            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
             {
                 if (failFast)
                 {

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -48,9 +48,9 @@ if (builder.Environment.IsDevelopment())
 // when the bootstrap vars are unset; logic lives in the loader to stay in the coverage denominator.
 var vaultwardenOptions = new VaultwardenOptions
 {
-    ApiUrl = Environment.GetEnvironmentVariable("VAULTWARDEN_API_URL"),
-    ApiKey = Environment.GetEnvironmentVariable("VAULTWARDEN_API_KEY"),
-    Organization = Environment.GetEnvironmentVariable("VAULTWARDEN_ORG") is { Length: > 0 } vaultOrg
+    ApiUrl = Environment.GetEnvironmentVariable("VAULTWARDEN_API_URL")?.Trim(),
+    ApiKey = Environment.GetEnvironmentVariable("VAULTWARDEN_API_KEY")?.Trim(),
+    Organization = Environment.GetEnvironmentVariable("VAULTWARDEN_ORG")?.Trim() is { Length: > 0 } vaultOrg
         ? vaultOrg
         : "GankedTV",
     Collection = Environment.GetEnvironmentVariable("VAULTWARDEN_COLLECTION"),

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -42,6 +42,43 @@ if (builder.Environment.IsDevelopment())
     }
 }
 
+// Vaultwarden secret bootstrap: like the DotNetEnv load above, fetch the manifest and set each as
+// an env var only when unset, so shell/.env still wins and every GetEnvironmentVariable read site
+// (the connection-string read below, the Production validation later) picks it up unchanged. No-op
+// when the bootstrap vars are unset; logic lives in the loader to stay in the coverage denominator.
+var vaultwardenOptions = new VaultwardenOptions
+{
+    ApiUrl = Environment.GetEnvironmentVariable("VAULTWARDEN_API_URL"),
+    ApiKey = Environment.GetEnvironmentVariable("VAULTWARDEN_API_KEY"),
+    Organization = Environment.GetEnvironmentVariable("VAULTWARDEN_ORG") is { Length: > 0 } vaultOrg
+        ? vaultOrg
+        : "GankedTV",
+    Collection = Environment.GetEnvironmentVariable("VAULTWARDEN_COLLECTION"),
+};
+if (vaultwardenOptions.IsConfigured)
+{
+    // One short-lived HttpClient for this pre-host bootstrap fetch — IHttpClientFactory isn't
+    // available before builder.Build(), and pooling buys nothing for a few sequential one-shot calls.
+    using var vaultwardenHttp = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(10),
+        MaxResponseContentBufferSize = 64 * 1024,
+    };
+    using var vaultwardenLoggerFactory = LoggerFactory.Create(b => b.AddConsole());
+    var vaultwardenLoader = new VaultwardenSecretsLoader(
+        vaultwardenHttp,
+        vaultwardenOptions,
+        vaultwardenOptions.EffectiveCollection(builder.Environment.EnvironmentName),
+        vaultwardenLoggerFactory.CreateLogger<VaultwardenSecretsLoader>());
+    vaultwardenLoader
+        .LoadAsync(
+            failFast: builder.Environment.IsProduction(),
+            Environment.GetEnvironmentVariable,
+            Environment.SetEnvironmentVariable)
+        .GetAwaiter()
+        .GetResult();
+}
+
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();

--- a/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenOptionsTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenOptionsTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using GankedTV.Api.Configuration;
+
+namespace GankedTV.Api.Tests.Configuration;
+
+public class VaultwardenOptionsTests
+{
+    [Theory]
+    [InlineData("https://vault", "api-key", true)]
+    [InlineData(null, "api-key", false)]
+    [InlineData("https://vault", null, false)]
+    [InlineData("", "api-key", false)]
+    [InlineData("   ", "api-key", false)]
+    [InlineData("https://vault", "", false)]
+    [InlineData("https://vault", "   ", false)]
+    public void IsConfigured_RequiresBothBootstrapVars(string? apiUrl, string? apiKey, bool expected)
+    {
+        var opts = new VaultwardenOptions { ApiUrl = apiUrl, ApiKey = apiKey };
+        opts.IsConfigured.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Production", "Secrets - PROD")]
+    [InlineData("production", "Secrets - PROD")]
+    [InlineData("Development", "Secrets - DEV")]
+    [InlineData("Staging", "Secrets - DEV")]
+    [InlineData("", "Secrets - DEV")]
+    [InlineData(null, "Secrets - DEV")]
+    public void ResolveCollection_DerivesFromEnvironment_WhenNoExplicitOverride(string? env, string expected)
+    {
+        VaultwardenOptions.ResolveCollection(null, env).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Development")]
+    [InlineData(null)]
+    public void ResolveCollection_ExplicitOverride_AlwaysWins(string? env)
+    {
+        VaultwardenOptions.ResolveCollection("Secrets - CUSTOM", env).Should().Be("Secrets - CUSTOM");
+    }
+
+    [Fact]
+    public void EffectiveCollection_UsesInstanceOverride_ThenFallsBackToEnvironment()
+    {
+        new VaultwardenOptions { Collection = "Secrets - CUSTOM" }
+            .EffectiveCollection("Production").Should().Be("Secrets - CUSTOM");
+
+        new VaultwardenOptions().EffectiveCollection("Production").Should().Be("Secrets - PROD");
+        new VaultwardenOptions().EffectiveCollection("Development").Should().Be("Secrets - DEV");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
@@ -204,4 +204,17 @@ public class VaultwardenSecretsLoaderTests
         applied.Should().BeEmpty();
         handler.Requests.Should().HaveCount(VaultwardenSecretsLoader.Manifest.Count);
     }
+
+    [Fact]
+    public async Task LoadAsync_CallerCancellation_Propagates()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.OK, """{"name":"DATABASE_URL","value":"v"}""");
+        var (get, set, _) = FakeEnv();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => Build(handler).LoadAsync(failFast: false, get, set, manifest: ["DATABASE_URL"], ct: cts.Token));
+    }
 }

--- a/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 using GankedTV.Api.Configuration;
 using GankedTV.Api.Tests.TestSupport;
@@ -43,6 +44,19 @@ public class VaultwardenSecretsLoaderTests
     }
 
     [Fact]
+    public void Constructor_RejectsBlankBootstrapVars()
+    {
+        using var http = new HttpClient();
+        var act = () => new VaultwardenSecretsLoader(
+            http,
+            new VaultwardenOptions { ApiUrl = "", ApiKey = "" },
+            "Secrets - DEV",
+            NullLogger<VaultwardenSecretsLoader>.Instance);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
     public async Task FetchSecretAsync_ParsesValue_AndScopesRequestByOrgAndCollection()
     {
         var handler = new TestHttpMessageHandler()
@@ -76,6 +90,16 @@ public class VaultwardenSecretsLoaderTests
             .OnGet(SecretPrefix, HttpStatusCode.InternalServerError, """{"error":"boom"}""");
 
         await Assert.ThrowsAsync<HttpRequestException>(
+            () => Build(handler).FetchSecretAsync("DATABASE_URL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task FetchSecretAsync_MalformedJson_Throws()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.OK, "<html>not json</html>");
+
+        await Assert.ThrowsAsync<JsonException>(
             () => Build(handler).FetchSecretAsync("DATABASE_URL", CancellationToken.None));
     }
 
@@ -139,6 +163,27 @@ public class VaultwardenSecretsLoaderTests
     {
         var handler = new TestHttpMessageHandler()
             .OnGet(SecretPrefix, HttpStatusCode.InternalServerError, """{"error":"boom"}""");
+        var (get, set, _) = FakeEnv();
+
+        var applied = await Build(handler).LoadAsync(failFast: false, get, set, manifest: ["DATABASE_URL"]);
+
+        applied.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_Production_MalformedJson_Throws()
+    {
+        var handler = new TestHttpMessageHandler().OnGet(SecretPrefix, HttpStatusCode.OK, "<html>");
+        var (get, set, _) = FakeEnv();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Build(handler).LoadAsync(failFast: true, get, set, manifest: ["DATABASE_URL"]));
+    }
+
+    [Fact]
+    public async Task LoadAsync_Development_MalformedJson_FallsBack()
+    {
+        var handler = new TestHttpMessageHandler().OnGet(SecretPrefix, HttpStatusCode.OK, "<html>");
         var (get, set, _) = FakeEnv();
 
         var applied = await Build(handler).LoadAsync(failFast: false, get, set, manifest: ["DATABASE_URL"]);

--- a/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using FluentAssertions;
+using GankedTV.Api.Configuration;
+using GankedTV.Api.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GankedTV.Api.Tests.Configuration;
+
+public class VaultwardenSecretsLoaderTests
+{
+    private const string ApiUrl = "https://vault.test";
+    private const string ApiKey = "test-api-key";
+    private const string SecretPrefix = "https://vault.test/secret/";
+
+    private static VaultwardenSecretsLoader Build(
+        HttpMessageHandler handler,
+        string collection = "Secrets - DEV")
+    {
+        var options = new VaultwardenOptions { ApiUrl = ApiUrl, ApiKey = ApiKey, Organization = "GankedTV" };
+        return new VaultwardenSecretsLoader(
+            new HttpClient(handler, disposeHandler: false),
+            options,
+            collection,
+            NullLogger<VaultwardenSecretsLoader>.Instance);
+    }
+
+    // A fake env backing store so LoadAsync never touches the real process environment.
+    private static (Func<string, string?> Get, Action<string, string> Set, Dictionary<string, string?> Store) FakeEnv(
+        IDictionary<string, string?>? seed = null)
+    {
+        var store = seed is null
+            ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string?>(seed, StringComparer.OrdinalIgnoreCase);
+        return (k => store.TryGetValue(k, out var v) ? v : null, (k, v) => store[k] = v, store);
+    }
+
+    [Fact]
+    public void Manifest_ContainsRequiredKeys_AndNoSentryDsn()
+    {
+        VaultwardenSecretsLoader.Manifest.Should().HaveCount(18);
+        VaultwardenSecretsLoader.Manifest.Should().Contain(["DATABASE_URL", "JWT_SECRET", "S3_SECRET_KEY", "CORS_ORIGINS"]);
+        VaultwardenSecretsLoader.Manifest.Should().NotContain("SENTRY_DSN");
+    }
+
+    [Fact]
+    public async Task FetchSecretAsync_ParsesValue_AndScopesRequestByOrgAndCollection()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.OK, """{"name":"DATABASE_URL","value":"postgres://x"}""");
+
+        var value = await Build(handler).FetchSecretAsync("DATABASE_URL", CancellationToken.None);
+
+        value.Should().Be("postgres://x");
+        var uri = handler.Requests.Should().ContainSingle().Subject.RequestUri!.AbsoluteUri;
+        uri.Should().Contain("/secret/DATABASE_URL")
+            .And.Contain("organization_name=GankedTV")
+            .And.Contain("collection_name=Secrets%20-%20DEV");
+        var auth = handler.Requests[0].Headers.Authorization!;
+        auth.Scheme.Should().Be("Bearer");
+        auth.Parameter.Should().Be(ApiKey);
+    }
+
+    [Fact]
+    public async Task FetchSecretAsync_404_ReturnsNull()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.NotFound, """{"error":"secret not found"}""");
+
+        (await Build(handler).FetchSecretAsync("MISSING", CancellationToken.None)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FetchSecretAsync_NonSuccess_Throws()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.InternalServerError, """{"error":"boom"}""");
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => Build(handler).FetchSecretAsync("DATABASE_URL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsUnsetKeys_AndSkipsAlreadySetWithoutRequest()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.OK, """{"name":"x","value":"from-vault"}""");
+        // JWT_SECRET is already set (env wins); DATABASE_URL is not.
+        var (get, set, store) = FakeEnv(new Dictionary<string, string?> { ["JWT_SECRET"] = "from-env" });
+
+        var applied = await Build(handler).LoadAsync(
+            failFast: false, get, set, manifest: ["JWT_SECRET", "DATABASE_URL"]);
+
+        applied.Should().ContainSingle().Which.Should().Be("DATABASE_URL");
+        store["DATABASE_URL"].Should().Be("from-vault");
+        store["JWT_SECRET"].Should().Be("from-env"); // never overwritten
+        // Only the unset key triggered a request.
+        handler.Requests.Should().ContainSingle().Subject.RequestUri!.AbsoluteUri.Should().Contain("/secret/DATABASE_URL");
+    }
+
+    [Fact]
+    public async Task LoadAsync_Production_MissingRequiredSecret_Throws()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.NotFound, """{"error":"secret not found"}""");
+        var (get, set, _) = FakeEnv();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Build(handler).LoadAsync(failFast: true, get, set, manifest: ["DATABASE_URL"]));
+        ex.Message.Should().Contain("DATABASE_URL").And.Contain("Secrets - DEV");
+    }
+
+    [Fact]
+    public async Task LoadAsync_Production_FetchError_ThrowsWrapped()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.Unauthorized, """{"error":"invalid api key"}""");
+        var (get, set, _) = FakeEnv();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Build(handler).LoadAsync(failFast: true, get, set, manifest: ["DATABASE_URL"]));
+        ex.Message.Should().Contain("failed to fetch");
+        ex.InnerException.Should().BeOfType<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task LoadAsync_Development_MissingSecret_ContinuesWithoutThrowing()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.NotFound, """{"error":"secret not found"}""");
+        var (get, set, _) = FakeEnv();
+
+        var applied = await Build(handler).LoadAsync(failFast: false, get, set, manifest: ["DATABASE_URL"]);
+
+        applied.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_Development_FetchError_FallsBackWithoutThrowing()
+    {
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.InternalServerError, """{"error":"boom"}""");
+        var (get, set, _) = FakeEnv();
+
+        var applied = await Build(handler).LoadAsync(failFast: false, get, set, manifest: ["DATABASE_URL"]);
+
+        applied.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_DefaultManifest_UsesFullManifest()
+    {
+        // No explicit manifest → the full 18-key Manifest is iterated. All 404 in dev → no-op.
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix, HttpStatusCode.NotFound, """{"error":"secret not found"}""");
+        var (get, set, _) = FakeEnv();
+
+        var applied = await Build(handler).LoadAsync(failFast: false, get, set);
+
+        applied.Should().BeEmpty();
+        handler.Requests.Should().HaveCount(VaultwardenSecretsLoader.Manifest.Count);
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/TestSupport/TestHttpMessageHandler.cs
+++ b/server/tests/GankedTV.Api.Tests/TestSupport/TestHttpMessageHandler.cs
@@ -38,6 +38,7 @@ public sealed class TestHttpMessageHandler : HttpMessageHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         Requests.Add(request);
         if (request.Content is not null)
         {

--- a/shared/vaultwarden/client.ts
+++ b/shared/vaultwarden/client.ts
@@ -1,0 +1,92 @@
+// Shared Vaultwarden-API client for the TypeScript consumers — the Discord bot (startup) and the
+// web build (prebuild). Pure and dependency-free so it runs under both Bun and Node. The contract
+// (collection selection, env-wins, sequential fetch) is documented in DEPLOYMENT.md.
+
+/**
+ * Explicit `VAULTWARDEN_COLLECTION` wins; otherwise Production (`ASPNETCORE_ENVIRONMENT`, falling
+ * back to `NODE_ENV`) maps to `"Secrets - PROD"` and anything else to `"Secrets - DEV"`.
+ */
+export function resolveCollection(env: Record<string, string | undefined>): string {
+  const explicit = env.VAULTWARDEN_COLLECTION;
+  if (explicit?.trim()) return explicit;
+  const e = env.ASPNETCORE_ENVIRONMENT ?? env.NODE_ENV;
+  return e?.toLowerCase() === 'production' ? 'Secrets - PROD' : 'Secrets - DEV';
+}
+
+export interface FetchSecretsOptions {
+  /** Base URL of the Vaultwarden-API (trailing slash optional). */
+  apiUrl: string;
+  /** Bearer token (the `secrets@` service user's API key). */
+  apiKey: string;
+  /** Collection to scope the fetch to (see {@link resolveCollection}). */
+  collection: string;
+  /** Exact secret names to fetch — never enumerates the whole vault. */
+  manifest: readonly string[];
+  /** Vaultwarden organization. Defaults to `GankedTV`. */
+  organization?: string;
+  /** Throw when a manifest secret is absent (404). Default false (skip — caller falls back). */
+  throwIfMissing?: boolean;
+  /** Throw on a non-404 / transport / timeout error. Default false (skip). */
+  throwOnError?: boolean;
+  /** Skip the request for a key already provided (env wins) — saves a call and survives a down vault. */
+  alreadySet?: (key: string) => boolean;
+  /** Injectable for tests. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout. Defaults to 10s. */
+  timeoutMs?: number;
+}
+
+/**
+ * Fetches the manifest sequentially, scoped to org + collection, and returns the `{ key: value }`
+ * map for the caller to apply. Keys where `alreadySet` returns true are skipped. A 404 throws only
+ * when `throwIfMissing`; a non-2xx / transport error throws only when `throwOnError`; else skipped.
+ */
+export async function fetchSecrets(opts: FetchSecretsOptions): Promise<Record<string, string>> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const organization = opts.organization ?? 'GankedTV';
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const throwIfMissing = opts.throwIfMissing ?? false;
+  const throwOnError = opts.throwOnError ?? false;
+  const base = opts.apiUrl.replace(/\/+$/, '');
+  const out: Record<string, string> = {};
+
+  for (const name of opts.manifest) {
+    if (opts.alreadySet?.(name)) continue; // already provided → env wins, no request
+
+    const url =
+      `${base}/secret/${encodeURIComponent(name)}` +
+      `?organization_name=${encodeURIComponent(organization)}` +
+      `&collection_name=${encodeURIComponent(opts.collection)}`;
+
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        headers: { authorization: `Bearer ${opts.apiKey}`, accept: 'application/json' },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      if (throwOnError) {
+        throw new Error(`Vaultwarden: failed to fetch ${name} from ${opts.collection}`, { cause: err });
+      }
+      continue;
+    }
+
+    if (res.status === 404) {
+      if (throwIfMissing) {
+        throw new Error(`Vaultwarden: required secret ${name} not found in ${opts.collection}`);
+      }
+      continue;
+    }
+    if (!res.ok) {
+      if (throwOnError) {
+        throw new Error(`Vaultwarden: ${name} → ${res.status}`);
+      }
+      continue;
+    }
+
+    const body = (await res.json()) as { name?: string; value?: string };
+    if (body.value) out[name] = body.value;
+  }
+
+  return out;
+}

--- a/shared/vaultwarden/client.ts
+++ b/shared/vaultwarden/client.ts
@@ -7,8 +7,8 @@
  * back to `NODE_ENV`) maps to `"Secrets - PROD"` and anything else to `"Secrets - DEV"`.
  */
 export function resolveCollection(env: Record<string, string | undefined>): string {
-  const explicit = env.VAULTWARDEN_COLLECTION;
-  if (explicit?.trim()) return explicit;
+  const explicit = env.VAULTWARDEN_COLLECTION?.trim();
+  if (explicit) return explicit;
   const e = env.ASPNETCORE_ENVIRONMENT ?? env.NODE_ENV;
   return e?.toLowerCase() === 'production' ? 'Secrets - PROD' : 'Secrets - DEV';
 }

--- a/shared/vaultwarden/client.ts
+++ b/shared/vaultwarden/client.ts
@@ -84,7 +84,15 @@ export async function fetchSecrets(opts: FetchSecretsOptions): Promise<Record<st
       continue;
     }
 
-    const body = (await res.json()) as { name?: string; value?: string };
+    let body: { name?: string; value?: string };
+    try {
+      body = (await res.json()) as { name?: string; value?: string };
+    } catch (err) {
+      if (throwOnError) {
+        throw new Error(`Vaultwarden: invalid JSON for ${name} from ${opts.collection}`, { cause: err });
+      }
+      continue;
+    }
     if (body.value) out[name] = body.value;
   }
 

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "packageManager": "bun@1.3.12",
   "scripts": {
     "dev": "vite",
+    "prebuild": "bun run scripts/fetch-vault-env.ts",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "test:unit": "vitest",
@@ -18,8 +19,8 @@
     "lint:check": "run-s lint:oxlint:check lint:eslint:check",
     "lint:oxlint:check": "oxlint .",
     "lint:eslint:check": "eslint . --cache",
-    "format": "prettier --write --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/",
-    "format:check": "prettier --check --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/"
+    "format": "prettier --write --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/ scripts/",
+    "format:check": "prettier --check --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/ scripts/"
   },
   "dependencies": {
     "hls.js": "^1.6.16",

--- a/web/scripts/__tests__/fetch-vault-env.spec.ts
+++ b/web/scripts/__tests__/fetch-vault-env.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { fetchViteEnv, renderEnvFile } from '../fetch-vault-env'
+
+// Builds canned responses so no real network is hit; mirrors the discord shared-client tests.
+function fakeFetch(responder: (url: string) => { status: number; body?: unknown } | 'throw') {
+  const calls: string[] = []
+  const fetchImpl = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    calls.push(url)
+    const r = responder(url)
+    if (r === 'throw') throw new Error('network down')
+    return new Response(r.body === undefined ? null : JSON.stringify(r.body), { status: r.status })
+  }) as typeof fetch
+  return { fetchImpl, calls }
+}
+
+const bootstrap = { VAULTWARDEN_API_URL: 'https://vault.test', VAULTWARDEN_API_KEY: 'k' }
+
+describe('renderEnvFile', () => {
+  it('emits KEY=value lines and trails with a newline', () => {
+    expect(renderEnvFile({ VITE_API_BASE_URL: 'https://api.ganked.tv' })).toBe(
+      'VITE_API_BASE_URL=https://api.ganked.tv\n',
+    )
+  })
+
+  it('quotes values containing whitespace', () => {
+    expect(renderEnvFile({ VITE_X: 'a b' })).toBe('VITE_X="a b"\n')
+  })
+})
+
+describe('fetchViteEnv', () => {
+  it('no-ops (returns {}) and never fetches when bootstrap vars are unset', async () => {
+    const { fetchImpl, calls } = fakeFetch(() => ({ status: 200, body: { value: 'x' } }))
+    expect(await fetchViteEnv({}, fetchImpl)).toEqual({})
+    expect(calls).toHaveLength(0)
+  })
+
+  it('fetches the manifest from the env-derived collection with a bearer token', async () => {
+    const { fetchImpl, calls } = fakeFetch((url) => {
+      const key = decodeURIComponent(url.split('/secret/')[1]!.split('?')[0]!)
+      return { status: 200, body: { value: `v-${key}` } }
+    })
+    const got = await fetchViteEnv(
+      { ...bootstrap, ASPNETCORE_ENVIRONMENT: 'Production' },
+      fetchImpl,
+      ['VITE_API_BASE_URL'],
+    )
+    expect(got).toEqual({ VITE_API_BASE_URL: 'v-VITE_API_BASE_URL' })
+    expect(calls[0]).toContain('collection_name=Secrets%20-%20PROD')
+  })
+
+  it('skips a missing (404) optional key but throws on a non-2xx error', async () => {
+    expect(
+      await fetchViteEnv({ ...bootstrap }, fakeFetch(() => ({ status: 404 })).fetchImpl, [
+        'VITE_GA_MEASUREMENT_ID',
+      ]),
+    ).toEqual({})
+    await expect(
+      fetchViteEnv({ ...bootstrap }, fakeFetch(() => ({ status: 500 })).fetchImpl, [
+        'VITE_API_BASE_URL',
+      ]),
+    ).rejects.toThrow(/500/)
+  })
+})

--- a/web/scripts/fetch-vault-env.ts
+++ b/web/scripts/fetch-vault-env.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+// Prebuild: pull the web build's VITE_* values from Vaultwarden into the repo-root
+// .env.production.local (the highest-precedence prod env file Vite reads via envDir: '../'). No-op
+// when the bootstrap vars are unset, so local builds use the committed .env. VITE_* values are
+// baked into the public bundle — not secret; Vaultwarden is just the single source of truth.
+
+import { writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fetchSecrets, resolveCollection } from '../../shared/vaultwarden/client'
+
+// VITE_* build-time vars — all baked into the public bundle.
+export const viteManifest = [
+  'VITE_API_BASE_URL',
+  'VITE_GA_MEASUREMENT_ID',
+  'VITE_USE_SECURE_COOKIES',
+  'VITE_MAX_UPLOAD_SIZE_MB',
+] as const
+
+// Render a key/value map to dotenv lines, quoting values that contain whitespace, '#', or quotes.
+export function renderEnvFile(values: Record<string, string>): string {
+  return (
+    Object.entries(values)
+      .map(([k, v]) => `${k}=${/[\s#"']/.test(v) ? JSON.stringify(v) : v}`)
+      .join('\n') + '\n'
+  )
+}
+
+// Fetch the VITE_* manifest. No-op (returns {}) when the bootstrap vars are unset. A missing key
+// (404) is skipped — the GA id is optional — but an auth/transport error throws so a misconfigured
+// prod build fails loudly.
+export async function fetchViteEnv(
+  env: Record<string, string | undefined> = process.env,
+  fetchImpl: typeof fetch = fetch,
+  manifest: readonly string[] = viteManifest,
+): Promise<Record<string, string>> {
+  const apiUrl = env.VAULTWARDEN_API_URL
+  const apiKey = env.VAULTWARDEN_API_KEY
+  if (!apiUrl?.trim() || !apiKey?.trim()) return {}
+  return fetchSecrets({
+    apiUrl,
+    apiKey,
+    collection: resolveCollection(env),
+    manifest,
+    organization: env.VAULTWARDEN_ORG?.trim() || undefined,
+    throwIfMissing: false,
+    throwOnError: true,
+    alreadySet: (key) => Boolean(env[key]?.trim()),
+    fetchImpl,
+  })
+}
+
+// Run directly (not when imported by tests): write only when there's something to write.
+if (import.meta.main) {
+  const values = await fetchViteEnv()
+  if (Object.keys(values).length > 0) {
+    const target = resolve(import.meta.dirname, '..', '..', '.env.production.local')
+    writeFileSync(target, renderEnvFile(values), 'utf8')
+    console.log(`Wrote ${Object.keys(values).length} VITE_* var(s) to ${target}`)
+  } else {
+    console.log(
+      'Vaultwarden not configured (or nothing to write) — leaving the committed .env as-is.',
+    )
+  }
+}

--- a/web/scripts/fetch-vault-env.ts
+++ b/web/scripts/fetch-vault-env.ts
@@ -33,9 +33,9 @@ export async function fetchViteEnv(
   fetchImpl: typeof fetch = fetch,
   manifest: readonly string[] = viteManifest,
 ): Promise<Record<string, string>> {
-  const apiUrl = env.VAULTWARDEN_API_URL
-  const apiKey = env.VAULTWARDEN_API_KEY
-  if (!apiUrl?.trim() || !apiKey?.trim()) return {}
+  const apiUrl = env.VAULTWARDEN_API_URL?.trim()
+  const apiKey = env.VAULTWARDEN_API_KEY?.trim()
+  if (!apiUrl || !apiKey) return {}
   return fetchSecrets({
     apiUrl,
     apiKey,

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -6,7 +6,9 @@
     "cypress.config.*",
     "nightwatch.conf.*",
     "playwright.config.*",
-    "eslint.config.*"
+    "eslint.config.*",
+    "scripts/**/*.ts",
+    "../shared/**/*.ts"
   ],
   "compilerOptions": {
     "noEmit": true,


### PR DESCRIPTION
## Summary

Fetch app secrets from the self-hosted [Vaultwarden-API](https://github.com/Turbootzz/Vaultwarden-API) at startup/build instead of scattering them across `.env` files, in both dev and prod. Each app (API, Discord bot, web build) pulls its secrets from the vault while a locally-set env var still wins — so the vault is the source of truth without losing per-key overrides. Opt-in: with the two bootstrap vars unset, everything falls back to `.env` exactly as before.

Closes #127

## What's here

- **Server (.NET):** `VaultwardenOptions` + `VaultwardenSecretsLoader` fetch the 18-key manifest at startup and set each as an env var when unset (mirrors the existing `DotNetEnv` NoClobber load), so every `GetEnvironmentVariable` read site — including #122's `ProductionStartupValidator` — picks them up unchanged. Production fails fast on a missing/errored secret; dev falls back.
- **Shared TS client (`shared/vaultwarden/`):** one dependency-free fetch loop + collection resolver, imported by both the bot and the web build.
- **Discord bot:** `loadVaultwardenSecrets` runs after the `.env` layering, before `loadConfig()`. The bot image now builds from the repo-root context so it can ship the shared module (repo-relative layout preserved so the import resolves the same in dev and the image).
- **Web build:** a `prebuild` script writes the vault's `VITE_*` into the repo-root `.env.production.local` (Vite's highest-precedence prod env file); no-op locally.
- **CI:** the web build workflow pulls `VITE_*` from the PROD collection on pushes to `main`, gated so PR CI stays independent of vault availability.
- **Docs:** bootstrap vars, the `secrets@` user, the `Secrets - DEV`/`Secrets - PROD` split, and per-app manifests in `DEPLOYMENT.md` / `.env.example`.

Deferred to #123: sourcing the deploy job's secrets from the vault (there's no deploy pipeline yet).

## How to test manually

With only `VAULTWARDEN_API_URL` + `VAULTWARDEN_API_KEY` set (the rest of `.env` empty):

1. **Server:** `ASPNETCORE_ENVIRONMENT=Production dotnet run --project server/src/GankedTV.Api` → boots with secrets from `Secrets - PROD`; rerun as `Development` → pulls `Secrets - DEV`.
2. **Override wins:** export `DATABASE_URL=...` alongside the bootstrap vars → the override is used, not the vault value.
3. **Bot:** `bun run start` in `discord/` → connects using the vault token (or logs "disabled" if that collection's token is empty).
4. **Web:** `bun run build` in `web/` → prebuild logs `Wrote N VITE_* var(s)`; the built bundle uses the vault's `VITE_API_BASE_URL`.
5. **Fallback:** unset the bootstrap vars → `make up` / `bun run dev` behave exactly as today (the loaders no-op).

## Checklist

- [x] Server / Discord / Web test suites pass locally (tests, type-check, lint, format)
- [x] Verified against a live Vaultwarden-API instance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Security**
  * Introduced Vaultwarden-based secret bootstrap: production and main builds can fetch secrets at build/startup while local/PR workflows keep committed .env values as a fallback.
  * CI/build behavior updated to fetch secrets only on main pushes; env precedence preserved.
  * Docker/dev build context and ignore rules adjusted to keep images lean.
* **Tests**
  * Added test coverage for the Vaultwarden secret fetching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gankedtv/gankedtv/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->