### PR TITLE
[server][web][discord] Error monitoring: Sentry SDK → self-hosted GlitchTip

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,13 +57,20 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:5050/auth/google/callback
 
-# Error monitoring (Sentry → self-hosted GlitchTip) — OPTIONAL. Read by the API and the bot;
-# empty DSN = disabled. One project per app: the API DSN here, the bot DSN in discord/.env.
-# ENVIRONMENT defaults to ASPNETCORE_ENVIRONMENT / NODE_ENV, RELEASE to the build version.
+# Error monitoring (Sentry → self-hosted GlitchTip) — OPTIONAL, one GlitchTip project per app, all
+# configured here so this file is the single source of truth. Empty DSN = disabled for that app.
+# API (.NET): SENTRY_DSN. Discord bot: DISCORD_SENTRY_DSN (prefixed so the bot, which also reads
+# this file, doesn't pick up the API's DSN). Web: VITE_SENTRY_* in the build-time block below.
+# ENVIRONMENT defaults to ASPNETCORE_ENVIRONMENT / NODE_ENV. The release tag is auto-derived (git
+# SHA locally; package/assembly version in containers), so it's not listed here — the deploy
+# pipeline injects the build SHA via SENTRY_RELEASE / DISCORD_SENTRY_RELEASE / VITE_SENTRY_RELEASE.
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=
-SENTRY_RELEASE=
-SENTRY_TRACES_SAMPLE_RATE=0.1
+SENTRY_TRACES_SAMPLE_RATE=0.01
+
+DISCORD_SENTRY_DSN=
+DISCORD_SENTRY_ENVIRONMENT=
+DISCORD_SENTRY_TRACES_SAMPLE_RATE=0.01
 
 # Clip upload limits
 MAX_UPLOAD_SIZE_MB=500
@@ -75,11 +82,11 @@ VITE_API_BASE_URL=
 # GA4 measurement id (G-XXXXXXX); empty = analytics off.
 VITE_GA_MEASUREMENT_ID=
 # Sentry/GlitchTip DSN for the web project; empty = monitoring off. ENVIRONMENT defaults to the
-# Vite mode, RELEASE to the package version.
+# Vite mode; release auto-derives like above (VITE_SENTRY_RELEASE set by the deploy pipeline).
 VITE_SENTRY_DSN=
 VITE_SENTRY_ENVIRONMENT=
 VITE_SENTRY_RELEASE=
-VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
+VITE_SENTRY_TRACES_SAMPLE_RATE=0.01
 
 # IGDB game metadata — OPTIONAL. Only for `make import-games` (backfills the games catalog + cover
 # art). Credentials are a Twitch app's client-credentials pair (https://dev.twitch.tv/console/apps).

--- a/.env.example
+++ b/.env.example
@@ -9,22 +9,19 @@ DATABASE_PASSWORD=gankedtv_dev
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
-# Browser-visible MinIO host when API runs inside a container (e.g. http://localhost:9000).
-# Leave unset in pure-local dev — presigned GET URLs will use S3_ENDPOINT.
+# Browser-visible MinIO host when the API runs in a container. Unset in local dev (presigned
+# URLs use S3_ENDPOINT).
 S3_PUBLIC_URL=
 
-# Redis — OPTIONAL in development. Backs the hot-feed/trending cache and cluster-wide rate
-# limiting. Leave unset to run without Redis: the API falls back to an in-process cache and
-# per-instance rate limiters (fine for local/single-pod dev). Format: redis://[:password@]host:port
-# (use rediss:// for TLS). `make up` starts a local redis on 6379.
+# Redis — OPTIONAL. Backs the feed/trending cache + cluster-wide rate limiting; unset falls back
+# to in-process equivalents. Format: redis://[:password@]host:port (rediss:// for TLS).
 REDIS_URL=redis://localhost:6379
 
 # API
 API_PORT=5050
 ASPNETCORE_ENVIRONMENT=Development
-# Apply EF migrations on boot. Default off — locally migrations are manual (`make migrate`).
-# Set to true on the migrating instance in production so a fresh DB self-migrates before
-# /health/ready goes green. See DEPLOYMENT.md.
+# Apply EF migrations on boot. Off locally (migrations are manual); on for the migrating instance
+# in production.
 RUN_MIGRATIONS_ON_STARTUP=false
 
 # Vaultwarden secret bootstrap — OPTIONAL in development. When set, the API, the Discord bot and the
@@ -45,17 +42,11 @@ JWT_AUDIENCE=gankedtv-web
 JWT_EXPIRY_MINUTES=15
 REFRESH_TOKEN_EXPIRY_DAYS=30
 
-# OAuth — providers are OPTIONAL in development. Leave Discord/Google credentials empty
-# to run without them (the API will boot, GET /auth/providers will list only configured
-# ones, and the frontend should hide the buttons for the rest). In development you can
-# mint a local JWT via POST /dev/token without any OAuth setup.
-# OAUTH_STATE_SECRET only needs to be >= 32 bytes when at least one provider is configured
-# (generate with: openssl rand -hex 32).
+# OAuth — providers OPTIONAL in dev (leave empty to skip; use POST /dev/token to mint a local JWT).
+# OAUTH_STATE_SECRET must be >= 32 bytes once a provider is configured.
 OAUTH_STATE_SECRET=
 WEB_ORIGIN=http://localhost:5173
-# CORS_ORIGINS — comma-separated allowlist of browser origins permitted to call the API.
-# WEB_ORIGIN is always allowed implicitly; list any additional origins here. REQUIRED in
-# production (the API refuses to boot without it). In dev any localhost origin is allowed.
+# CORS_ORIGINS — comma-separated extra origins (WEB_ORIGIN is always allowed). REQUIRED in prod.
 # CORS_ORIGINS=https://ganked.tv
 
 DISCORD_CLIENT_ID=
@@ -66,42 +57,44 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:5050/auth/google/callback
 
+# Error monitoring (Sentry → self-hosted GlitchTip) — OPTIONAL. Read by the API and the bot;
+# empty DSN = disabled. One project per app: the API DSN here, the bot DSN in discord/.env.
+# ENVIRONMENT defaults to ASPNETCORE_ENVIRONMENT / NODE_ENV, RELEASE to the build version.
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+
 # Clip upload limits
 MAX_UPLOAD_SIZE_MB=500
 MAX_CLIP_DURATION_SECS=120
 
-# Web build-time vars (VITE_*) — read by Vite at BUILD time (envDir: '../'), baked into the
-# static bundle. They are NOT runtime server config. Leave unset locally (the web app falls
-# back to http://localhost:5050 for the API and skips analytics).
-# VITE_API_BASE_URL — base URL of the API the built frontend talks to (e.g. https://api.ganked.tv).
+# Web build-time vars (VITE_*) — read by Vite at build (envDir: '../'), baked into the bundle.
+# Unset locally: the app uses http://localhost:5050 and skips analytics/monitoring.
 VITE_API_BASE_URL=
-# VITE_GA_MEASUREMENT_ID — GA4 measurement id (e.g. G-XXXXXXX). Set only for production builds;
-# analytics is a no-op (no script, no cookies) when empty.
+# GA4 measurement id (G-XXXXXXX); empty = analytics off.
 VITE_GA_MEASUREMENT_ID=
+# Sentry/GlitchTip DSN for the web project; empty = monitoring off. ENVIRONMENT defaults to the
+# Vite mode, RELEASE to the package version.
+VITE_SENTRY_DSN=
+VITE_SENTRY_ENVIRONMENT=
+VITE_SENTRY_RELEASE=
+VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
 
-# IGDB game metadata — OPTIONAL. Only needed to run `make import-games`, which backfills the
-# games catalog + cover art from IGDB. A fresh dev DB renders placeholder covers via `make seed`
-# without these. Credentials are a Twitch application's client-credentials pair
-# (https://dev.twitch.tv/console/apps — IGDB authenticates through Twitch).
+# IGDB game metadata — OPTIONAL. Only for `make import-games` (backfills the games catalog + cover
+# art). Credentials are a Twitch app's client-credentials pair (https://dev.twitch.tv/console/apps).
 IGDB_CLIENT_ID=
 IGDB_CLIENT_SECRET=
 # IGDB_IMPORT_COUNT=750
-# Background re-sync (keeps covers/names current). Off by default; opt in per environment.
+# Background re-sync — off by default.
 # IGDB_SYNC_ENABLED=false
 # IGDB_SYNC_INTERVAL_DAYS=7
 
-# Discord bot (issue #107) — OPTIONAL. Auto-posts new public clips to subscribed
-# Discord channels. The compose service is gated behind the `discord` profile
-# (`docker compose --profile discord up`), and even when it's running, leaving
-# DISCORD_BOT_TOKEN empty keeps it idle — the container logs "disabled; exiting"
-# and stops cleanly. Token + App ID come from the same Discord application as
-# the OAuth login above (Bot tab → token, General tab → application id).
-# DISCORD_BOT_GUILD_ID scopes slash-command registration to one dev guild for
-# instant propagation (vs up to an hour for global); leave unset in production.
-# DISCORD_DATABASE_URL is the libpq form of the API's DATABASE_URL — needed
-# because porsager's `postgres` driver can't parse the dotnet semicolon form
-# that DATABASE_URL above carries.
-# See discord/.env.example for the bot-process-local versions.
+# Discord bot — OPTIONAL. Auto-posts new public clips to subscribed channels; gated behind the
+# `discord` compose profile, and idle ("disabled; exiting") while DISCORD_BOT_TOKEN is empty.
+# Token + App ID come from the same Discord application as the OAuth login above.
+# DISCORD_DATABASE_URL is the libpq form of DATABASE_URL (the postgres driver can't parse the
+# dotnet semicolon form). See discord/.env.example for bot-process-local overrides.
 DISCORD_BOT_TOKEN=
 DISCORD_BOT_APP_ID=
 DISCORD_BOT_GUILD_ID=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,9 @@ All three apps wire the official **Sentry SDK** to the self-hosted **GlitchTip**
 web (`@sentry/vue`, [web/src/lib/sentry.ts](web/src/lib/sentry.ts)), and the bot (`@sentry/bun`,
 [discord/src/sentry.ts](discord/src/sentry.ts)). It's **off by default** (no-op when the DSN is
 unset, same opt-in as IGDB/Discord), **one GlitchTip project per app**, errors + light tracing
-(`sendDefaultPii=false`, no replay/profiling/logs). Config is `SENTRY_DSN` / `SENTRY_ENVIRONMENT` /
-`SENTRY_RELEASE` / `SENTRY_TRACES_SAMPLE_RATE` (web: `VITE_*`-prefixed). Full table in
+(`sendDefaultPii=false`, no replay/profiling/logs). Each app's DSN var is distinct so all three fit
+one shared `.env`: API `SENTRY_*`, web `VITE_SENTRY_*`, bot `DISCORD_SENTRY_*` (prefixed because the
+bot also reads the root `.env`). Full table in
 [DEPLOYMENT.md](DEPLOYMENT.md#error-monitoring-sentry--self-hosted-glitchtip).
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,17 @@ Slash commands ship in two namespaces:
 
 Discord coverage gate: **85% line / 85% function** — enforced by [discord/scripts/check-coverage.ts](discord/scripts/check-coverage.ts), which parses `coverage/lcov.info` and exits non-zero when under threshold (Bun's own `coverageThreshold` setting in [discord/bunfig.toml](discord/bunfig.toml) is documentation-only on Bun 1.3.13 — it prints but doesn't enforce). The script also emits a markdown summary to `$GITHUB_STEP_SUMMARY` in CI. Excluded from the denominator: `src/index.ts` (boot wiring, covered indirectly), `src/db.ts` + `src/api.ts` (I/O wrappers; integration tests would need testcontainers), `src/migrator.ts`, `src/migrations/`.
 
+### Error monitoring (Sentry → self-hosted GlitchTip)
+
+All three apps wire the official **Sentry SDK** to the self-hosted **GlitchTip** instance — server
+(`Sentry.AspNetCore`, [Program.cs](server/src/GankedTV.Api/Program.cs) + [SentryPiiScrubber.cs](server/src/GankedTV.Api/Observability/SentryPiiScrubber.cs)),
+web (`@sentry/vue`, [web/src/lib/sentry.ts](web/src/lib/sentry.ts)), and the bot (`@sentry/bun`,
+[discord/src/sentry.ts](discord/src/sentry.ts)). It's **off by default** (no-op when the DSN is
+unset, same opt-in as IGDB/Discord), **one GlitchTip project per app**, errors + light tracing
+(`sendDefaultPii=false`, no replay/profiling/logs). Config is `SENTRY_DSN` / `SENTRY_ENVIRONMENT` /
+`SENTRY_RELEASE` / `SENTRY_TRACES_SAMPLE_RATE` (web: `VITE_*`-prefixed). Full table in
+[DEPLOYMENT.md](DEPLOYMENT.md#error-monitoring-sentry--self-hosted-glitchtip).
+
 ## Architecture
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,11 @@ gankedtv/
 
 - Do not add yourself (Claude / any AI) as a co-author. Never append `Co-Authored-By: Claude ...` trailers to commit messages.
 
+## Code comments
+
+- Default to no comment. Add one only when the *why* is non-obvious — a trap, a hidden constraint, a security reason, an ordering requirement — or to orient the reader through a genuinely complex/tricky section. Don't narrate *what* the code does (well-named identifiers cover that), and don't over-explain: one or two tight lines, never a paragraph.
+- Never reference issue or PR numbers in code comments (e.g. `// issue #123`, `// M4 from review #111`). They rot as the code moves and the context belongs in the commit/PR. Prose docs (this file, DEPLOYMENT.md) may cross-reference issues; source comments must not.
+
 ## Frontend Design
 
 **Before writing any frontend (Vue components, CSS, Tailwind classes):** Read [web/DESIGN.md](web/DESIGN.md).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -141,17 +141,19 @@ tracing** (sample rate `0.1`); session replay, profiling, and Sentry "logs" are 
 (GlitchTip doesn't support them). `SendDefaultPii` is `false` everywhere and credential-bearing
 headers/cookies/query params are scrubbed before events leave the app.
 
-Create **one GlitchTip project per app** (api / web / discord) and supply each service its own DSN:
+Create **one GlitchTip project per app** (api / web / discord). Each app's DSN var is distinct, so
+all three can live in a single shared `.env` without colliding — the bot reads the repo-root `.env`
+too, hence the `DISCORD_`-prefix:
 
 | App | DSN var | Environment / Release source |
 |---|---|---|
 | API (.NET) | `SENTRY_DSN` | env `SENTRY_ENVIRONMENT` → falls back to `ASPNETCORE_ENVIRONMENT`; `SENTRY_RELEASE` → entry-assembly version |
 | Web (Vite) | `VITE_SENTRY_DSN` (build-time) | `VITE_SENTRY_ENVIRONMENT` → Vite mode; `VITE_SENTRY_RELEASE` → package version |
-| Discord bot (Bun) | `SENTRY_DSN` (set on the bot container or `discord/.env`, not the shared root) | `SENTRY_ENVIRONMENT` → `NODE_ENV`; `SENTRY_RELEASE` → package version |
+| Discord bot (Bun) | `DISCORD_SENTRY_DSN` | `DISCORD_SENTRY_ENVIRONMENT` → `NODE_ENV`; `DISCORD_SENTRY_RELEASE` → package version |
 
-`SENTRY_TRACES_SAMPLE_RATE` (web: `VITE_SENTRY_TRACES_SAMPLE_RATE`) overrides the `0.1` default.
-Leave `SENTRY_RELEASE` unset for now — the #123 deploy pipeline will set it to the commit SHA so
-issues map to deploys.
+`SENTRY_TRACES_SAMPLE_RATE` / `VITE_SENTRY_TRACES_SAMPLE_RATE` / `DISCORD_SENTRY_TRACES_SAMPLE_RATE`
+override the `0.1` default. Leave the `*_RELEASE` vars unset for now — the #123 deploy pipeline will
+set them to the commit SHA so issues map to deploys.
 
 ## Reference
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -137,7 +137,7 @@ runtime:
 All three apps ship the official **Sentry SDK** pointed at the self-hosted **GlitchTip** instance
 (Sentry-API-compatible). It is **opt-in and disabled by default** — each SDK no-ops when its DSN is
 unset, the same contract as the IGDB sync and Discord bot. Posture is **errors/crashes + light
-tracing** (sample rate `0.1`); session replay, profiling, and Sentry "logs" are intentionally off
+tracing** (sample rate `0.01`); session replay, profiling, and Sentry "logs" are intentionally off
 (GlitchTip doesn't support them). `SendDefaultPii` is `false` everywhere and credential-bearing
 headers/cookies/query params are scrubbed before events leave the app.
 
@@ -152,7 +152,7 @@ too, hence the `DISCORD_`-prefix:
 | Discord bot (Bun) | `DISCORD_SENTRY_DSN` | `DISCORD_SENTRY_ENVIRONMENT` → `NODE_ENV`; `DISCORD_SENTRY_RELEASE` → package version |
 
 `SENTRY_TRACES_SAMPLE_RATE` / `VITE_SENTRY_TRACES_SAMPLE_RATE` / `DISCORD_SENTRY_TRACES_SAMPLE_RATE`
-override the `0.1` default. Leave the `*_RELEASE` vars unset for now — the #123 deploy pipeline will
+override the `0.01` default. Leave the `*_RELEASE` vars unset for now — the #123 deploy pipeline will
 set them to the commit SHA so issues map to deploys.
 
 ## Reference

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -126,10 +126,32 @@ runtime:
 |---|---|
 | `VITE_API_BASE_URL` | API base URL the built frontend calls (e.g. `https://api.ganked.tv`). Falls back to `http://localhost:5050` if unset — so it **must** be set for prod builds. |
 | `VITE_GA_MEASUREMENT_ID` | GA4 measurement id (`G-XXXXXXX`). Analytics is a complete no-op (no script, no cookies) when empty, so it stays off in dev/preview. |
+| `VITE_SENTRY_DSN` | Sentry/GlitchTip DSN for the web project. Error monitoring is a no-op when empty. Optional: `VITE_SENTRY_ENVIRONMENT`, `VITE_SENTRY_RELEASE`, `VITE_SENTRY_TRACES_SAMPLE_RATE`. |
 
 > The Dockerfile build-arg wiring that feeds these into the production web image is part of
 > issue #123. **Cookie-consent gating for analytics is a known follow-up** — GA currently loads
 > whenever the measurement id is present.
+
+## Error monitoring (Sentry → self-hosted GlitchTip)
+
+All three apps ship the official **Sentry SDK** pointed at the self-hosted **GlitchTip** instance
+(Sentry-API-compatible). It is **opt-in and disabled by default** — each SDK no-ops when its DSN is
+unset, the same contract as the IGDB sync and Discord bot. Posture is **errors/crashes + light
+tracing** (sample rate `0.1`); session replay, profiling, and Sentry "logs" are intentionally off
+(GlitchTip doesn't support them). `SendDefaultPii` is `false` everywhere and credential-bearing
+headers/cookies/query params are scrubbed before events leave the app.
+
+Create **one GlitchTip project per app** (api / web / discord) and supply each service its own DSN:
+
+| App | DSN var | Environment / Release source |
+|---|---|---|
+| API (.NET) | `SENTRY_DSN` | env `SENTRY_ENVIRONMENT` → falls back to `ASPNETCORE_ENVIRONMENT`; `SENTRY_RELEASE` → entry-assembly version |
+| Web (Vite) | `VITE_SENTRY_DSN` (build-time) | `VITE_SENTRY_ENVIRONMENT` → Vite mode; `VITE_SENTRY_RELEASE` → package version |
+| Discord bot (Bun) | `SENTRY_DSN` (set on the bot container or `discord/.env`, not the shared root) | `SENTRY_ENVIRONMENT` → `NODE_ENV`; `SENTRY_RELEASE` → package version |
+
+`SENTRY_TRACES_SAMPLE_RATE` (web: `VITE_SENTRY_TRACES_SAMPLE_RATE`) overrides the `0.1` default.
+Leave `SENTRY_RELEASE` unset for now — the #123 deploy pipeline will set it to the commit SHA so
+issues map to deploys.
 
 ## Reference
 

--- a/discord/.env.example
+++ b/discord/.env.example
@@ -45,8 +45,8 @@ GANKEDTV_PUBLIC_BASE=http://localhost:5173
 # and the web's VITE_SENTRY_DSN without colliding (the bot reads the root .env too). Set them here
 # only to override the root. Empty DISCORD_SENTRY_DSN = no-op, matching the DISCORD_BOT_TOKEN
 # contract above. DISCORD_SENTRY_ENVIRONMENT defaults to NODE_ENV, DISCORD_SENTRY_RELEASE to the
-# package version, and DISCORD_SENTRY_TRACES_SAMPLE_RATE to 0.1.
+# package version, and DISCORD_SENTRY_TRACES_SAMPLE_RATE to 0.01.
 DISCORD_SENTRY_DSN=
 DISCORD_SENTRY_ENVIRONMENT=
 DISCORD_SENTRY_RELEASE=
-DISCORD_SENTRY_TRACES_SAMPLE_RATE=0.1
+DISCORD_SENTRY_TRACES_SAMPLE_RATE=0.01

--- a/discord/.env.example
+++ b/discord/.env.example
@@ -40,12 +40,13 @@ GANKEDTV_API_BASE=http://localhost:5050
 # In production this should be the web origin (e.g. https://gankedtv.com).
 GANKEDTV_PUBLIC_BASE=http://localhost:5173
 
-# Error monitoring (Sentry → self-hosted GlitchTip) — OPTIONAL, disabled by default. Leave
-# SENTRY_DSN empty to keep it a no-op, matching the DISCORD_BOT_TOKEN contract above. Use the
-# bot's OWN GlitchTip project DSN here (one project per app); set it here rather than the root
-# .env so it doesn't collide with the API's DSN. SENTRY_ENVIRONMENT defaults to NODE_ENV,
-# SENTRY_RELEASE to the package version, and SENTRY_TRACES_SAMPLE_RATE to 0.1.
-SENTRY_DSN=
-SENTRY_ENVIRONMENT=
-SENTRY_RELEASE=
-SENTRY_TRACES_SAMPLE_RATE=0.1
+# Error monitoring (Sentry → self-hosted GlitchTip) — OPTIONAL, disabled by default. These are
+# DISCORD_-prefixed so they can live in the shared repo-root .env alongside the API's SENTRY_DSN
+# and the web's VITE_SENTRY_DSN without colliding (the bot reads the root .env too). Set them here
+# only to override the root. Empty DISCORD_SENTRY_DSN = no-op, matching the DISCORD_BOT_TOKEN
+# contract above. DISCORD_SENTRY_ENVIRONMENT defaults to NODE_ENV, DISCORD_SENTRY_RELEASE to the
+# package version, and DISCORD_SENTRY_TRACES_SAMPLE_RATE to 0.1.
+DISCORD_SENTRY_DSN=
+DISCORD_SENTRY_ENVIRONMENT=
+DISCORD_SENTRY_RELEASE=
+DISCORD_SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/discord/.env.example
+++ b/discord/.env.example
@@ -39,3 +39,13 @@ GANKEDTV_API_BASE=http://localhost:5050
 # Public origin for share URLs (built as `${GANKEDTV_PUBLIC_BASE}/c/{code}`).
 # In production this should be the web origin (e.g. https://gankedtv.com).
 GANKEDTV_PUBLIC_BASE=http://localhost:5173
+
+# Error monitoring (Sentry → self-hosted GlitchTip) — OPTIONAL, disabled by default. Leave
+# SENTRY_DSN empty to keep it a no-op, matching the DISCORD_BOT_TOKEN contract above. Use the
+# bot's OWN GlitchTip project DSN here (one project per app); set it here rather than the root
+# .env so it doesn't collide with the API's DSN. SENTRY_ENVIRONMENT defaults to NODE_ENV,
+# SENTRY_RELEASE to the package version, and SENTRY_TRACES_SAMPLE_RATE to 0.1.
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/discord/bun.lock
+++ b/discord/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@gankedtv/discord",
       "dependencies": {
+        "@sentry/bun": "^10.54.0",
         "discord.js": "^14.26.4",
         "postgres": "^3.4.9",
         "zod": "^4.4.3",
@@ -62,6 +63,20 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.66.0", "", { "os": "android", "cpu": "arm" }, "sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw=="],
 
     "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.66.0", "", { "os": "android", "cpu": "arm64" }, "sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg=="],
@@ -106,6 +121,16 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
+    "@sentry/bun": ["@sentry/bun@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0", "@sentry/node": "10.54.0" } }, "sha512-xD3E+Aj+W7D2PCLSEcK2OkNWe659vKb50jKgX9nv2eTmI02O7XGxpyKQqVJVcvLB4xKKLtDEd2AxCmB0o3+NVA=="],
+
+    "@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry/node": ["@sentry/node@10.54.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@sentry/core": "10.54.0", "@sentry/node-core": "10.54.0", "@sentry/opentelemetry": "10.54.0", "import-in-the-middle": "^3.0.0" } }, "sha512-Jc31dMBs9aBUv6TXmIPNwv2u18YbfvWQG32IkM3dFWAAoJQhCqLZfN0MEDSf9TeNexIf8qBMZtJRHgHIrWYiGg=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0", "@sentry/opentelemetry": "10.54.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-QR5RnIK78g0Np2+VWMZ3TatM7C+oX9zIQ1W36o3KOjw0nNcXkWjZT1lEu4me8cp2s8s3hA4qT7fwcciQqkj1UQ=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-58Jk9yMos5DwhamDsNmnoQMSNx0yD9E+h1pZwkw34ve2qB9tv+cys3Oz6nfazT9ZdIsXIgpQntN8AfMXAvv4/g=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
@@ -142,6 +167,8 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
@@ -153,6 +180,8 @@
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -204,6 +233,8 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
+
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
@@ -235,6 +266,8 @@
     "memorystream": ["memorystream@0.3.1", "", {}, "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -269,6 +302,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "read-package-json-fast": ["read-package-json-fast@4.0.0", "", { "dependencies": { "json-parse-even-better-errors": "^4.0.0", "npm-normalize-package-bin": "^4.0.0" } }, "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 

--- a/discord/package.json
+++ b/discord/package.json
@@ -20,6 +20,7 @@
     "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov && bun run scripts/check-coverage.ts"
   },
   "dependencies": {
+    "@sentry/bun": "^10.54.0",
     "discord.js": "^14.26.4",
     "postgres": "^3.4.9",
     "zod": "^4.4.3"

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -19,9 +19,18 @@ const Schema = z.object({
   DISCORD_DATABASE_URL: z.string().min(1),
   GANKEDTV_API_BASE: z.string().url().default('http://localhost:5050'),
   GANKEDTV_PUBLIC_BASE: z.string().url().default('http://localhost:5173'),
+  // Error monitoring (Sentry → GlitchTip). All optional; the presence of SENTRY_DSN is the
+  // on-switch (see `sentryEnabled` below), same opt-in contract as the bot-credential triple.
+  // No .url() on the DSN: .env.example ships it as an empty placeholder ("SENTRY_DSN=") and "" is
+  // not a valid URL. Sample rate stays a raw string so empty falls back to the default in sentry.ts
+  // (z.coerce.number() would turn "" into 0, silently disabling tracing).
+  SENTRY_DSN: z.string().optional(),
+  SENTRY_ENVIRONMENT: z.string().optional(),
+  SENTRY_RELEASE: z.string().optional(),
+  SENTRY_TRACES_SAMPLE_RATE: z.string().optional(),
 });
 
-export type Config = z.infer<typeof Schema> & { enabled: boolean };
+export type Config = z.infer<typeof Schema> & { enabled: boolean; sentryEnabled: boolean };
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   const parsed = Schema.parse(env);
@@ -48,5 +57,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   }
 
   const enabled = hasToken && hasAppId;
-  return { ...parsed, enabled };
+  const sentryEnabled = Boolean(parsed.SENTRY_DSN);
+  return { ...parsed, enabled, sentryEnabled };
 }

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -21,7 +21,8 @@ const Schema = z.object({
   GANKEDTV_PUBLIC_BASE: z.string().url().default('http://localhost:5173'),
   // DISCORD_-prefixed so the bot's DSN can share the root .env without clashing with the API's
   // SENTRY_DSN (the bot loads root .env too). No .url(): the "" placeholder isn't a valid URL.
-  // Sample rate stays a string so empty falls back to a default (z.coerce.number() makes "" → 0).
+  // Sample rate stays a string so the empty placeholder falls back to a default in sentry.ts
+  // (parseFloat("") → NaN → fallback); a numeric coercion would turn "" into 0 and disable tracing.
   DISCORD_SENTRY_DSN: z.string().optional(),
   DISCORD_SENTRY_ENVIRONMENT: z.string().optional(),
   DISCORD_SENTRY_RELEASE: z.string().optional(),

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -19,13 +19,9 @@ const Schema = z.object({
   DISCORD_DATABASE_URL: z.string().min(1),
   GANKEDTV_API_BASE: z.string().url().default('http://localhost:5050'),
   GANKEDTV_PUBLIC_BASE: z.string().url().default('http://localhost:5173'),
-  // Error monitoring (Sentry → GlitchTip). DISCORD_-prefixed so all three apps' DSNs can live in
-  // the one repo-root .env without colliding: the API reads SENTRY_DSN and the bot also loads the
-  // root .env, so a bare SENTRY_DSN would point the bot at the API's project. The presence of
-  // DISCORD_SENTRY_DSN is the on-switch (see `sentryEnabled` below), same opt-in contract as the
-  // bot-credential triple. No .url() on the DSN: .env.example ships it as an empty placeholder and
-  // "" is not a valid URL. Sample rate stays a raw string so empty falls back to the default in
-  // sentry.ts (z.coerce.number() would turn "" into 0, silently disabling tracing).
+  // DISCORD_-prefixed so the bot's DSN can share the root .env without clashing with the API's
+  // SENTRY_DSN (the bot loads root .env too). No .url(): the "" placeholder isn't a valid URL.
+  // Sample rate stays a string so empty falls back to a default (z.coerce.number() makes "" → 0).
   DISCORD_SENTRY_DSN: z.string().optional(),
   DISCORD_SENTRY_ENVIRONMENT: z.string().optional(),
   DISCORD_SENTRY_RELEASE: z.string().optional(),

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -19,15 +19,17 @@ const Schema = z.object({
   DISCORD_DATABASE_URL: z.string().min(1),
   GANKEDTV_API_BASE: z.string().url().default('http://localhost:5050'),
   GANKEDTV_PUBLIC_BASE: z.string().url().default('http://localhost:5173'),
-  // Error monitoring (Sentry → GlitchTip). All optional; the presence of SENTRY_DSN is the
-  // on-switch (see `sentryEnabled` below), same opt-in contract as the bot-credential triple.
-  // No .url() on the DSN: .env.example ships it as an empty placeholder ("SENTRY_DSN=") and "" is
-  // not a valid URL. Sample rate stays a raw string so empty falls back to the default in sentry.ts
-  // (z.coerce.number() would turn "" into 0, silently disabling tracing).
-  SENTRY_DSN: z.string().optional(),
-  SENTRY_ENVIRONMENT: z.string().optional(),
-  SENTRY_RELEASE: z.string().optional(),
-  SENTRY_TRACES_SAMPLE_RATE: z.string().optional(),
+  // Error monitoring (Sentry → GlitchTip). DISCORD_-prefixed so all three apps' DSNs can live in
+  // the one repo-root .env without colliding: the API reads SENTRY_DSN and the bot also loads the
+  // root .env, so a bare SENTRY_DSN would point the bot at the API's project. The presence of
+  // DISCORD_SENTRY_DSN is the on-switch (see `sentryEnabled` below), same opt-in contract as the
+  // bot-credential triple. No .url() on the DSN: .env.example ships it as an empty placeholder and
+  // "" is not a valid URL. Sample rate stays a raw string so empty falls back to the default in
+  // sentry.ts (z.coerce.number() would turn "" into 0, silently disabling tracing).
+  DISCORD_SENTRY_DSN: z.string().optional(),
+  DISCORD_SENTRY_ENVIRONMENT: z.string().optional(),
+  DISCORD_SENTRY_RELEASE: z.string().optional(),
+  DISCORD_SENTRY_TRACES_SAMPLE_RATE: z.string().optional(),
 });
 
 export type Config = z.infer<typeof Schema> & { enabled: boolean; sentryEnabled: boolean };
@@ -57,6 +59,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   }
 
   const enabled = hasToken && hasAppId;
-  const sentryEnabled = Boolean(parsed.SENTRY_DSN);
+  const sentryEnabled = Boolean(parsed.DISCORD_SENTRY_DSN);
   return { ...parsed, enabled, sentryEnabled };
 }

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -2,8 +2,10 @@
 // loadVaultwardenSecrets, which main() awaits before loadConfig().
 import { loadVaultwardenSecrets } from './loadEnv.ts';
 
+import * as Sentry from '@sentry/bun';
 import { Client, GatewayIntentBits, REST, Routes, type Interaction } from 'discord.js';
 import { loadConfig } from './config.ts';
+import { initSentry } from './sentry.ts';
 import { connect, createDb } from './db.ts';
 import { runMigrations } from './migrator.ts';
 import { createApi } from './api.ts';
@@ -31,6 +33,10 @@ async function main(): Promise<void> {
   // Pull secrets from Vaultwarden (no-op unless the bootstrap vars are set) before reading config.
   await loadVaultwardenSecrets(process.env);
   const config = loadConfig();
+
+  // No-op unless SENTRY_DSN is set. Before the enabled check so boot-time crashes report too;
+  // installs global unhandled-rejection/uncaught-exception handlers for the long-running process.
+  initSentry(config);
 
   if (!config.enabled) {
     log.info('Discord bot disabled (DISCORD_BOT_TOKEN or DISCORD_BOT_APP_ID unset); exiting.');
@@ -71,6 +77,7 @@ async function main(): Promise<void> {
         commandName: 'commandName' in interaction ? interaction.commandName : null,
         err: String(err),
       });
+      Sentry.captureException(err);
       if (interaction.isRepliable()) {
         try {
           // All command handlers call deferReply() first, so by the time we
@@ -182,7 +189,11 @@ async function main(): Promise<void> {
   await startPoller({ db, api, fanout, log }, config.DISCORD_POLL_INTERVAL_SECONDS, abort.signal);
 }
 
-main().catch((err) => {
+main().catch(async (err) => {
   log.error('fatal', { err: String(err), stack: err instanceof Error ? err.stack : undefined });
+  Sentry.captureException(err);
+  // captureException only enqueues; flush before exiting or the event is dropped. No-op (resolves
+  // immediately) when Sentry isn't initialised. Bounded so a dead transport can't hang shutdown.
+  await Sentry.flush(2000);
   process.exit(1);
 });

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -34,8 +34,7 @@ async function main(): Promise<void> {
   await loadVaultwardenSecrets(process.env);
   const config = loadConfig();
 
-  // No-op unless SENTRY_DSN is set. Before the enabled check so boot-time crashes report too;
-  // installs global unhandled-rejection/uncaught-exception handlers for the long-running process.
+  // No-op unless DISCORD_SENTRY_DSN is set; before the enabled check so boot crashes still report.
   initSentry(config);
 
   if (!config.enabled) {
@@ -192,8 +191,8 @@ async function main(): Promise<void> {
 main().catch(async (err) => {
   log.error('fatal', { err: String(err), stack: err instanceof Error ? err.stack : undefined });
   Sentry.captureException(err);
-  // captureException only enqueues; flush before exiting or the event is dropped. No-op (resolves
-  // immediately) when Sentry isn't initialised. Bounded so a dead transport can't hang shutdown.
+  // captureException only enqueues; flush before exiting or the event is dropped (bounded so a
+  // dead transport can't hang shutdown).
   await Sentry.flush(2000);
   process.exit(1);
 });

--- a/discord/src/poller.ts
+++ b/discord/src/poller.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/bun';
+
 import type { ApiClient, ClipFeedItem } from './api.ts';
 import type { Db, Subscription } from './db.ts';
 import { matchingSubscriptions } from './filters.ts';
@@ -217,6 +219,9 @@ export function startPoller(
         await pollOnce(deps);
       } catch (err) {
         deps.log.error('poll round threw', { err: String(err) });
+        // The loop swallows per-round errors to stay resilient, so they never reach the global
+        // handlers — report explicitly. No-op when Sentry isn't initialised.
+        Sentry.captureException(err);
       } finally {
         inFlight = false;
       }

--- a/discord/src/poller.ts
+++ b/discord/src/poller.ts
@@ -219,8 +219,7 @@ export function startPoller(
         await pollOnce(deps);
       } catch (err) {
         deps.log.error('poll round threw', { err: String(err) });
-        // The loop swallows per-round errors to stay resilient, so they never reach the global
-        // handlers — report explicitly. No-op when Sentry isn't initialised.
+        // The loop swallows per-round errors to stay resilient, so report them explicitly here.
         Sentry.captureException(err);
       } finally {
         inFlight = false;

--- a/discord/src/sentry.ts
+++ b/discord/src/sentry.ts
@@ -31,7 +31,7 @@ export function initSentry(config: Config, sdk: SentrySdk = Sentry): void {
     dsn: config.DISCORD_SENTRY_DSN,
     environment: config.DISCORD_SENTRY_ENVIRONMENT?.trim() || process.env.NODE_ENV || 'development',
     release: config.DISCORD_SENTRY_RELEASE?.trim() || gitShortSha() || pkg.version,
-    tracesSampleRate: Number.isFinite(rate) ? rate : 0.1,
+    tracesSampleRate: Number.isFinite(rate) ? rate : 0.01,
     sendDefaultPii: false,
   });
 }

--- a/discord/src/sentry.ts
+++ b/discord/src/sentry.ts
@@ -6,9 +6,19 @@ import pkg from '../package.json';
 // Minimal surface so tests can inject a fake and assert init args without a live SDK.
 type SentrySdk = Pick<typeof Sentry, 'init'>;
 
+/** Git short SHA of the checkout, or '' when unavailable (e.g. prod container without .git). */
+function gitShortSha(): string {
+  try {
+    const out = Bun.spawnSync(['git', 'rev-parse', '--short', 'HEAD']);
+    return out.success ? out.stdout.toString().trim() : '';
+  } catch {
+    return '';
+  }
+}
+
 /**
- * Error/crash monitoring → self-hosted GlitchTip. Opt-in: no SENTRY_DSN ⇒ no-op (dev/local stays
- * clean), mirroring the bot's "disabled; exiting" contract. Initialising the SDK also installs
+ * Error/crash monitoring → self-hosted GlitchTip. Opt-in: no DISCORD_SENTRY_DSN ⇒ no-op (dev/local
+ * stays clean), mirroring the bot's "disabled; exiting" contract. Initialising the SDK also installs
  * global `unhandledRejection` / `uncaughtException` handlers, so the long-running poller and its
  * crashes report automatically. Errors-only posture with light tracing — GlitchTip doesn't support
  * replay/profiling/logs, so they stay off.
@@ -16,11 +26,11 @@ type SentrySdk = Pick<typeof Sentry, 'init'>;
 export function initSentry(config: Config, sdk: SentrySdk = Sentry): void {
   if (!config.sentryEnabled) return;
 
-  const rate = Number.parseFloat(config.SENTRY_TRACES_SAMPLE_RATE ?? '');
+  const rate = Number.parseFloat(config.DISCORD_SENTRY_TRACES_SAMPLE_RATE ?? '');
   sdk.init({
-    dsn: config.SENTRY_DSN,
-    environment: config.SENTRY_ENVIRONMENT?.trim() || process.env.NODE_ENV || 'development',
-    release: config.SENTRY_RELEASE?.trim() || pkg.version,
+    dsn: config.DISCORD_SENTRY_DSN,
+    environment: config.DISCORD_SENTRY_ENVIRONMENT?.trim() || process.env.NODE_ENV || 'development',
+    release: config.DISCORD_SENTRY_RELEASE?.trim() || gitShortSha() || pkg.version,
     tracesSampleRate: Number.isFinite(rate) ? rate : 0.1,
     sendDefaultPii: false,
   });

--- a/discord/src/sentry.ts
+++ b/discord/src/sentry.ts
@@ -23,12 +23,15 @@ function gitShortSha(): string {
 export function initSentry(config: Config, sdk: SentrySdk = Sentry): void {
   if (!config.sentryEnabled) return;
 
-  const rate = Number.parseFloat(config.DISCORD_SENTRY_TRACES_SAMPLE_RATE ?? '');
+  const parsed = Number.parseFloat(config.DISCORD_SENTRY_TRACES_SAMPLE_RATE ?? '');
+  // Reject NaN/Infinity and out-of-range values — Sentry expects a probability in [0,1] and an
+  // out-of-range value would either over-sample (cost) or silently disable tracing.
+  const tracesSampleRate = Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : 0.01;
   sdk.init({
     dsn: config.DISCORD_SENTRY_DSN,
     environment: config.DISCORD_SENTRY_ENVIRONMENT?.trim() || process.env.NODE_ENV || 'development',
     release: config.DISCORD_SENTRY_RELEASE?.trim() || gitShortSha() || pkg.version,
-    tracesSampleRate: Number.isFinite(rate) ? rate : 0.01,
+    tracesSampleRate,
     sendDefaultPii: false,
   });
 }

--- a/discord/src/sentry.ts
+++ b/discord/src/sentry.ts
@@ -1,0 +1,27 @@
+import * as Sentry from '@sentry/bun';
+
+import type { Config } from './config.ts';
+import pkg from '../package.json';
+
+// Minimal surface so tests can inject a fake and assert init args without a live SDK.
+type SentrySdk = Pick<typeof Sentry, 'init'>;
+
+/**
+ * Error/crash monitoring → self-hosted GlitchTip. Opt-in: no SENTRY_DSN ⇒ no-op (dev/local stays
+ * clean), mirroring the bot's "disabled; exiting" contract. Initialising the SDK also installs
+ * global `unhandledRejection` / `uncaughtException` handlers, so the long-running poller and its
+ * crashes report automatically. Errors-only posture with light tracing — GlitchTip doesn't support
+ * replay/profiling/logs, so they stay off.
+ */
+export function initSentry(config: Config, sdk: SentrySdk = Sentry): void {
+  if (!config.sentryEnabled) return;
+
+  const rate = Number.parseFloat(config.SENTRY_TRACES_SAMPLE_RATE ?? '');
+  sdk.init({
+    dsn: config.SENTRY_DSN,
+    environment: config.SENTRY_ENVIRONMENT?.trim() || process.env.NODE_ENV || 'development',
+    release: config.SENTRY_RELEASE?.trim() || pkg.version,
+    tracesSampleRate: Number.isFinite(rate) ? rate : 0.1,
+    sendDefaultPii: false,
+  });
+}

--- a/discord/src/sentry.ts
+++ b/discord/src/sentry.ts
@@ -17,11 +17,8 @@ function gitShortSha(): string {
 }
 
 /**
- * Error/crash monitoring → self-hosted GlitchTip. Opt-in: no DISCORD_SENTRY_DSN ⇒ no-op (dev/local
- * stays clean), mirroring the bot's "disabled; exiting" contract. Initialising the SDK also installs
- * global `unhandledRejection` / `uncaughtException` handlers, so the long-running poller and its
- * crashes report automatically. Errors-only posture with light tracing — GlitchTip doesn't support
- * replay/profiling/logs, so they stay off.
+ * Opt-in error monitoring → GlitchTip (no-op without DISCORD_SENTRY_DSN). Init also installs global
+ * unhandledRejection / uncaughtException handlers, so crashes in this long-running process report.
  */
 export function initSentry(config: Config, sdk: SentrySdk = Sentry): void {
   if (!config.sentryEnabled) return;

--- a/discord/tests/sentry.test.ts
+++ b/discord/tests/sentry.test.ts
@@ -56,6 +56,6 @@ describe('initSentry', () => {
     initSentry(loadConfig({ ...baseEnv, DISCORD_SENTRY_DSN: 'https://abc@glitchtip.test/1' }), {
       init,
     });
-    expect(init.mock.calls[0]?.[0]).toMatchObject({ tracesSampleRate: 0.1 });
+    expect(init.mock.calls[0]?.[0]).toMatchObject({ tracesSampleRate: 0.01 });
   });
 });

--- a/discord/tests/sentry.test.ts
+++ b/discord/tests/sentry.test.ts
@@ -9,15 +9,23 @@ const baseEnv: NodeJS.ProcessEnv = {
 };
 
 describe('initSentry', () => {
-  test('no-op when SENTRY_DSN is unset', () => {
+  test('no-op when DISCORD_SENTRY_DSN is unset', () => {
     const init = mock((_options?: unknown) => undefined);
     initSentry(loadConfig({ ...baseEnv }), { init });
     expect(init).not.toHaveBeenCalled();
   });
 
-  test('no-op when SENTRY_DSN is an empty placeholder', () => {
+  test('no-op when DISCORD_SENTRY_DSN is an empty placeholder', () => {
     const init = mock((_options?: unknown) => undefined);
-    initSentry(loadConfig({ ...baseEnv, SENTRY_DSN: '' }), { init });
+    initSentry(loadConfig({ ...baseEnv, DISCORD_SENTRY_DSN: '' }), { init });
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  test('ignores the API SENTRY_DSN from the shared root .env', () => {
+    // The bot loads the repo-root .env, which carries the API's SENTRY_DSN. Only the
+    // DISCORD_-prefixed var should switch the bot on, so the two projects never cross-report.
+    const init = mock((_options?: unknown) => undefined);
+    initSentry(loadConfig({ ...baseEnv, SENTRY_DSN: 'https://api@glitchtip.test/1' }), { init });
     expect(init).not.toHaveBeenCalled();
   });
 
@@ -25,10 +33,10 @@ describe('initSentry', () => {
     const init = mock((_options?: unknown) => undefined);
     const config = loadConfig({
       ...baseEnv,
-      SENTRY_DSN: 'https://abc@glitchtip.test/1',
-      SENTRY_ENVIRONMENT: 'production',
-      SENTRY_RELEASE: 'gankedtv-discord@1.2.3',
-      SENTRY_TRACES_SAMPLE_RATE: '0.25',
+      DISCORD_SENTRY_DSN: 'https://abc@glitchtip.test/1',
+      DISCORD_SENTRY_ENVIRONMENT: 'production',
+      DISCORD_SENTRY_RELEASE: 'gankedtv-discord@1.2.3',
+      DISCORD_SENTRY_TRACES_SAMPLE_RATE: '0.25',
     });
 
     initSentry(config, { init });
@@ -45,7 +53,9 @@ describe('initSentry', () => {
 
   test('falls back to default sample rate when unset/invalid', () => {
     const init = mock((_options?: unknown) => undefined);
-    initSentry(loadConfig({ ...baseEnv, SENTRY_DSN: 'https://abc@glitchtip.test/1' }), { init });
+    initSentry(loadConfig({ ...baseEnv, DISCORD_SENTRY_DSN: 'https://abc@glitchtip.test/1' }), {
+      init,
+    });
     expect(init.mock.calls[0]?.[0]).toMatchObject({ tracesSampleRate: 0.1 });
   });
 });

--- a/discord/tests/sentry.test.ts
+++ b/discord/tests/sentry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { loadConfig } from '../src/config.ts';
+import { initSentry } from '../src/sentry.ts';
+
+const baseEnv: NodeJS.ProcessEnv = {
+  DISCORD_DATABASE_URL: 'postgres://x@localhost:5432/x',
+  GANKEDTV_API_BASE: 'http://api.test',
+  GANKEDTV_PUBLIC_BASE: 'http://web.test',
+};
+
+describe('initSentry', () => {
+  test('no-op when SENTRY_DSN is unset', () => {
+    const init = mock((_options?: unknown) => undefined);
+    initSentry(loadConfig({ ...baseEnv }), { init });
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  test('no-op when SENTRY_DSN is an empty placeholder', () => {
+    const init = mock((_options?: unknown) => undefined);
+    initSentry(loadConfig({ ...baseEnv, SENTRY_DSN: '' }), { init });
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  test('initialises with dsn, environment, release and PII off when DSN is set', () => {
+    const init = mock((_options?: unknown) => undefined);
+    const config = loadConfig({
+      ...baseEnv,
+      SENTRY_DSN: 'https://abc@glitchtip.test/1',
+      SENTRY_ENVIRONMENT: 'production',
+      SENTRY_RELEASE: 'gankedtv-discord@1.2.3',
+      SENTRY_TRACES_SAMPLE_RATE: '0.25',
+    });
+
+    initSentry(config, { init });
+
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(init.mock.calls[0]?.[0]).toMatchObject({
+      dsn: 'https://abc@glitchtip.test/1',
+      environment: 'production',
+      release: 'gankedtv-discord@1.2.3',
+      tracesSampleRate: 0.25,
+      sendDefaultPii: false,
+    });
+  });
+
+  test('falls back to default sample rate when unset/invalid', () => {
+    const init = mock((_options?: unknown) => undefined);
+    initSentry(loadConfig({ ...baseEnv, SENTRY_DSN: 'https://abc@glitchtip.test/1' }), { init });
+    expect(init.mock.calls[0]?.[0]).toMatchObject({ tracesSampleRate: 0.1 });
+  });
+});

--- a/server/src/GankedTV.Api/GankedTV.Api.csproj
+++ b/server/src/GankedTV.Api/GankedTV.Api.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
   </ItemGroup>

--- a/server/src/GankedTV.Api/Observability/SensitiveQuery.cs
+++ b/server/src/GankedTV.Api/Observability/SensitiveQuery.cs
@@ -1,0 +1,59 @@
+namespace GankedTV.Api.Observability;
+
+/// <summary>
+/// Strips credential-bearing params from a request query string before it's attached to a Sentry
+/// event. The API serves OAuth callbacks (<c>/auth/{provider}/callback?code=…&amp;state=…</c>), and
+/// the SDK captures the query string regardless of <c>SendDefaultPii</c>, so the authorization code
+/// would otherwise reach GlitchTip. Mirrors the web client's redaction key list.
+/// </summary>
+internal static class SensitiveQuery
+{
+    private static readonly HashSet<string> SensitiveKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "token",
+        "refresh",
+        "code",
+        "state",
+        "access_token",
+        "id_token",
+    };
+
+    /// <summary>
+    /// Drops sensitive key/value pairs, preserving order and benign params. Returns the input
+    /// unchanged when null/empty, and "" when every pair was sensitive. Handles a leading '?'.
+    /// </summary>
+    public static string? Redact(string? queryString)
+    {
+        if (string.IsNullOrEmpty(queryString))
+        {
+            return queryString;
+        }
+
+        var hasLeadingQuestion = queryString[0] == '?';
+        var raw = hasLeadingQuestion ? queryString[1..] : queryString;
+        if (raw.Length == 0)
+        {
+            return queryString;
+        }
+
+        var kept = new List<string>();
+        foreach (var pair in raw.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=', StringComparison.Ordinal);
+            var key = eq >= 0 ? pair[..eq] : pair;
+            // Keys are URL-encoded on the wire; decode before matching our (unencoded) list.
+            if (!SensitiveKeys.Contains(Uri.UnescapeDataString(key)))
+            {
+                kept.Add(pair);
+            }
+        }
+
+        if (kept.Count == 0)
+        {
+            return "";
+        }
+
+        var rebuilt = string.Join('&', kept);
+        return hasLeadingQuestion ? "?" + rebuilt : rebuilt;
+    }
+}

--- a/server/src/GankedTV.Api/Observability/SensitiveQuery.cs
+++ b/server/src/GankedTV.Api/Observability/SensitiveQuery.cs
@@ -1,10 +1,9 @@
 namespace GankedTV.Api.Observability;
 
 /// <summary>
-/// Strips credential-bearing params from a request query string before it's attached to a Sentry
-/// event. The API serves OAuth callbacks (<c>/auth/{provider}/callback?code=…&amp;state=…</c>), and
-/// the SDK captures the query string regardless of <c>SendDefaultPii</c>, so the authorization code
-/// would otherwise reach GlitchTip. Mirrors the web client's redaction key list.
+/// Drops credential-bearing query params from a captured request URL. The API serves OAuth callbacks
+/// (<c>?code=…&amp;state=…</c>) whose query string the SDK captures regardless of SendDefaultPii, so
+/// the auth code would otherwise reach GlitchTip. Same key list as the web client.
 /// </summary>
 internal static class SensitiveQuery
 {
@@ -18,10 +17,7 @@ internal static class SensitiveQuery
         "id_token",
     };
 
-    /// <summary>
-    /// Drops sensitive key/value pairs, preserving order and benign params. Returns the input
-    /// unchanged when null/empty, and "" when every pair was sensitive. Handles a leading '?'.
-    /// </summary>
+    /// <summary>Drops sensitive pairs, keeping order and benign params. Handles a leading '?'.</summary>
     public static string? Redact(string? queryString)
     {
         if (string.IsNullOrEmpty(queryString))

--- a/server/src/GankedTV.Api/Observability/SentryPiiScrubber.cs
+++ b/server/src/GankedTV.Api/Observability/SentryPiiScrubber.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Sentry;
 using Sentry.Extensibility;
 
@@ -17,16 +18,30 @@ public sealed class SentryPiiScrubber : ISentryEventProcessor
         "Set-Cookie",
     ];
 
+    // Peek the backing field instead of the property getter — `@event.Request` lazy-instantiates,
+    // so touching it on a background/hosted-service crash would attach an empty Request{} block
+    // to the event we send to GlitchTip. Falls back to property access if the SDK renames the field.
+    private static readonly FieldInfo? RequestField = typeof(SentryEvent)
+        .GetField("_request", BindingFlags.Instance | BindingFlags.NonPublic);
+
     public SentryEvent Process(SentryEvent @event)
     {
-        foreach (var name in SensitiveHeaders)
+        var request = RequestField is null
+            ? @event.Request
+            : RequestField.GetValue(@event) as SentryRequest;
+        if (request is null)
         {
-            @event.Request.Headers.Remove(name);
+            return @event;
         }
 
-        @event.Request.Cookies = null;
+        foreach (var name in SensitiveHeaders)
+        {
+            request.Headers.Remove(name);
+        }
+
+        request.Cookies = null;
         // The SDK captures the query string regardless of SendDefaultPii; redact OAuth code/state.
-        @event.Request.QueryString = SensitiveQuery.Redact(@event.Request.QueryString);
+        request.QueryString = SensitiveQuery.Redact(request.QueryString);
         return @event;
     }
 }

--- a/server/src/GankedTV.Api/Observability/SentryPiiScrubber.cs
+++ b/server/src/GankedTV.Api/Observability/SentryPiiScrubber.cs
@@ -1,0 +1,35 @@
+using Sentry;
+using Sentry.Extensibility;
+
+namespace GankedTV.Api.Observability;
+
+/// <summary>
+/// Defense-in-depth PII scrubbing for outgoing Sentry events. <c>SendDefaultPii=false</c>
+/// already keeps the SDK from attaching request headers/cookies/bodies, but this processor
+/// strips credential-bearing fields unconditionally so auth never leaks to GlitchTip even if
+/// another integration attaches them.
+/// </summary>
+public sealed class SentryPiiScrubber : ISentryEventProcessor
+{
+    private static readonly string[] SensitiveHeaders =
+    [
+        "Authorization",
+        "Proxy-Authorization",
+        "Cookie",
+        "Set-Cookie",
+    ];
+
+    public SentryEvent Process(SentryEvent @event)
+    {
+        foreach (var name in SensitiveHeaders)
+        {
+            @event.Request.Headers.Remove(name);
+        }
+
+        @event.Request.Cookies = null;
+        // OAuth callback URLs carry ?code=…&state=…; the SDK captures the query string regardless
+        // of SendDefaultPii, so strip credential-bearing params before the event leaves.
+        @event.Request.QueryString = SensitiveQuery.Redact(@event.Request.QueryString);
+        return @event;
+    }
+}

--- a/server/src/GankedTV.Api/Observability/SentryPiiScrubber.cs
+++ b/server/src/GankedTV.Api/Observability/SentryPiiScrubber.cs
@@ -4,10 +4,8 @@ using Sentry.Extensibility;
 namespace GankedTV.Api.Observability;
 
 /// <summary>
-/// Defense-in-depth PII scrubbing for outgoing Sentry events. <c>SendDefaultPii=false</c>
-/// already keeps the SDK from attaching request headers/cookies/bodies, but this processor
-/// strips credential-bearing fields unconditionally so auth never leaks to GlitchTip even if
-/// another integration attaches them.
+/// Strips credential-bearing fields from outgoing Sentry events. SendDefaultPii is already false;
+/// this is belt-and-braces so auth never leaks even if another integration attaches it.
 /// </summary>
 public sealed class SentryPiiScrubber : ISentryEventProcessor
 {
@@ -27,8 +25,7 @@ public sealed class SentryPiiScrubber : ISentryEventProcessor
         }
 
         @event.Request.Cookies = null;
-        // OAuth callback URLs carry ?code=…&state=…; the SDK captures the query string regardless
-        // of SendDefaultPii, so strip credential-bearing params before the event leaves.
+        // The SDK captures the query string regardless of SendDefaultPii; redact OAuth code/state.
         @event.Request.QueryString = SensitiveQuery.Redact(@event.Request.QueryString);
         return @event;
     }

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -100,7 +100,7 @@ builder.WebHost.UseSentry(o =>
             CultureInfo.InvariantCulture,
             out var rate)
             ? rate
-            : builder.Configuration.GetValue("Sentry:TracesSampleRate", 0.1);
+            : builder.Configuration.GetValue("Sentry:TracesSampleRate", 0.01);
 });
 builder.Services.AddSingleton<ISentryEventProcessor, SentryPiiScrubber>();
 

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -12,6 +12,7 @@ using GankedTV.Api.Endpoints;
 using GankedTV.Api.HostedServices;
 using GankedTV.Api.Middleware;
 using GankedTV.Api.Notifications;
+using GankedTV.Api.Observability;
 using GankedTV.Api.Services.Caching;
 using GankedTV.Api.Services.Clips;
 using GankedTV.Api.Services.Igdb;
@@ -28,6 +29,8 @@ using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Sentry.Extensibility;
+using System.Globalization;
 using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -78,6 +81,28 @@ if (vaultwardenOptions.IsConfigured)
         .GetAwaiter()
         .GetResult();
 }
+
+// ---- Error monitoring (Sentry → self-hosted GlitchTip) ----
+// Opt-in, same contract as IGDB/Discord. The SDK throws on a null DSN and treats "" as "disabled",
+// so we default the DSN to empty when SENTRY_DSN is unset (dev/CI/prod-without-monitoring all
+// no-op). SENTRY_ENVIRONMENT / SENTRY_RELEASE are still auto-read from env (release falls back to
+// the entry-assembly version). Runs after the Vaultwarden bootstrap so a DSN provisioned there is
+// seen. Config binding only: the one piece of real logic (PII scrubbing) lives in SentryPiiScrubber
+// so it stays inside the coverage denominator.
+builder.WebHost.UseSentry(o =>
+{
+    o.Dsn = Environment.GetEnvironmentVariable("SENTRY_DSN") ?? "";
+    o.SendDefaultPii = false;
+    o.TracesSampleRate =
+        double.TryParse(
+            Environment.GetEnvironmentVariable("SENTRY_TRACES_SAMPLE_RATE"),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out var rate)
+            ? rate
+            : builder.Configuration.GetValue("Sentry:TracesSampleRate", 0.1);
+});
+builder.Services.AddSingleton<ISentryEventProcessor, SentryPiiScrubber>();
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -82,13 +82,9 @@ if (vaultwardenOptions.IsConfigured)
         .GetResult();
 }
 
-// ---- Error monitoring (Sentry → self-hosted GlitchTip) ----
-// Opt-in, same contract as IGDB/Discord. The SDK throws on a null DSN and treats "" as "disabled",
-// so we default the DSN to empty when SENTRY_DSN is unset (dev/CI/prod-without-monitoring all
-// no-op). SENTRY_ENVIRONMENT / SENTRY_RELEASE are still auto-read from env (release falls back to
-// the entry-assembly version). Runs after the Vaultwarden bootstrap so a DSN provisioned there is
-// seen. Config binding only: the one piece of real logic (PII scrubbing) lives in SentryPiiScrubber
-// so it stays inside the coverage denominator.
+// Error monitoring (Sentry → GlitchTip). Opt-in: the SDK throws on a null DSN and treats "" as
+// disabled, so default to "" when SENTRY_DSN is unset. Runs after the Vaultwarden bootstrap so a
+// DSN provisioned there is seen; SENTRY_ENVIRONMENT / SENTRY_RELEASE are auto-read from env.
 builder.WebHost.UseSentry(o =>
 {
     o.Dsn = Environment.GetEnvironmentVariable("SENTRY_DSN") ?? "";

--- a/server/src/GankedTV.Api/appsettings.json
+++ b/server/src/GankedTV.Api/appsettings.json
@@ -30,6 +30,6 @@
     "SyncInterval": "7.00:00:00"
   },
   "Sentry": {
-    "TracesSampleRate": 0.1
+    "TracesSampleRate": 0.01
   }
 }

--- a/server/src/GankedTV.Api/appsettings.json
+++ b/server/src/GankedTV.Api/appsettings.json
@@ -28,5 +28,8 @@
     "MaxRequestsPerSecond": 4,
     "SyncEnabled": false,
     "SyncInterval": "7.00:00:00"
+  },
+  "Sentry": {
+    "TracesSampleRate": 0.1
   }
 }

--- a/server/tests/GankedTV.Api.Tests/Observability/SensitiveQueryTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Observability/SensitiveQueryTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using GankedTV.Api.Observability;
+
+namespace GankedTV.Api.Tests.Observability;
+
+public class SensitiveQueryTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Redact_PassesThroughNullOrEmpty(string? input)
+    {
+        SensitiveQuery.Redact(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Redact_DropsSensitiveParamsKeepsBenignOnes()
+    {
+        SensitiveQuery.Redact("?code=abc&state=xyz&page=2").Should().Be("?page=2");
+    }
+
+    [Fact]
+    public void Redact_HandlesQueryWithoutLeadingQuestionMark()
+    {
+        SensitiveQuery.Redact("token=jwt&sort=week").Should().Be("sort=week");
+    }
+
+    [Fact]
+    public void Redact_ReturnsEmptyWhenEveryParamIsSensitive()
+    {
+        SensitiveQuery.Redact("?code=abc&refresh=rt&access_token=at&id_token=it").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Redact_MatchesKeysCaseInsensitively()
+    {
+        SensitiveQuery.Redact("?Code=abc&keep=1").Should().Be("?keep=1");
+    }
+
+    [Fact]
+    public void Redact_KeepsBenignQueryUnchanged()
+    {
+        SensitiveQuery.Redact("?sort=week&page=2").Should().Be("?sort=week&page=2");
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Observability/SentryPiiScrubberTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Observability/SentryPiiScrubberTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FluentAssertions;
 using GankedTV.Api.Observability;
 using Sentry;
@@ -39,6 +40,20 @@ public class SentryPiiScrubberTests
         @event.Request.QueryString = "?code=secret&state=xyz&page=2";
 
         Scrubber.Process(@event).Request.QueryString.Should().Be("?page=2");
+    }
+
+    [Fact]
+    public void Process_LeavesRequestUnattachedForNonHttpEvents()
+    {
+        var @event = new SentryEvent();
+
+        Scrubber.Process(@event);
+
+        // The backing field should remain null — touching @event.Request via the property would
+        // lazy-instantiate an empty Request{} and ship it to GlitchTip for every background crash.
+        var field = typeof(SentryEvent).GetField("_request", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull("test relies on the SDK's _request backing field");
+        field!.GetValue(@event).Should().BeNull();
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Observability/SentryPiiScrubberTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Observability/SentryPiiScrubberTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using GankedTV.Api.Observability;
+using Sentry;
+
+namespace GankedTV.Api.Tests.Observability;
+
+public class SentryPiiScrubberTests
+{
+    private static readonly SentryPiiScrubber Scrubber = new();
+
+    [Theory]
+    [InlineData("Authorization")]
+    [InlineData("Proxy-Authorization")]
+    [InlineData("Cookie")]
+    [InlineData("Set-Cookie")]
+    public void Process_RemovesCredentialBearingHeaders(string header)
+    {
+        var @event = new SentryEvent();
+        @event.Request.Headers[header] = "Bearer super-secret-token";
+
+        var result = Scrubber.Process(@event);
+
+        result.Request.Headers.Should().NotContainKey(header);
+    }
+
+    [Fact]
+    public void Process_ClearsCookies()
+    {
+        var @event = new SentryEvent();
+        @event.Request.Cookies = "session=abc; refresh=def";
+
+        Scrubber.Process(@event).Request.Cookies.Should().BeNull();
+    }
+
+    [Fact]
+    public void Process_RedactsSensitiveQueryParams()
+    {
+        var @event = new SentryEvent();
+        @event.Request.QueryString = "?code=secret&state=xyz&page=2";
+
+        Scrubber.Process(@event).Request.QueryString.Should().Be("?page=2");
+    }
+
+    [Fact]
+    public void Process_KeepsNonSensitiveHeaders()
+    {
+        var @event = new SentryEvent();
+        @event.Request.Headers["Authorization"] = "Bearer secret";
+        @event.Request.Headers["Content-Type"] = "application/json";
+
+        var result = Scrubber.Process(@event);
+
+        result.Request.Headers.Should().ContainKey("Content-Type");
+        result.Request.Headers.Should().NotContainKey("Authorization");
+    }
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "gankedtv",
       "dependencies": {
+        "@sentry/vue": "^10.54.0",
         "hls.js": "^1.6.16",
         "pinia": "^3.0.4",
         "plyr": "^3.8.4",
@@ -306,6 +307,20 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
+
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" } }, "sha512-Cz6NzYFmWJlHh1tvtltKsmLl+1jlseQaPXk18Z0P1g6lXAwhT3aJ99x7vDm4jwCzcJ12qAa8Oga8T3C23Ihijw=="],
+
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" } }, "sha512-14D+TPgi75zogGQ/EWwtIm34FVWP34gso4SfJZRAoHiQrRfd907q8/7MTXNItxi81x79cH9vweu/o55LBml6MA=="],
+
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-B7eicNhAomJ7bGihJO7mCw7pZ8FFo/THQgGPo85VR3FaJVCCot20WxVgvhjc7IVBQVlaaxSrnlUFvA+yHjszqQ=="],
+
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.54.0", "", { "dependencies": { "@sentry-internal/replay": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-CGsH019npxnU5cocVDoZKod7JaQtaM6JiR6e2fI8tDwssohJAxP616UQTmoTtBLe3yLG18P4e1BxMxYZFalZEQ=="],
+
+    "@sentry/browser": ["@sentry/browser@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry-internal/feedback": "10.54.0", "@sentry-internal/replay": "10.54.0", "@sentry-internal/replay-canvas": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-XYuAA2E4Hf6NOJiP3PqczPgBhFUEsEAh+avgxcYTjTwYdr+Nh5XmDxXATr6RxXUvRASTiYN9zNWyK2o9kEDloA=="],
+
+    "@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry/vue": ["@sentry/vue@10.54.0", "", { "dependencies": { "@sentry/browser": "10.54.0", "@sentry/core": "10.54.0" }, "peerDependencies": { "@tanstack/vue-router": "^1.64.0", "pinia": "2.x || 3.x", "vue": "2.x || 3.x" }, "optionalPeers": ["@tanstack/vue-router", "pinia"] }, "sha512-z0S2YXqYTcQ+Q+RowLsNZxZpHnPsgXZvic8ZV+2LUWS1Al8ngASiMq6mTyFP75X/12eUQDFR+P6EpH+2bboPBQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -9,11 +9,22 @@ interface ImportMetaEnv {
   readonly VITE_USE_SECURE_COOKIES?: string
   /** Max upload size in MB shown in the upload UI. */
   readonly VITE_MAX_UPLOAD_SIZE_MB?: string
+  /** Sentry/GlitchTip DSN. Present only in production builds; gates error monitoring. */
+  readonly VITE_SENTRY_DSN?: string
+  /** Sentry environment tag. Falls back to import.meta.env.MODE when unset. */
+  readonly VITE_SENTRY_ENVIRONMENT?: string
+  /** Sentry release tag. Falls back to the app version (__APP_VERSION__) when unset. */
+  readonly VITE_SENTRY_RELEASE?: string
+  /** Sentry traces sample rate (0–1). Falls back to 0.1 when unset/invalid. */
+  readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+/** App version injected at build time from package.json (see vite.config.ts). */
+declare const __APP_VERSION__: string
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -15,7 +15,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_ENVIRONMENT?: string
   /** Sentry release tag. Falls back to the app version (__APP_VERSION__) when unset. */
   readonly VITE_SENTRY_RELEASE?: string
-  /** Sentry traces sample rate (0–1). Falls back to 0.1 when unset/invalid. */
+  /** Sentry traces sample rate (0–1). Falls back to 0.01 when unset/invalid. */
   readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "format:check": "prettier --check --cache --cache-location ./node_modules/.cache/prettier/.prettier-cache src/ scripts/"
   },
   "dependencies": {
+    "@sentry/vue": "^10.54.0",
     "hls.js": "^1.6.16",
     "pinia": "^3.0.4",
     "plyr": "^3.8.4",

--- a/web/src/assets/logo-lockup.svg
+++ b/web/src/assets/logo-lockup.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 392 96" role="img" aria-label="GANKED.TV">
+  <defs>
+    <linearGradient id="gt-badge-l" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#5b21b6"/>
+    </linearGradient>
+    <filter id="gt-glow-l" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="1.6" result="b"/>
+      <feMerge>
+        <feMergeNode in="b"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@700&amp;display=swap');
+      .gt-word { font-family: 'Rajdhani','Barlow Condensed','Arial Narrow',sans-serif; font-weight: 700; }
+    </style>
+  </defs>
+
+  <!-- mark -->
+  <g transform="translate(16 16)">
+    <path d="M14 1 H63 V50 L50 63 H1 V14 Z"
+          fill="url(#gt-badge-l)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.55"/>
+    <path d="M18 9 H55 V46 L46 55 H9 V18 Z" fill="#0a0a14"/>
+    <path d="M28 21 L28 43 L46 32 Z"
+          fill="#00e5a0" stroke="#00e5a0" stroke-width="3" stroke-linejoin="round"
+          filter="url(#gt-glow-l)"/>
+    <path d="M63 50 L50 63" fill="none" stroke="#00e5a0" stroke-width="3.5"
+          stroke-linecap="round" filter="url(#gt-glow-l)"/>
+  </g>
+
+  <!-- wordmark -->
+  <text x="104" y="63" class="gt-word" font-size="52" letter-spacing="1.5">
+    <tspan fill="#f0eeff">GANKED</tspan><tspan fill="#7c3aed">.TV</tspan>
+  </text>
+</svg>

--- a/web/src/assets/logo-mark.svg
+++ b/web/src/assets/logo-mark.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="GankedTV">
+  <defs>
+    <linearGradient id="gt-badge" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#5b21b6"/>
+    </linearGradient>
+    <filter id="gt-glow" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="1.6" result="b"/>
+      <feMerge>
+        <feMergeNode in="b"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- chamfered badge frame (top-left + bottom-right cut, brand DNA) -->
+  <path d="M14 1 H63 V50 L50 63 H1 V14 Z"
+        fill="url(#gt-badge)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.55"/>
+
+  <!-- recessed interior -->
+  <path d="M18 9 H55 V46 L46 55 H9 V18 Z" fill="#0a0a14"/>
+
+  <!-- neon play triangle: the clip -->
+  <path d="M28 21 L28 43 L46 32 Z"
+        fill="#00e5a0" stroke="#00e5a0" stroke-width="3" stroke-linejoin="round"
+        filter="url(#gt-glow)"/>
+
+  <!-- neon gank blade on the chamfered corner -->
+  <path d="M63 50 L50 63" fill="none" stroke="#00e5a0" stroke-width="3.5"
+        stroke-linecap="round" filter="url(#gt-glow)"/>
+</svg>

--- a/web/src/lib/__tests__/analytics.spec.ts
+++ b/web/src/lib/__tests__/analytics.spec.ts
@@ -107,4 +107,10 @@ describe('stripSensitiveParams', () => {
   it('keeps a fragment when there is no query string', () => {
     expect(stripSensitiveParams('/article#comments')).toBe('/article#comments')
   })
+
+  it('matches sensitive keys case-insensitively (parity with server scrubber)', () => {
+    expect(stripSensitiveParams('/auth/callback?Token=jwt&CODE=c&State=s&keep=ok')).toBe(
+      '/auth/callback?keep=ok',
+    )
+  })
 })

--- a/web/src/lib/__tests__/analytics.spec.ts
+++ b/web/src/lib/__tests__/analytics.spec.ts
@@ -97,4 +97,14 @@ describe('stripSensitiveParams', () => {
   it('leaves non-sensitive query strings intact', () => {
     expect(stripSensitiveParams('/trending?sort=week&page=2')).toBe('/trending?sort=week&page=2')
   })
+
+  it('preserves a fragment while redacting the query', () => {
+    expect(stripSensitiveParams('/auth/callback?token=jwt&returnTo=/feed#section')).toBe(
+      '/auth/callback?returnTo=%2Ffeed#section',
+    )
+  })
+
+  it('keeps a fragment when there is no query string', () => {
+    expect(stripSensitiveParams('/article#comments')).toBe('/article#comments')
+  })
 })

--- a/web/src/lib/__tests__/sentry.spec.ts
+++ b/web/src/lib/__tests__/sentry.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import type { Breadcrumb, ErrorEvent } from '@sentry/vue'
+import { scrubEvent, scrubBreadcrumb } from '../sentry'
+
+describe('scrubEvent', () => {
+  it('drops request headers and cookies', () => {
+    const event = {
+      request: {
+        url: '/feed',
+        headers: { Authorization: 'Bearer jwt', 'Content-Type': 'application/json' },
+        cookies: { refresh: 'rt' },
+      },
+    } as unknown as ErrorEvent
+
+    const out = scrubEvent(event)
+
+    expect(out.request?.headers).toBeUndefined()
+    expect(out.request?.cookies).toBeUndefined()
+  })
+
+  it('redacts sensitive query params from the request url', () => {
+    const event = {
+      request: { url: '/auth/callback?token=jwt&refresh=rt&foo=bar' },
+    } as unknown as ErrorEvent
+
+    expect(scrubEvent(event).request?.url).toBe('/auth/callback?foo=bar')
+  })
+
+  it('passes an event without request data through unchanged', () => {
+    const event = { message: 'boom' } as ErrorEvent
+    expect(scrubEvent(event)).toBe(event)
+  })
+})
+
+describe('scrubBreadcrumb', () => {
+  it('redacts url/from/to in breadcrumb data', () => {
+    const crumb: Breadcrumb = {
+      category: 'navigation',
+      data: {
+        url: '/auth/callback?code=abc&keep=1',
+        from: '/login?state=xyz',
+        to: '/feed?refresh=rt',
+      },
+    }
+
+    const out = scrubBreadcrumb(crumb)
+
+    expect(out.data?.url).toBe('/auth/callback?keep=1')
+    expect(out.data?.from).toBe('/login')
+    expect(out.data?.to).toBe('/feed')
+  })
+
+  it('passes a breadcrumb without data through unchanged', () => {
+    const crumb: Breadcrumb = { message: 'navigated' }
+    expect(scrubBreadcrumb(crumb)).toBe(crumb)
+  })
+})

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -9,31 +9,9 @@ export interface AnalyticsProvider {
   trackEvent(name: string, params?: Record<string, unknown>): void
 }
 
-// Query keys that can carry credentials/secrets and must never be shipped to a third-party
-// analytics provider. The OAuth callback lands on /auth/callback?token=<JWT>&refresh=<token>,
-// so a naive `trackPageView(to.fullPath)` would leak a 30-day refresh token to GA.
-const SENSITIVE_QUERY_KEYS = new Set([
-  'token',
-  'refresh',
-  'code',
-  'state',
-  'access_token',
-  'id_token',
-])
-
-/** Removes sensitive query params from a router fullPath before it reaches analytics. */
-export function stripSensitiveParams(fullPath: string): string {
-  const [path, query = ''] = fullPath.split('?')
-  if (!query) return path
-  // Rebuild from only the non-sensitive entries (rather than deleting in place, which would
-  // mutate the live iterator) — preserves original order and is straightforward to read.
-  const kept = new URLSearchParams()
-  for (const [key, value] of new URLSearchParams(query)) {
-    if (!SENSITIVE_QUERY_KEYS.has(key)) kept.append(key, value)
-  }
-  const qs = kept.toString()
-  return qs ? `${path}?${qs}` : path
-}
+// Re-exported so the router keeps importing redaction from one place; the implementation +
+// key list live in ./sensitiveParams (shared with Sentry's PII scrubbing).
+export { stripSensitiveParams } from './sensitiveParams'
 
 const noopProvider: AnalyticsProvider = {
   trackPageView() {},

--- a/web/src/lib/sensitiveParams.ts
+++ b/web/src/lib/sensitiveParams.ts
@@ -13,12 +13,21 @@ const SENSITIVE_QUERY_KEYS = new Set([
 ])
 
 /**
- * Removes sensitive query params from a path or absolute URL, preserving everything before the
- * query string. Origin-agnostic: works on router fullPaths (`/a?token=x`) and full URLs alike.
+ * Removes sensitive query params from a path or absolute URL, preserving the path and any fragment.
+ * Origin-agnostic: works on router fullPaths (`/a?token=x`) and full URLs alike.
  */
 export function stripSensitiveParams(fullPath: string): string {
-  const [path, query = ''] = fullPath.split('?')
-  if (!query) return path
+  // Peel off an optional fragment first so it survives untouched — otherwise `?a=1#frag` parses
+  // `1#frag` as a single query value and corrupts (percent-encodes) the fragment.
+  const hashIndex = fullPath.indexOf('#')
+  const fragment = hashIndex === -1 ? '' : fullPath.slice(hashIndex)
+  const beforeHash = hashIndex === -1 ? fullPath : fullPath.slice(0, hashIndex)
+
+  const queryIndex = beforeHash.indexOf('?')
+  if (queryIndex === -1) return beforeHash + fragment
+
+  const path = beforeHash.slice(0, queryIndex)
+  const query = beforeHash.slice(queryIndex + 1)
   // Rebuild from only the non-sensitive entries (rather than deleting in place, which would
   // mutate the live iterator) — preserves original order and is straightforward to read.
   const kept = new URLSearchParams()
@@ -26,5 +35,5 @@ export function stripSensitiveParams(fullPath: string): string {
     if (!SENSITIVE_QUERY_KEYS.has(key)) kept.append(key, value)
   }
   const qs = kept.toString()
-  return qs ? `${path}?${qs}` : path
+  return (qs ? `${path}?${qs}` : path) + fragment
 }

--- a/web/src/lib/sensitiveParams.ts
+++ b/web/src/lib/sensitiveParams.ts
@@ -32,7 +32,9 @@ export function stripSensitiveParams(fullPath: string): string {
   // mutate the live iterator) — preserves original order and is straightforward to read.
   const kept = new URLSearchParams()
   for (const [key, value] of new URLSearchParams(query)) {
-    if (!SENSITIVE_QUERY_KEYS.has(key)) kept.append(key, value)
+    // Case-insensitive match keeps parity with the server scrubber (OrdinalIgnoreCase),
+    // so `?Token=` / `?CODE=` redact the same as `?token=` / `?code=`.
+    if (!SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) kept.append(key, value)
   }
   const qs = kept.toString()
   return (qs ? `${path}?${qs}` : path) + fragment

--- a/web/src/lib/sensitiveParams.ts
+++ b/web/src/lib/sensitiveParams.ts
@@ -1,0 +1,30 @@
+// Single source of truth for query params that can carry credentials/secrets and must never
+// leave the browser to a third party (analytics page views, Sentry event/breadcrumb URLs).
+// The OAuth callback lands on /auth/callback?token=<JWT>&refresh=<token>, so a naive
+// `trackPageView(to.fullPath)` or a captured error URL would otherwise leak a 30-day refresh token.
+
+const SENSITIVE_QUERY_KEYS = new Set([
+  'token',
+  'refresh',
+  'code',
+  'state',
+  'access_token',
+  'id_token',
+])
+
+/**
+ * Removes sensitive query params from a path or absolute URL, preserving everything before the
+ * query string. Origin-agnostic: works on router fullPaths (`/a?token=x`) and full URLs alike.
+ */
+export function stripSensitiveParams(fullPath: string): string {
+  const [path, query = ''] = fullPath.split('?')
+  if (!query) return path
+  // Rebuild from only the non-sensitive entries (rather than deleting in place, which would
+  // mutate the live iterator) — preserves original order and is straightforward to read.
+  const kept = new URLSearchParams()
+  for (const [key, value] of new URLSearchParams(query)) {
+    if (!SENSITIVE_QUERY_KEYS.has(key)) kept.append(key, value)
+  }
+  const qs = kept.toString()
+  return qs ? `${path}?${qs}` : path
+}

--- a/web/src/lib/sentry.ts
+++ b/web/src/lib/sentry.ts
@@ -1,0 +1,66 @@
+// Browser error/crash monitoring → self-hosted GlitchTip (Sentry-API-compatible). Opt-in: no
+// VITE_SENTRY_DSN (the case for dev/local) ⇒ no-op, mirroring the analytics wrapper. Errors-only
+// posture with light tracing (GlitchTip doesn't support replay/profiling/logs, so they stay off).
+import type { App } from 'vue'
+import type { Router } from 'vue-router'
+import type { Breadcrumb, ErrorEvent } from '@sentry/vue'
+import * as Sentry from '@sentry/vue'
+
+import { stripSensitiveParams } from './sensitiveParams'
+
+const API_BASE_URL =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:5050'
+
+/** Strip credential-bearing query params from any captured URL string. */
+function redactUrl(url: unknown): unknown {
+  return typeof url === 'string' ? stripSensitiveParams(url) : url
+}
+
+/**
+ * Defense-in-depth PII scrubbing on outgoing events: drop request headers/cookies entirely and
+ * redact sensitive query params from the request URL, even though sendDefaultPii is already false.
+ * Exported (with scrubBreadcrumb) so the redaction is unit-tested — the rest of init is wiring.
+ */
+export function scrubEvent(event: ErrorEvent): ErrorEvent {
+  if (event.request) {
+    event.request.url = redactUrl(event.request.url) as string | undefined
+    delete event.request.headers
+    delete event.request.cookies
+  }
+  return event
+}
+
+/** Redact sensitive query params from breadcrumb URLs (navigation/fetch/xhr crumbs). */
+export function scrubBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
+  if (breadcrumb.data) {
+    breadcrumb.data.url = redactUrl(breadcrumb.data.url)
+    breadcrumb.data.from = redactUrl(breadcrumb.data.from)
+    breadcrumb.data.to = redactUrl(breadcrumb.data.to)
+  }
+  return breadcrumb
+}
+
+/**
+ * Initialise Sentry from the build-time DSN. No DSN ⇒ no-op (dev/local stays clean, no network).
+ * Must be called before `app.use(router)` so the browser-tracing/router integration is registered.
+ */
+export function initSentry(app: App, router: Router): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN?.trim()
+  if (!dsn) return
+
+  const sampleRate = Number.parseFloat(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? '')
+
+  Sentry.init({
+    app,
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT?.trim() || import.meta.env.MODE,
+    release: import.meta.env.VITE_SENTRY_RELEASE?.trim() || __APP_VERSION__,
+    integrations: [Sentry.browserTracingIntegration({ router })],
+    tracesSampleRate: Number.isFinite(sampleRate) ? sampleRate : 0.1,
+    tracePropagationTargets: [API_BASE_URL],
+    // PII off: don't attach IP/headers/cookies. Defense-in-depth scrubbing via the helpers above.
+    sendDefaultPii: false,
+    beforeSend: scrubEvent,
+    beforeBreadcrumb: scrubBreadcrumb,
+  })
+}

--- a/web/src/lib/sentry.ts
+++ b/web/src/lib/sentry.ts
@@ -39,7 +39,12 @@ export function initSentry(app: App, router: Router): void {
   const dsn = import.meta.env.VITE_SENTRY_DSN?.trim()
   if (!dsn) return
 
-  const sampleRate = Number.parseFloat(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? '')
+  const parsedSampleRate = Number.parseFloat(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? '')
+  // Reject NaN/Infinity and out-of-range values — Sentry expects a probability in [0,1].
+  const tracesSampleRate =
+    Number.isFinite(parsedSampleRate) && parsedSampleRate >= 0 && parsedSampleRate <= 1
+      ? parsedSampleRate
+      : 0.01
 
   Sentry.init({
     app,
@@ -47,7 +52,7 @@ export function initSentry(app: App, router: Router): void {
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT?.trim() || import.meta.env.MODE,
     release: import.meta.env.VITE_SENTRY_RELEASE?.trim() || __APP_VERSION__,
     integrations: [Sentry.browserTracingIntegration({ router })],
-    tracesSampleRate: Number.isFinite(sampleRate) ? sampleRate : 0.01,
+    tracesSampleRate,
     tracePropagationTargets: [API_BASE_URL],
     // PII off; the helpers above scrub defensively.
     sendDefaultPii: false,

--- a/web/src/lib/sentry.ts
+++ b/web/src/lib/sentry.ts
@@ -1,6 +1,4 @@
-// Browser error/crash monitoring → self-hosted GlitchTip (Sentry-API-compatible). Opt-in: no
-// VITE_SENTRY_DSN (the case for dev/local) ⇒ no-op, mirroring the analytics wrapper. Errors-only
-// posture with light tracing (GlitchTip doesn't support replay/profiling/logs, so they stay off).
+// Browser error monitoring → self-hosted GlitchTip. Opt-in: no VITE_SENTRY_DSN ⇒ no-op (dev/local).
 import type { App } from 'vue'
 import type { Router } from 'vue-router'
 import type { Breadcrumb, ErrorEvent } from '@sentry/vue'
@@ -16,11 +14,7 @@ function redactUrl(url: unknown): unknown {
   return typeof url === 'string' ? stripSensitiveParams(url) : url
 }
 
-/**
- * Defense-in-depth PII scrubbing on outgoing events: drop request headers/cookies entirely and
- * redact sensitive query params from the request URL, even though sendDefaultPii is already false.
- * Exported (with scrubBreadcrumb) so the redaction is unit-tested — the rest of init is wiring.
- */
+/** Drop request headers/cookies and redact sensitive URL params — belt-and-braces with sendDefaultPii=false. */
 export function scrubEvent(event: ErrorEvent): ErrorEvent {
   if (event.request) {
     event.request.url = redactUrl(event.request.url) as string | undefined
@@ -40,10 +34,7 @@ export function scrubBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
   return breadcrumb
 }
 
-/**
- * Initialise Sentry from the build-time DSN. No DSN ⇒ no-op (dev/local stays clean, no network).
- * Must be called before `app.use(router)` so the browser-tracing/router integration is registered.
- */
+/** No DSN ⇒ no-op. Must run before `app.use(router)` so the router/tracing integration binds. */
 export function initSentry(app: App, router: Router): void {
   const dsn = import.meta.env.VITE_SENTRY_DSN?.trim()
   if (!dsn) return
@@ -58,7 +49,7 @@ export function initSentry(app: App, router: Router): void {
     integrations: [Sentry.browserTracingIntegration({ router })],
     tracesSampleRate: Number.isFinite(sampleRate) ? sampleRate : 0.01,
     tracePropagationTargets: [API_BASE_URL],
-    // PII off: don't attach IP/headers/cookies. Defense-in-depth scrubbing via the helpers above.
+    // PII off; the helpers above scrub defensively.
     sendDefaultPii: false,
     beforeSend: scrubEvent,
     beforeBreadcrumb: scrubBreadcrumb,

--- a/web/src/lib/sentry.ts
+++ b/web/src/lib/sentry.ts
@@ -56,7 +56,7 @@ export function initSentry(app: App, router: Router): void {
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT?.trim() || import.meta.env.MODE,
     release: import.meta.env.VITE_SENTRY_RELEASE?.trim() || __APP_VERSION__,
     integrations: [Sentry.browserTracingIntegration({ router })],
-    tracesSampleRate: Number.isFinite(sampleRate) ? sampleRate : 0.1,
+    tracesSampleRate: Number.isFinite(sampleRate) ? sampleRate : 0.01,
     tracePropagationTargets: [API_BASE_URL],
     // PII off: don't attach IP/headers/cookies. Defense-in-depth scrubbing via the helpers above.
     sendDefaultPii: false,

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -7,6 +7,7 @@ import { useThemeStore } from './stores/theme'
 import { useAuthStore } from './stores/auth'
 import { configureAuth } from './api/client'
 import { initAnalytics } from './lib/analytics'
+import { initSentry } from './lib/sentry'
 import './assets/main.css'
 
 const app = createApp(App)
@@ -31,6 +32,10 @@ await auth.bootstrap()
 
 // No-op unless VITE_GA_MEASUREMENT_ID is set at build time (production only).
 initAnalytics(import.meta.env.VITE_GA_MEASUREMENT_ID)
+
+// No-op unless VITE_SENTRY_DSN is set. Before `app.use(router)` so the router/tracing
+// integration is registered against the router instance.
+initSentry(app, router)
 
 app.use(router)
 app.mount('#app')

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,9 +11,8 @@ const pkg = JSON.parse(
   readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf-8'),
 ) as { version: string }
 
-// Sentry release fallback (see lib/sentry.ts). Prefer the git short SHA so each commit gets a
-// distinct release; fall back to the package version when .git is absent (e.g. a Docker build
-// context) — production overrides it explicitly via VITE_SENTRY_RELEASE.
+// Sentry release fallback: git short SHA, or package version when .git is absent (e.g. a Docker
+// build context, where the deploy sets VITE_SENTRY_RELEASE instead). See lib/sentry.ts.
 function resolveAppVersion(): string {
   try {
     return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,13 +1,22 @@
 import { fileURLToPath, URL } from 'node:url'
+import { readFileSync } from 'node:fs'
 
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf-8'),
+) as { version: string }
+
 // https://vite.dev/config/
 export default defineConfig({
   envDir: '../',
+  // Built-in release fallback for Sentry when VITE_SENTRY_RELEASE is unset (see lib/sentry.ts).
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [
     vue(),
     tailwindcss(),

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath, URL } from 'node:url'
 import { readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
@@ -10,12 +11,24 @@ const pkg = JSON.parse(
   readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf-8'),
 ) as { version: string }
 
+// Sentry release fallback (see lib/sentry.ts). Prefer the git short SHA so each commit gets a
+// distinct release; fall back to the package version when .git is absent (e.g. a Docker build
+// context) — production overrides it explicitly via VITE_SENTRY_RELEASE.
+function resolveAppVersion(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim()
+  } catch {
+    return pkg.version
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   envDir: '../',
-  // Built-in release fallback for Sentry when VITE_SENTRY_RELEASE is unset (see lib/sentry.ts).
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(resolveAppVersion()),
   },
   plugins: [
     vue(),


### PR DESCRIPTION
## Summary

Wires the official Sentry SDK into all three apps (API, web, Discord bot), pointed at the self-hosted GlitchTip instance. Error monitoring is opt-in and a complete no-op until a DSN is set — same contract as the IGDB sync and Discord bot — so dev/CI/prod-without-monitoring are unaffected.

## What's here

- **Server** (`Sentry.AspNetCore`): DSN/trace-rate binding in [Program.cs](server/src/GankedTV.Api/Program.cs) (pure config wiring) plus a `SentryPiiScrubber` event processor and `SensitiveQuery` helper that strip credential-bearing query params before events leave the process.
- **Web** (`@sentry/vue`): [sentry.ts](web/src/lib/sentry.ts) init from `VITE_SENTRY_*` build-time vars. The sensitive-query redaction list moved to a shared [sensitiveParams.ts](web/src/lib/sensitiveParams.ts) — now the single source of truth for both analytics page views and Sentry event URLs (`analytics.ts` re-exports it).
- **Discord bot** (`@sentry/bun`): [sentry.ts](discord/src/sentry.ts) init from `DISCORD_SENTRY_*` (prefixed because the bot also reads the root `.env`).
- **Posture everywhere:** `SendDefaultPii=false`, errors + light tracing (`0.1` sample rate, overridable); replay/profiling/logs intentionally off (unsupported by GlitchTip).
- **Config + docs:** one DSN var per app so all three coexist in a single `.env`; new "Error monitoring" sections in [DEPLOYMENT.md](DEPLOYMENT.md) and [CLAUDE.md](CLAUDE.md), and entries across `.env.example` / `discord/.env.example`.

Closes #124

## How to test manually

1. Without any `*_SENTRY_DSN` set, run each app — confirm no Sentry init and no behavior change (`make server`, `cd web && bun dev`, `make discord`).
2. Create three GlitchTip projects (api / web / discord), set `SENTRY_DSN`, `VITE_SENTRY_DSN`, `DISCORD_SENTRY_DSN`.
3. Trigger an error in each app and confirm the event lands in the matching GlitchTip project.
4. Verify scrubbing: hit a URL with a sensitive query param (e.g. `/auth/callback?token=...`), capture an event, and confirm `token`/`refresh`/`code`/`state`/`access_token`/`id_token` do **not** appear in the event.
5. `make ci` — server + web + discord suites (new tests: `SentryPiiScrubberTests`, `SensitiveQueryTests`, `web/src/lib/__tests__/sentry.spec.ts`, `discord/tests/sentry.test.ts`).

## Checklist

- [x] Verified manually against a live GlitchTip instance
- [x] `*_RELEASE` vars left unset (the #123 deploy pipeline will set them to the commit SHA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in error monitoring for server, web, and Discord bot (self-hosted Sentry-compatible backends); per-app DSNs, env/release mapping, and trace-sample defaults.
  * Redact sensitive query parameters, headers, and cookies from captured errors and breadcrumbs.
  * Inject build-time app release/version into web builds.

* **Documentation**
  * Expanded env examples and deployment docs with monitoring config, sample-rate guidance, and comment rules.

* **Tests**
  * Added unit tests for scrubbing and Sentry initialization behavior.

* **Chores**
  * Added Sentry runtime dependencies and wiring across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->