### PR TITLE
fix(media): probe yt-dlp with --version; persist DataProtection keys to Redis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,3 +175,43 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=discord
           cache-to: type=gha,scope=discord,mode=max
+
+  # Private encoder image for the GPU box: gankedtv-server + NVENC ffmpeg. Built FROM the
+  # exact server image published above (same commit), and only when server/ changed — so it tracks
+  # server and its tests gate it (needs: server). Keep its GHCR package PRIVATE; it's only for the
+  # dedicated encoder host. See server/Dockerfile.dedicated-encoder + DEPLOYMENT.md.
+  dedicated-encoder:
+    needs: [changes, server]
+    if: needs.changes.outputs.server == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/gankedtv-dedicated-encoder
+          tags: |
+            type=sha,prefix=,format=long
+            type=raw,value=latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: server # unused (the Dockerfile only layers ffmpeg onto the base), mirrors the api job
+          file: server/Dockerfile.dedicated-encoder
+          push: true
+          build-args: |
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gankedtv-server:${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=dedicated-encoder
+          cache-to: type=gha,scope=dedicated-encoder,mode=max

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -29,6 +29,7 @@ each tagged with the commit SHA **and** `latest`:
 | `ghcr.io/gankedtv/gankedtv-server` | [server/Dockerfile.api](server/Dockerfile.api) | API + media workers (bundles `ffmpeg`, `yt-dlp`, `curl`) |
 | `ghcr.io/gankedtv/gankedtv-web` | [web/Dockerfile](web/Dockerfile) | Built Vue bundle served by Caddy (internal `:80`, no TLS) |
 | `ghcr.io/gankedtv/gankedtv-discord` | [discord/Dockerfile](discord/Dockerfile) | Discord bot |
+| `ghcr.io/gankedtv/gankedtv-dedicated-encoder` | [server/Dockerfile.dedicated-encoder](server/Dockerfile.dedicated-encoder) | `gankedtv-server` + NVENC ffmpeg for the GPU box. **Keep this package private** — it's deployment-specific. Built only when `server/` changes. |
 
 A per-image change filter skips images whose sources didn't change — their `latest` already points at
 the correct digest. **There is no deploy job**: the host pulls the moved `latest` itself (Watchtower /
@@ -119,46 +120,62 @@ S3_PUBLIC_URL=https://cdn.example.com          # browser-facing, via your revers
 Buckets are still auto-created on api boot — no manual setup. The app-host api reaches the store over
 the LAN; browsers use `S3_PUBLIC_URL` (presigned URLs are host-rewritten to it).
 
-**GPU transcode worker** — the compress + JIT stages are GPU-heavy and location-independent. Leave the
-app-host api on thumbnails only (`MEDIA_TRANSCODE_WORKER_ENABLED=false`) and run a second container of
-the **same** api image on the GPU host:
+**GPU media worker** — the compress + JIT stages are GPU-heavy and location-independent (the job
+queues use `FOR UPDATE SKIP LOCKED`), so they run on a separate GPU host using the
+**`gankedtv-dedicated-encoder`** image (= `gankedtv-server` with an NVENC ffmpeg baked in). Run the
+media workers there and leave the app-host api as pure API:
+
+| Toggle | App-host api | GPU host (encoder) |
+|---|---|---|
+| `MEDIA_THUMBNAIL_WORKER_ENABLED` | `false` | `true` |
+| `MEDIA_TRANSCODE_WORKER_ENABLED` | `false` | `true` |
+| `MEDIA_TRANSCODE_ENABLED` | `true` | `true` |
+| `MEDIA_IMPORT_WORKER_ENABLED` | `true` | `false` |
+| `MEDIA_VIDEO_ENCODER` / `MEDIA_VIDEO_CODEC` | — | `av1_nvenc` / `av1` |
+| `MEDIA_JIT_VIDEO_ENCODER` | — | `h264_nvenc` |
+| `RUN_MIGRATIONS_ON_STARTUP` | `true` | `false` |
+
+(Thumbnail is a software frame-grab — it doesn't use the GPU — so you can leave it `true` on the
+app-host instead if you'd rather posters keep generating when the GPU host is down. Either works.)
 
 ```yaml
-# GPU host — shares the app host's Postgres + the storage host's MinIO over the LAN
+# GPU host — shares the app-host Postgres + the storage-host object store over the LAN
 services:
-  transcode:
-    image: ghcr.io/gankedtv/gankedtv-server:latest
+  encoder:
+    image: ghcr.io/gankedtv/gankedtv-dedicated-encoder:latest   # NVENC ffmpeg baked in
     environment:
       ASPNETCORE_ENVIRONMENT: Production
-      RUN_MIGRATIONS_ON_STARTUP: "false"       # MUST stay off — the app-host api migrates; avoid races
-      MEDIA_THUMBNAIL_WORKER_ENABLED: "false"
+      RUN_MIGRATIONS_ON_STARTUP: "false"        # the app-host api migrates — keep off here
+      MEDIA_THUMBNAIL_WORKER_ENABLED: "true"
       MEDIA_TRANSCODE_WORKER_ENABLED: "true"
       MEDIA_TRANSCODE_ENABLED: "true"
-      MEDIA_IMPORT_WORKER_ENABLED: "false"     # URL-import stays on the app-host api
-      MEDIA_VIDEO_ENCODER: av1_nvenc           # GPU master encoder
+      MEDIA_IMPORT_WORKER_ENABLED: "false"
+      MEDIA_VIDEO_ENCODER: av1_nvenc
       MEDIA_VIDEO_CODEC: av1
-      MEDIA_JIT_VIDEO_ENCODER: h264_nvenc      # GPU compatibility ladder
-      DATABASE_URL: "Host=<app-host-lan-ip>;Port=5432;Database=gankedtv;Username=gankedtv;Password=..."
-      S3_ENDPOINT: http://<storage-lan-ip>:9000
-      S3_PUBLIC_URL: https://cdn.example.com
-      S3_ACCESS_KEY: ...
-      S3_SECRET_KEY: ...
-      JWT_SECRET: ...                          # it's a full API boot — the fail-fast secrets still apply
-      WEB_ORIGIN: https://example.com
-      CORS_ORIGINS: https://example.com
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - { driver: nvidia, count: 1, capabilities: [gpu, video] }
+      MEDIA_JIT_VIDEO_ENCODER: h264_nvenc
+      # Full api boot → fetches JWT/S3/etc. from Secrets - PROD, same as the app-host.
+      VAULTWARDEN_API_URL: https://<your-vault-api>
+      VAULTWARDEN_API_KEY: <secrets@ token>
+      # DB over the LAN to the app host (publish 5432 there — see below). Set explicitly so it points
+      # at the app host, not the vault's compose-internal value.
+      DATABASE_URL: "Host=<app-host-lan-ip>;Port=5432;Database=gankedtv;Username=gankedtv;Password=<pw>"
 ```
 
-Requires the **NVIDIA Container Toolkit** on the GPU host. **Caveat:** the stock api image bundles
-Debian's *software* ffmpeg, so `av1_nvenc`/`h264_nvenc` fail at encode time. Give the worker an
-NVENC-enabled ffmpeg — either build a thin image `FROM ghcr.io/gankedtv/gankedtv-server:latest` that drops
-in a `jellyfin/ffmpeg` / `jrottenberg/ffmpeg` build and set `FFMPEG_PATH`/`FFPROBE_PATH`, or bind-mount
-one and point `FFMPEG_PATH` at it. The worker owns no schema and runs no migrations — it only leases
-transcode jobs from the shared DB.
+On **TrueNAS Scale**, just attach the app's GPU device — Apps wire the NVIDIA driver libs / passthrough
+out of the box (no manual NVIDIA Container Toolkit), and the encoder image already bundles the NVENC
+ffmpeg, so `av1_nvenc`/`h264_nvenc` work once the GPU is attached. Keep the `gankedtv-dedicated-encoder`
+GHCR package **private** and give the host a `read:packages` token to pull it.
+
+**App-host changes when you move transcoding to the GPU box:**
+1. Set the api's `MEDIA_TRANSCODE_WORKER_ENABLED=false` (and `MEDIA_THUMBNAIL_WORKER_ENABLED=false` if
+   you moved thumbnails too) — otherwise both hosts race the same jobs.
+2. **Publish Postgres on the LAN** so the GPU host can reach it (the prod compose keeps `postgres`
+   internal-only): add `ports: ["<app-host-lan-ip>:5432:5432"]` to the `postgres` service.
+3. Stand the GPU worker up and confirm it's claiming jobs **before** flipping the app-host workers off,
+   so there's no gap where nothing processes.
+
+The worker owns no schema and runs no migrations — it only leases media jobs from the shared DB and
+reads/writes the shared object store.
 
 ## Fail-fast secret validation
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -246,6 +246,18 @@ correctness. The flag accepts `true`/`1`/`yes`/`on`.
 | `GET /health/live` | Process is up (no dependency checks). | Liveness probe / restart signal. |
 | `GET /health/ready` | DB reachable **and** migrations applied. | Readiness gate, load-balancer membership, post-deploy smoke check. |
 
+## Redis
+
+Optional (`REDIS_URL`): backs the feed/trending cache, cluster-wide rate limiting, and — when set —
+**DataProtection key persistence** (keys survive restarts instead of an ephemeral in-memory keyring).
+
+> **Do not enable an `allkeys-*` `maxmemory-policy`** on this instance. DataProtection keys are stored
+> as ordinary (non-expiring) Redis keys, so an all-keys eviction policy could silently drop them under
+> memory pressure — invalidating everything they protect. The default `redis:7` config (no eviction)
+> is correct; if you set a `maxmemory` limit, keep the policy at `noeviction` or a `volatile-*` one
+> (those only evict keys that carry a TTL, which the DP keys don't). Keys are persisted unencrypted at
+> rest, so keep this Redis on the internal network.
+
 ## Worker toggles (media pipeline)
 
 The media pipeline can be split across hosts (see the table in [CLAUDE.md](CLAUDE.md) under

--- a/server/Dockerfile.dedicated-encoder
+++ b/server/Dockerfile.dedicated-encoder
@@ -1,0 +1,34 @@
+# Dedicated GPU encoder image: gankedtv-server (the same API/worker binary) + an NVENC-capable
+# ffmpeg, for the box that runs the compress + JIT (+ thumbnail) media workers on its GPU. The base
+# gankedtv-server image ships Debian's SOFTWARE ffmpeg, so av1_nvenc / h264_nvenc would fail at
+# encode time; this layer drops in a static NVENC build and points FFMPEG_PATH / FFPROBE_PATH at it.
+# NVENC needs the host's NVIDIA driver libs at runtime, provided by GPU passthrough (TrueNAS Scale
+# apps wire this out of the box). Nothing in the image is GPU-specific until those libs are present,
+# so the build itself needs no GPU. It's the same binary as gankedtv-server — runtime env
+# (MEDIA_*_WORKER_ENABLED, MEDIA_VIDEO_ENCODER=av1_nvenc, …) is what makes it the encoder; see
+# DEPLOYMENT.md.
+
+ARG BASE_IMAGE=ghcr.io/gankedtv/gankedtv-server:latest
+FROM ${BASE_IMAGE}
+
+# Static, self-contained GPL build with NVENC/NVDEC + libsvtav1. Pin via --build-arg for a
+# reproducible image; "latest" tracks upstream for this personal box.
+ARG FFMPEG_URL=https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz
+
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl xz-utils ca-certificates \
+    && mkdir -p /opt/ffmpeg \
+    && curl -fsSL "$FFMPEG_URL" -o /tmp/ffmpeg.tar.xz \
+    && tar -xJf /tmp/ffmpeg.tar.xz -C /opt/ffmpeg --strip-components=1 \
+    && rm /tmp/ffmpeg.tar.xz \
+    && apt-get purge -y xz-utils \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && /opt/ffmpeg/bin/ffmpeg -hide_banner -encoders | grep -q nvenc
+
+# Override the bundled software ffmpeg/ffprobe (MediaJobOptions reads these).
+ENV FFMPEG_PATH=/opt/ffmpeg/bin/ffmpeg \
+    FFPROBE_PATH=/opt/ffmpeg/bin/ffprobe
+
+USER gankedtv

--- a/server/src/GankedTV.Api/GankedTV.Api.csproj
+++ b/server/src/GankedTV.Api/GankedTV.Api.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
     <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
   <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">

--- a/server/src/GankedTV.Api/Services/Caching/RedisRegistration.cs
+++ b/server/src/GankedTV.Api/Services/Caching/RedisRegistration.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.StackExchangeRedis;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,6 +41,17 @@ public static class RedisRegistration
             services.AddOptions<RedisCacheOptions>().Configure<IServiceProvider>((cacheOptions, sp) =>
                 cacheOptions.ConnectionMultiplexerFactory =
                     () => Task.FromResult(sp.GetRequiredService<IConnectionMultiplexer>()));
+
+            // Persist DataProtection keys to Redis so they survive restarts and are shared across
+            // replicas — otherwise ASP.NET Core uses an ephemeral in-memory keyring (the boot
+            // warning), and anything DP-protected breaks on restart. Reuses the same lazy
+            // multiplexer; the factory is only invoked when DP actually reads/writes keys. Without
+            // Redis (local dev) DP stays default — ephemeral is fine there.
+            services.AddDataProtection();
+            services.AddOptions<KeyManagementOptions>().Configure<IServiceProvider>((keyOptions, sp) =>
+                keyOptions.XmlRepository = new RedisXmlRepository(
+                    () => sp.GetRequiredService<IConnectionMultiplexer>().GetDatabase(),
+                    "gankedtv:dataprotection-keys"));
         }
 
         return services;

--- a/server/src/GankedTV.Api/Services/Media/ImportWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/ImportWorker.cs
@@ -44,7 +44,7 @@ public sealed class ImportWorker : MediaStageWorker<ClaimedImportJob>
     protected override async Task ProbeBinariesAsync(MediaJobOptions opts, CancellationToken ct)
     {
         await base.ProbeBinariesAsync(opts, ct);
-        await ProbeOneAsync(opts.Import.YtdlpPath, ct);
+        await ProbeOneAsync(opts.Import.YtdlpPath, ct, "--version");
     }
 
     protected override Guid ClipIdOf(ClaimedImportJob job) => job.ClipId;

--- a/server/src/GankedTV.Api/Services/Media/MediaStageWorker.cs
+++ b/server/src/GankedTV.Api/Services/Media/MediaStageWorker.cs
@@ -110,11 +110,13 @@ public abstract class MediaStageWorker<TJob> : BackgroundService
         await ProbeOneAsync(opts.FfprobePath, ct);
     }
 
-    protected async Task ProbeOneAsync(string executable, CancellationToken ct)
+    // versionArg defaults to ffmpeg/ffprobe's single-dash "-version"; yt-dlp needs GNU-style
+    // "--version" — a single dash makes yt-dlp parse "-version" as bundled short flags and error.
+    protected async Task ProbeOneAsync(string executable, CancellationToken ct, string versionArg = "-version")
     {
         try
         {
-            var result = await _ffmpeg.RunAsync(executable, new[] { "-version" }, TimeSpan.FromSeconds(5), ct);
+            var result = await _ffmpeg.RunAsync(executable, new[] { versionArg }, TimeSpan.FromSeconds(5), ct);
             if (result.ExitCode != 0)
             {
                 _logger.LogWarning(

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRegistrationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRegistrationTests.cs
@@ -38,4 +38,13 @@ public class RedisRegistrationTests
         var km = ResolveKeyOptions(redisUrl: null);
         (km.XmlRepository as RedisXmlRepository).Should().BeNull();
     }
+
+    [Fact]
+    public void AddGankedCaching_WithMalformedRedisUrl_LeavesDataProtectionAtDefault()
+    {
+        // A non-URL value fails TryBuildConfiguration's Uri.TryCreate, degrading to the in-process
+        // fallback (no Redis) — so DP must NOT be wired to Redis.
+        var km = ResolveKeyOptions("not-a-url");
+        (km.XmlRepository as RedisXmlRepository).Should().BeNull();
+    }
 }

--- a/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRegistrationTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Caching/RedisRegistrationTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using GankedTV.Api.Services.Caching;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.StackExchangeRedis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace GankedTV.Api.Tests.Services.Caching;
+
+// AddGankedCaching wires DataProtection key persistence to Redis only when REDIS_URL is configured,
+// so keys survive restarts (and are shared across replicas) instead of falling back to an ephemeral
+// in-memory keyring. Without Redis (local dev) it stays at the default.
+public class RedisRegistrationTests
+{
+    private static KeyManagementOptions ResolveKeyOptions(string? redisUrl)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddGankedCaching(new RedisOptions { Url = redisUrl });
+        // Resolving the options runs the configure delegate but never invokes the multiplexer
+        // factory (RedisXmlRepository's IDatabase factory is lazy), so no Redis is contacted.
+        using var sp = services.BuildServiceProvider();
+        return sp.GetRequiredService<IOptions<KeyManagementOptions>>().Value;
+    }
+
+    [Fact]
+    public void AddGankedCaching_WithRedisConfigured_PersistsDataProtectionKeysToRedis()
+    {
+        var km = ResolveKeyOptions("redis://localhost:6379");
+        km.XmlRepository.Should().BeOfType<RedisXmlRepository>();
+    }
+
+    [Fact]
+    public void AddGankedCaching_WithoutRedis_LeavesDataProtectionAtDefault()
+    {
+        var km = ResolveKeyOptions(redisUrl: null);
+        (km.XmlRepository as RedisXmlRepository).Should().BeNull();
+    }
+}

--- a/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
@@ -106,6 +106,8 @@ public class ImportWorkerTests
             Arg.Is<IReadOnlyList<string>>(a => a.Contains("--version")), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
         await h.Ffmpeg.Received(1).RunAsync("ffmpeg",
             Arg.Is<IReadOnlyList<string>>(a => a.Contains("-version")), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await h.Ffmpeg.Received(1).RunAsync("ffprobe",
+            Arg.Is<IReadOnlyList<string>>(a => a.Contains("-version")), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Services/Media/ImportWorkerTests.cs
@@ -20,7 +20,8 @@ public class ImportWorkerTests
         IClipMediaJobStore Store,
         IClipImportSource Source,
         IObjectStorageService Storage,
-        IClipImportUrlValidator Validator);
+        IClipImportUrlValidator Validator,
+        IFfmpegRunner Ffmpeg);
 
     // ffprobeStdout, when non-null, replaces the default empty-JSON ffmpeg/ffprobe stdout —
     // lets tests simulate "ffprobe says duration=240s" without rebuilding the harness.
@@ -73,7 +74,7 @@ public class ImportWorkerTests
             ffmpeg,
             monitor,
             NullLogger<ImportWorker>.Instance);
-        return new Harness(worker, store, source, storage, validator);
+        return new Harness(worker, store, source, storage, validator, ffmpeg);
     }
 
     private static ClaimedImportJob ImportJob(int attempt = 1) =>
@@ -82,6 +83,30 @@ public class ImportWorkerTests
             ImportSourceUrl: "https://medal.tv/clips/abc",
             Title: "from import",
             AttemptNumber: attempt);
+
+    [Fact]
+    public async Task ImportWorker_StartupProbe_ProbesYtdlpWithDoubleDashVersion()
+    {
+        var h = Build(new MediaJobOptions { Enabled = true, PollInterval = TimeSpan.FromMinutes(5), MaxAttempts = 3 });
+        h.Store.ClaimNextImportAsync(Arg.Any<TimeSpan>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((ClaimedImportJob?)null);
+
+        await h.Worker.StartAsync(CancellationToken.None);
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(2);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (h.Ffmpeg.ReceivedCalls().Count(c => c.GetMethodInfo().Name == nameof(IFfmpegRunner.RunAsync)) >= 3) break;
+            await Task.Delay(10);
+        }
+        await h.Worker.StopAsync(CancellationToken.None);
+
+        // yt-dlp needs GNU-style --version (a single dash misparses as bundled short flags);
+        // ffmpeg/ffprobe keep the single-dash form.
+        await h.Ffmpeg.Received(1).RunAsync("yt-dlp",
+            Arg.Is<IReadOnlyList<string>>(a => a.Contains("--version")), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await h.Ffmpeg.Received(1).RunAsync("ffmpeg",
+            Arg.Is<IReadOnlyList<string>>(a => a.Contains("-version")), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task ImportWorker_NoJob_ReturnsFalse()


### PR DESCRIPTION
Two production fixes found while deploying.

## 1. `yt-dlp` boot probe used the wrong version flag
`ImportWorker` reused the shared binary probe, which checks every tool with **`-version`** (correct for ffmpeg/ffprobe). yt-dlp parses `-version` as bundled short flags (`-v -e -r …`) and errors with `invalid rate limit "…"`, so the startup probe wrongly logged *"import jobs will fail"* and URL imports were dead. Parameterized the probe's version flag — **yt-dlp now uses `--version`**; ffmpeg/ffprobe keep `-version`.

## 2. DataProtection keys were ephemeral
ASP.NET Core was using an in-memory keyring (the `Using an ephemeral key repository` boot warning) — keys regenerate on every restart, breaking anything DP-protected. Now, **when `REDIS_URL` is configured, DataProtection keys persist to Redis** (reusing the existing connection multiplexer), so they survive restarts and are shared across replicas. Without Redis (local dev) it stays at the default. Adds `Microsoft.AspNetCore.DataProtection.StackExchangeRedis`; the conditional wiring lives in `RedisRegistration` (coverage denominator, per CLAUDE.md).

## Tests
- `ImportWorkerTests`: asserts the startup probe calls yt-dlp with `--version` (and ffmpeg with `-version`).
- `RedisRegistrationTests`: asserts DP keys persist to Redis when configured, default otherwise.
- Full server suite green via the pre-push hook.

These ship in the next `gankedtv-server` image build (post-merge) — then the yt-dlp warning clears and DP keys persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis configuration support for securely persisting application data protection keys, enabling enhanced security and redundancy across distributed deployments

* **Improvements**
  * Enhanced startup verification processes for media processing tools with improved version detection mechanisms, ensuring better compatibility with different tool versions and configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->