### PR TITLE
fix(storage): sign presigned URLs against public S3 host; responsive navbar

### DIFF
--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -157,6 +157,23 @@ builder.Services.AddSingleton<IAmazonS3>(sp =>
     });
 });
 
+// Presigning client: signs against the BROWSER-FACING host (S3_PUBLIC_URL) so SigV4's canonical
+// Host header matches the request the browser actually sends. Strict S3 servers (AIStor) reject
+// post-sign host rewriting; community MinIO tolerated it. Used ONLY for GetPreSignedURL — local
+// crypto, never a network call — so pointing it at the public host can't hairpin internal ops.
+// Falls back to the internal endpoint when no public URL is set (dev MinIO), so the dev flow is
+// unchanged: browser hits MinIO directly at the endpoint host the URL is signed with.
+builder.Services.AddKeyedSingleton<IAmazonS3>("presigner", (sp, _) =>
+{
+    var o = sp.GetRequiredService<IOptions<S3Options>>().Value;
+    var signingUrl = string.IsNullOrWhiteSpace(o.PublicUrl) ? o.Endpoint : o.PublicUrl;
+    return new AmazonS3Client(o.AccessKey, o.SecretKey, new AmazonS3Config
+    {
+        ServiceURL = signingUrl,
+        ForcePathStyle = true,
+    });
+});
+
 builder.Services.AddSingleton<IObjectStorageService, S3ObjectStorageService>();
 builder.Services.AddHostedService<BucketBootstrapHostedService>();
 

--- a/server/src/GankedTV.Api/Services/ObjectStorage/S3ObjectStorageService.cs
+++ b/server/src/GankedTV.Api/Services/ObjectStorage/S3ObjectStorageService.cs
@@ -1,5 +1,6 @@
 using Amazon.S3;
 using Amazon.S3.Model;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace GankedTV.Api.Services.ObjectStorage;
@@ -9,18 +10,28 @@ public sealed class S3ObjectStorageService : IObjectStorageService
     private static readonly TimeSpan DefaultExpiry = TimeSpan.FromMinutes(15);
 
     private readonly IAmazonS3 _s3;
+    // Signs presigned URLs against the browser-facing host (see the "presigner" registration in
+    // Program.cs). Separate from _s3 so real ops stay on the fast internal endpoint.
+    private readonly IAmazonS3 _presigner;
     private readonly S3Options _options;
     private readonly ILogger<S3ObjectStorageService> _logger;
 
     public S3ObjectStorageService(
         IAmazonS3 s3,
+        [FromKeyedServices("presigner")] IAmazonS3 presigner,
         IOptions<S3Options> options,
         ILogger<S3ObjectStorageService> logger)
     {
         _s3 = s3;
+        _presigner = presigner;
         _options = options.Value;
         _logger = logger;
     }
+
+    // The host SigV4 signs against: the browser-facing PublicUrl when set, else the internal
+    // endpoint (dev). Mirrors the "presigner" client's ServiceURL so the protocol matches.
+    private string SigningUrl =>
+        string.IsNullOrWhiteSpace(_options.PublicUrl) ? _options.Endpoint : _options.PublicUrl;
 
     public async Task EnsureBucketsAsync(CancellationToken ct = default)
     {
@@ -141,10 +152,10 @@ public sealed class S3ObjectStorageService : IObjectStorageService
             Verb = HttpVerb.PUT,
             ContentType = contentType,
             Expires = DateTime.UtcNow.Add(expiry ?? DefaultExpiry),
-            Protocol = ResolveProtocol(_options.Endpoint),
+            Protocol = ResolveProtocol(SigningUrl),
         };
 
-        return RewriteHost(_s3.GetPreSignedURL(request), _options.PublicUrl);
+        return RewriteHost(_presigner.GetPreSignedURL(request), _options.PublicUrl);
     }
 
     public string GetPresignedGetUrl(
@@ -158,10 +169,10 @@ public sealed class S3ObjectStorageService : IObjectStorageService
             Key = key,
             Verb = HttpVerb.GET,
             Expires = DateTime.UtcNow.Add(expiry ?? DefaultExpiry),
-            Protocol = ResolveProtocol(_options.Endpoint),
+            Protocol = ResolveProtocol(SigningUrl),
         };
 
-        return RewriteHost(_s3.GetPreSignedURL(request), _options.PublicUrl);
+        return RewriteHost(_presigner.GetPreSignedURL(request), _options.PublicUrl);
     }
 
     // GetPreSignedURL defaults to https:// regardless of the ServiceURL scheme. For MinIO dev
@@ -249,12 +260,11 @@ public sealed class S3ObjectStorageService : IObjectStorageService
         }
     }
 
-    // MinIO signs with the container-internal endpoint (http://minio:9000) but browsers
-    // need to hit the host-visible URL. Preserve path, query, and signature verbatim.
-    // Caveat: SigV4 canonicalizes the Host header into the signature, so post-sign host
-    // rewriting is technically a mismatch. MinIO permits it in practice; if we ever
-    // switch to strict S3, sign with PublicUrl directly and keep a second internal-only
-    // IAmazonS3 for admin ops (ListBuckets / PutBucket / DeleteObject).
+    // Presigned URLs are now signed against PublicUrl directly (the "presigner" client), so the
+    // SigV4 host is already correct and this is a defensive scheme/host normalization, not the
+    // primary mechanism. It stays for the dev/no-PublicUrl path (where it's a no-op) and to assert
+    // S3_PUBLIC_URL is a valid absolute URL. Strict S3 servers (AIStor) reject the old approach of
+    // signing with the internal endpoint and rewriting the host afterwards; community MinIO didn't.
     internal static string RewriteHost(string signedUrl, string? publicUrl)
     {
         if (string.IsNullOrWhiteSpace(publicUrl))

--- a/server/tests/GankedTV.Api.Tests/ObjectStorageTests.cs
+++ b/server/tests/GankedTV.Api.Tests/ObjectStorageTests.cs
@@ -315,6 +315,33 @@ public class ObjectStorageTests
     }
 
     [Fact]
+    public void GetPresignedGetUrl_SignsWithPresignerClient_NotOpsClient()
+    {
+        // Mirror of the PUT guard: the GET presign path must also use the presigner (public host),
+        // never the ops client (internal endpoint), or AIStor rejects the playback signature.
+        var ops = Substitute.For<IAmazonS3>();
+        var presigner = Substitute.For<IAmazonS3>();
+        presigner.GetPreSignedURL(Arg.Any<GetPreSignedUrlRequest>())
+            .Returns("https://cdn.example/clips/key?X-Amz-Signature=pub");
+        var options = Options.Create(new S3Options
+        {
+            Endpoint = "http://minio:9000",
+            AccessKey = "k",
+            SecretKey = "s",
+            PublicUrl = "https://cdn.example",
+            ClipsBucket = "clips",
+            ThumbnailsBucket = "thumbnails",
+        });
+
+        var url = new S3ObjectStorageService(ops, presigner, options, NullLogger<S3ObjectStorageService>.Instance)
+            .GetPresignedGetUrl("clips", "key");
+
+        url.Should().Be("https://cdn.example/clips/key?X-Amz-Signature=pub");
+        presigner.Received(1).GetPreSignedURL(Arg.Any<GetPreSignedUrlRequest>());
+        ops.DidNotReceive().GetPreSignedURL(Arg.Any<GetPreSignedUrlRequest>());
+    }
+
+    [Fact]
     public void RewriteHost_ThrowsOnMalformedPublicUrl()
     {
         var s3 = Substitute.For<IAmazonS3>();

--- a/server/tests/GankedTV.Api.Tests/ObjectStorageTests.cs
+++ b/server/tests/GankedTV.Api.Tests/ObjectStorageTests.cs
@@ -25,7 +25,8 @@ public class ObjectStorageTests
             GameCoversBucket = "game-covers",
             StreamCacheBucket = "stream-cache",
         });
-        return new S3ObjectStorageService(s3, options, NullLogger<S3ObjectStorageService>.Instance);
+        // Same mock for ops + presigner: presign tests keep mocking GetPreSignedURL on `s3`.
+        return new S3ObjectStorageService(s3, s3, options, NullLogger<S3ObjectStorageService>.Instance);
     }
 
     [Fact]
@@ -107,7 +108,7 @@ public class ObjectStorageTests
             AvatarsBucket = "clips", // and the avatars bucket — must not expose private media either
         });
 
-        await new S3ObjectStorageService(s3, options, NullLogger<S3ObjectStorageService>.Instance)
+        await new S3ObjectStorageService(s3, s3, options, NullLogger<S3ObjectStorageService>.Instance)
             .EnsureBucketsAsync();
 
         await s3.DidNotReceive().PutBucketPolicyAsync(
@@ -286,6 +287,34 @@ public class ObjectStorageTests
     }
 
     [Fact]
+    public void GetPresignedPutUrl_SignsWithPresignerClient_NotOpsClient()
+    {
+        // Ops client = internal endpoint; presigner = public host. Presigned URLs must be signed by
+        // the presigner so SigV4's canonical Host matches the browser's request (AIStor enforces
+        // this; community MinIO tolerated post-sign host rewriting).
+        var ops = Substitute.For<IAmazonS3>();
+        var presigner = Substitute.For<IAmazonS3>();
+        presigner.GetPreSignedURL(Arg.Any<GetPreSignedUrlRequest>())
+            .Returns("https://cdn.example/clips/key?X-Amz-Signature=pub");
+        var options = Options.Create(new S3Options
+        {
+            Endpoint = "http://minio:9000",
+            AccessKey = "k",
+            SecretKey = "s",
+            PublicUrl = "https://cdn.example",
+            ClipsBucket = "clips",
+            ThumbnailsBucket = "thumbnails",
+        });
+
+        var url = new S3ObjectStorageService(ops, presigner, options, NullLogger<S3ObjectStorageService>.Instance)
+            .GetPresignedPutUrl("clips", "key", "video/mp4");
+
+        url.Should().Be("https://cdn.example/clips/key?X-Amz-Signature=pub");
+        presigner.Received(1).GetPreSignedURL(Arg.Any<GetPreSignedUrlRequest>());
+        ops.DidNotReceive().GetPreSignedURL(Arg.Any<GetPreSignedUrlRequest>());
+    }
+
+    [Fact]
     public void RewriteHost_ThrowsOnMalformedPublicUrl()
     {
         var s3 = Substitute.For<IAmazonS3>();
@@ -388,7 +417,7 @@ public class ObjectStorageTests
             ClipsBucket = "clips",
             ThumbnailsBucket = "thumbnails",
         });
-        new S3ObjectStorageService(s3, opts, NullLogger<S3ObjectStorageService>.Instance)
+        new S3ObjectStorageService(s3, s3, opts, NullLogger<S3ObjectStorageService>.Instance)
             .GetPresignedPutUrl("clips", "key", "video/mp4");
 
         captured!.Protocol.Should().Be(Protocol.HTTPS);

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -163,6 +163,7 @@ function onSubmit() {
   if (!trimmed) return
   cancelInFlight()
   isFocused.value = false
+  isMobileSearchOpen.value = false
   void router.push({ name: 'search', query: { q: trimmed } })
 }
 
@@ -264,6 +265,26 @@ const isDrawerOpen = ref(false)
 watch(isDrawerOpen, (open) => {
   if (!open) nextTick(() => hamburgerRef.value?.focus())
 })
+
+// --- Mobile search overlay ----------------------------------------------------
+//
+// The inline search bar only renders ≥1281px (see template). On narrower screens a
+// search icon opens this full-width overlay over the nav bar, reusing the same query
+// + onSubmit so there's a single search implementation. Submit/Esc close it; we focus
+// the input on open and return focus to the trigger on close.
+const isMobileSearchOpen = ref(false)
+const mobileSearchRef = useTemplateRef<HTMLInputElement>('mobileSearchRef')
+const mobileSearchTriggerRef = useTemplateRef<HTMLButtonElement>('mobileSearchTriggerRef')
+
+function openMobileSearch() {
+  isMobileSearchOpen.value = true
+  nextTick(() => mobileSearchRef.value?.focus())
+}
+
+function closeMobileSearch() {
+  isMobileSearchOpen.value = false
+  nextTick(() => mobileSearchTriggerRef.value?.focus())
+}
 </script>
 
 <template>
@@ -271,13 +292,14 @@ watch(isDrawerOpen, (open) => {
     class="sticky top-0 z-50 h-16 border-b border-border bg-[color-mix(in_oklab,var(--color-surface-base)_85%,transparent)] backdrop-blur-[14px]"
   >
     <div class="mx-auto flex h-full max-w-360 min-w-0 items-center gap-5 px-6 *:shrink-0">
-      <!-- Logo -->
+      <!-- Logo — wordmark collapses to the mark alone on mobile to free top-bar space. -->
       <RouterLink
         to="/"
+        aria-label="GankedTV home"
         class="flex items-center gap-2 font-display text-[22px] font-bold uppercase tracking-[0.06em] text-text-primary no-underline"
       >
         <span class="logo__mark"></span>
-        GANKED<span class="logo__tv">.TV</span>
+        <span class="max-tablet:hidden">GANKED<span class="logo__tv">.TV</span></span>
       </RouterLink>
 
       <!-- Hamburger trigger (mobile only). Below the tablet breakpoint, Games / Trending /
@@ -293,8 +315,9 @@ watch(isDrawerOpen, (open) => {
         <IconMenu :size="16" />
       </button>
 
-      <!-- Nav links -->
-      <nav class="flex flex-1 items-center gap-1" aria-label="Main navigation">
+      <!-- Nav links (desktop). The whole row collapses into the drawer below the tablet
+           breakpoint so the mobile bar shows only the mark, hamburger, and actions. -->
+      <nav class="flex flex-1 items-center gap-1 max-tablet:hidden" aria-label="Main navigation">
         <RouterLink
           to="/"
           class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary"
@@ -304,21 +327,21 @@ watch(isDrawerOpen, (open) => {
         </RouterLink>
         <RouterLink
           to="/games"
-          class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary max-tablet:hidden"
+          class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary"
           :active-class="navLinkActive"
         >
           Games
         </RouterLink>
         <RouterLink
           to="/trending"
-          class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary max-tablet:hidden"
+          class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary"
           :active-class="navLinkActive"
         >
           Trending
         </RouterLink>
         <RouterLink
           to="/leaderboards"
-          class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary max-tablet:hidden"
+          class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary"
           :active-class="navLinkActive"
         >
           Leaderboards
@@ -424,20 +447,35 @@ watch(isDrawerOpen, (open) => {
 
       <!-- Actions -->
       <div class="ml-auto flex items-center gap-2">
-        <!-- Theme picker (Underground / Tactical / Arcade) -->
-        <ThemePicker />
-
-        <!-- Light/dark toggle -->
+        <!-- Mobile search trigger — the inline search bar is ≥1281px only, so narrower
+             screens get an icon that opens the full-width overlay below. -->
         <button
-          class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-all duration-150 hover:border-border-hover hover:text-text-primary"
-          :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
-          :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
-          :aria-pressed="!theme.isDark"
-          @click="theme.toggle()"
+          ref="mobileSearchTriggerRef"
+          type="button"
+          class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary min-[1281px]:hidden"
+          aria-label="Search"
+          @click="openMobileSearch"
         >
-          <IconSun v-if="theme.isDark" :size="16" />
-          <IconMoon v-else :size="16" />
+          <IconSearch :size="16" />
         </button>
+
+        <!-- Theme controls — collapse into the drawer below the tablet breakpoint. -->
+        <div class="flex items-center gap-2 max-tablet:hidden">
+          <!-- Theme picker (Underground / Tactical / Arcade) -->
+          <ThemePicker />
+
+          <!-- Light/dark toggle -->
+          <button
+            class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-all duration-150 hover:border-border-hover hover:text-text-primary"
+            :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
+            :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+            :aria-pressed="!theme.isDark"
+            @click="theme.toggle()"
+          >
+            <IconSun v-if="theme.isDark" :size="16" />
+            <IconMoon v-else :size="16" />
+          </button>
+        </div>
 
         <!-- Notifications bell (authenticated only) -->
         <button
@@ -459,11 +497,11 @@ watch(isDrawerOpen, (open) => {
           </span>
         </button>
 
-        <!-- Admin link (moderator / admin only) -->
+        <!-- Admin link (moderator / admin only) — in the drawer on mobile -->
         <RouterLink
           v-if="auth.isModerator"
           to="/admin"
-          class="inline-flex h-9 cursor-pointer items-center rounded-md border border-border bg-transparent px-3 font-heading text-[12px] font-bold uppercase tracking-wider text-text-secondary no-underline transition-colors duration-150 hover:border-border-hover hover:text-text-primary"
+          class="inline-flex h-9 cursor-pointer items-center rounded-md border border-border bg-transparent px-3 font-heading text-[12px] font-bold uppercase tracking-wider text-text-secondary no-underline transition-colors duration-150 hover:border-border-hover hover:text-text-primary max-tablet:hidden"
         >
           Admin
         </RouterLink>
@@ -498,6 +536,34 @@ watch(isDrawerOpen, (open) => {
           <UserAvatar :user="auth.user" :size="36" />
         </RouterLink>
       </div>
+    </div>
+
+    <!-- Mobile search overlay — fills the bar when the search icon is tapped (inline search
+         is ≥1281px only). Reuses the same query + onSubmit, so there's one search path;
+         Enter opens the /search results view. -->
+    <div
+      v-if="isMobileSearchOpen"
+      class="absolute inset-0 z-20 flex items-center gap-2 bg-surface-base px-6 min-[1281px]:hidden"
+    >
+      <IconSearch :size="16" class="shrink-0 text-text-muted" />
+      <input
+        ref="mobileSearchRef"
+        v-model="query"
+        type="search"
+        aria-label="Search clips and games"
+        placeholder="search clips, games"
+        class="min-w-0 flex-1 border-0 bg-transparent font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none"
+        @keydown.enter.prevent="onSubmit"
+        @keydown.escape="closeMobileSearch"
+      />
+      <button
+        type="button"
+        aria-label="Close search"
+        class="shrink-0 cursor-pointer px-2 font-mono text-xl leading-none text-text-muted transition-colors duration-150 hover:text-text-primary"
+        @click="closeMobileSearch"
+      >
+        ×
+      </button>
     </div>
 
     <!-- Bell popover — teleported to body so the header's backdrop-filter context can't trap or

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -474,7 +474,7 @@ function closeMobileSearch() {
             class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-all duration-150 hover:border-border-hover hover:text-text-primary"
             :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
             :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
-            :aria-pressed="!theme.isDark"
+            :aria-pressed="theme.isDark"
             @click="theme.toggle()"
           >
             <IconSun v-if="theme.isDark" :size="16" />

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -199,11 +199,16 @@ function updateBellPos() {
   }
 }
 
-const bellPopoverStyle = computed(() => ({
-  top: `${bellPopoverPos.value.top}px`,
-  right: `${bellPopoverPos.value.right}px`,
-  width: '360px',
-}))
+const bellPopoverStyle = computed(() => {
+  const right = bellPopoverPos.value.right
+  return {
+    top: `${bellPopoverPos.value.top}px`,
+    right: `${right}px`,
+    // Cap to the space between the right anchor and an 8px left gutter so the 360px panel
+    // never runs off a narrow viewport (it otherwise overflows the left edge on mobile).
+    width: `min(360px, calc(100vw - ${right}px - 8px))`,
+  }
+})
 
 async function toggleBell() {
   isBellOpen.value = !isBellOpen.value

--- a/web/src/components/MobileNavDrawer.vue
+++ b/web/src/components/MobileNavDrawer.vue
@@ -1,6 +1,16 @@
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, useId, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { useThemeStore } from '@/stores/theme'
+import ThemePicker from './ThemePicker.vue'
+import IconSun from './icons/IconSun.vue'
+import IconMoon from './icons/IconMoon.vue'
+
+// The drawer is the mobile home for everything the desktop bar exposes inline: the nav links
+// plus profile/admin and the theme controls (which collapse off the top bar on mobile).
+const auth = useAuthStore()
+const theme = useThemeStore()
 
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{ 'update:open': [boolean] }>()
@@ -113,7 +123,54 @@ const linkActive =
               <RouterLink to="/leaderboards" :class="linkBase" :active-class="linkActive">
                 Leaderboards
               </RouterLink>
+              <RouterLink
+                v-if="auth.isAuthenticated && auth.user"
+                :to="`/user/${auth.user.username}`"
+                :class="linkBase"
+                :active-class="linkActive"
+              >
+                Profile
+              </RouterLink>
+              <RouterLink
+                v-if="auth.isModerator"
+                to="/admin"
+                :class="linkBase"
+                :active-class="linkActive"
+              >
+                Admin
+              </RouterLink>
             </nav>
+
+            <!-- Theme controls + sign-in pinned to the bottom: they collapse off the mobile
+                 top bar, so the drawer is the only place to reach them on small screens. -->
+            <div class="mt-auto flex flex-col gap-3 border-t border-border px-5 py-4">
+              <div class="flex items-center justify-between gap-3">
+                <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">
+                  Theme
+                </span>
+                <div class="flex items-center gap-2">
+                  <ThemePicker />
+                  <button
+                    type="button"
+                    class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary"
+                    :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
+                    :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+                    :aria-pressed="!theme.isDark"
+                    @click="theme.toggle()"
+                  >
+                    <IconSun v-if="theme.isDark" :size="16" />
+                    <IconMoon v-else :size="16" />
+                  </button>
+                </div>
+              </div>
+              <RouterLink
+                v-if="!auth.isAuthenticated"
+                to="/login"
+                class="inline-flex h-9 items-center justify-center rounded-md bg-brand px-4 text-[13px] font-semibold uppercase tracking-[0.02em] text-white no-underline transition-colors duration-150 hover:bg-brand-light"
+              >
+                Sign In
+              </RouterLink>
+            </div>
           </aside>
         </Transition>
       </div>

--- a/web/src/components/MobileNavDrawer.vue
+++ b/web/src/components/MobileNavDrawer.vue
@@ -155,7 +155,7 @@ const linkActive =
                     class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary"
                     :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
                     :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
-                    :aria-pressed="!theme.isDark"
+                    :aria-pressed="theme.isDark"
                     @click="theme.toggle()"
                   >
                     <IconSun v-if="theme.isDark" :size="16" />


### PR DESCRIPTION
Two changes (one branch, per request): an urgent storage fix that unblocks uploads in prod, plus a responsive navbar.

## 1. `fix(storage)` — sign presigned URLs against the public host (AIStor)
Browser uploads were 403ing on the `PUT` to `cdn.ganked.tv`. The presigned URL was signed against the **internal** S3 endpoint host and then string-rewritten to `S3_PUBLIC_URL`. SigV4 canonicalizes the `Host` header into the signature, so the rewritten URL is a mismatch — **community MinIO tolerated it, but AIStor (strict S3) rejects it** with `SignatureDoesNotMatch`. The code comment even predicted this.

Fix: a dedicated keyed **`presigner`** `IAmazonS3` whose `ServiceURL` is `S3_PUBLIC_URL`, used **only** for `GetPreSignedURL` (local crypto — never a network call, so no hairpin). Real ops stay on the internal-endpoint client. The signed `Host` now matches the browser's request, so AIStor validates it.

- **Dev unchanged:** `PublicUrl=null` → presigner falls back to the internal `Endpoint` (verified by `appsettings.Development.json` + tests).
- `RewriteHost` stays as a defensive no-op + `S3_PUBLIC_URL` validation.
- Regression test asserts presigning uses the presigner, not the ops client; 25 ObjectStorage tests green.

## 2. `feat(web)` — responsive navbar
The top bar overflowed on phones. Now:
- Brand collapses to the logo mark alone on mobile (wordmark hidden; `aria-label` added).
- The whole desktop nav row collapses into the drawer on mobile; the drawer also gains **Profile, Admin, theme picker + light/dark toggle, and Sign In** — everything the desktop bar exposes is reachable.
- A **mobile search icon** opens a full-width overlay reusing the same `query`/`onSubmit` (one search path) with focus management + Esc/close.
- Theme controls + admin move off the mobile bar so it can't overflow (bell/upload/avatar stay).
- Notifications dropdown width is capped to the viewport so it no longer runs off the left edge on mobile.

type-check, lint, build, and 284 web unit tests all green.

## Deploy note
The storage fix lives in the `gankedtv-server` base layer, so the rebuilt `gankedtv-dedicated-encoder` includes it too — after merge, repull both on their hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile search overlay accessible from the mobile navigation bar
  * Integrated theme toggle controls in the mobile drawer menu
  * Added Profile, Admin, and Sign In links to the mobile navigation drawer

* **Improvements**
  * Reorganized mobile navigation layout for improved usability
  * Enhanced mobile header layout with better spacing and visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->