### PR TITLE
fix(discord): migrator transaction; fix(web): responsive bugs (#142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,7 @@ gankedtv/
 ## Git workflow
 
 - Do not add yourself (Claude / any AI) as a co-author. Never append `Co-Authored-By: Claude ...` trailers to commit messages.
+- Do not add AI attribution to PR descriptions either — no "🤖 Generated with Claude Code" (or similar) trailer in PR bodies.
 
 ## Code comments
 

--- a/discord/src/migrator.ts
+++ b/discord/src/migrator.ts
@@ -45,12 +45,18 @@ export async function runMigrations(sql: Sql): Promise<string[]> {
       for (const filename of all) {
         if (appliedSet.has(filename)) continue;
         const body = await readFile(join(MIGRATIONS_DIR, filename), 'utf8');
-        // begin() on the reserved connection inherits the same session, so the
-        // advisory lock held above also covers the DDL transaction.
-        await conn.begin(async (tx) => {
-          await tx.unsafe(body);
-          await tx`INSERT INTO discord_migrations (filename) VALUES (${filename})`;
-        });
+        // Reserved connections (sql.reserve()) don't expose .begin(), so drive the transaction
+        // with explicit statements on the same reserved session — that keeps the DDL under the
+        // advisory lock held above (and rolls back cleanly if a migration body throws).
+        await conn`BEGIN`;
+        try {
+          await conn.unsafe(body);
+          await conn`INSERT INTO discord_migrations (filename) VALUES (${filename})`;
+          await conn`COMMIT`;
+        } catch (err) {
+          await conn`ROLLBACK`;
+          throw err;
+        }
         ranNow.push(filename);
       }
       return ranNow;

--- a/web/src/components/AppNav.vue
+++ b/web/src/components/AppNav.vue
@@ -2,23 +2,20 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { useThemeStore } from '@/stores/theme'
 import { useNotificationsStore } from '@/stores/notifications'
 import { search, type SearchResponse } from '@/api/search'
 import ThemePicker from './ThemePicker.vue'
+import ThemeModeToggle from './ThemeModeToggle.vue'
 import UserAvatar from './UserAvatar.vue'
 import GameSearchResult from './GameSearchResult.vue'
 import NotificationsDropdown from './notifications/NotificationsDropdown.vue'
 import IconSearch from './icons/IconSearch.vue'
-import IconSun from './icons/IconSun.vue'
-import IconMoon from './icons/IconMoon.vue'
 import IconPlus from './icons/IconPlus.vue'
 import IconBell from './icons/IconBell.vue'
 import IconMenu from './icons/IconMenu.vue'
 import MobileNavDrawer from './MobileNavDrawer.vue'
 
 const auth = useAuthStore()
-const theme = useThemeStore()
 const router = useRouter()
 const notificationsStore = useNotificationsStore()
 
@@ -258,12 +255,9 @@ onBeforeUnmount(() => {
 })
 
 // --- Mobile nav drawer --------------------------------------------------------
-//
-// Below the `tablet` breakpoint (720px), Games/Trending/Leaderboards are hidden via
-// max-tablet:hidden on the desktop nav links. The hamburger + drawer surface them on
-// mobile so two top-level features aren't unreachable. Drawer owns its own escape /
-// route-change / backdrop close handling; we just track open-state here and return
-// focus to the hamburger when it closes.
+// Below 1024px the nav row, theme controls, and admin collapse into the drawer (the full bar
+// overflows at tablet/iPad widths). The drawer owns its own close handling; we return focus
+// to the hamburger when it closes.
 const hamburgerRef = useTemplateRef<HTMLButtonElement>('hamburgerRef')
 const isDrawerOpen = ref(false)
 
@@ -272,11 +266,8 @@ watch(isDrawerOpen, (open) => {
 })
 
 // --- Mobile search overlay ----------------------------------------------------
-//
-// The inline search bar only renders ≥1281px (see template). On narrower screens a
-// search icon opens this full-width overlay over the nav bar, reusing the same query
-// + onSubmit so there's a single search implementation. Submit/Esc close it; we focus
-// the input on open and return focus to the trigger on close.
+// Below 1281px the inline search bar is hidden; a search icon opens this overlay, reusing
+// the same query + onSubmit. Focus the input on open, return focus to the trigger on close.
 const isMobileSearchOpen = ref(false)
 const mobileSearchRef = useTemplateRef<HTMLInputElement>('mobileSearchRef')
 const mobileSearchTriggerRef = useTemplateRef<HTMLButtonElement>('mobileSearchTriggerRef')
@@ -307,12 +298,11 @@ function closeMobileSearch() {
         <span class="max-tablet:hidden">GANKED<span class="logo__tv">.TV</span></span>
       </RouterLink>
 
-      <!-- Hamburger trigger (mobile only). Below the tablet breakpoint, Games / Trending /
-           Leaderboards collapse into the drawer below. -->
+      <!-- Hamburger — shown below 1024px; opens the drawer. -->
       <button
         ref="hamburgerRef"
         type="button"
-        class="hidden h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary max-tablet:inline-flex"
+        class="hidden h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary max-lg:inline-flex"
         aria-label="Open menu"
         :aria-expanded="isDrawerOpen"
         @click="isDrawerOpen = true"
@@ -320,9 +310,8 @@ function closeMobileSearch() {
         <IconMenu :size="16" />
       </button>
 
-      <!-- Nav links (desktop). The whole row collapses into the drawer below the tablet
-           breakpoint so the mobile bar shows only the mark, hamburger, and actions. -->
-      <nav class="flex flex-1 items-center gap-1 max-tablet:hidden" aria-label="Main navigation">
+      <!-- Desktop nav links — collapse into the drawer below 1024px. -->
+      <nav class="flex flex-1 items-center gap-1 max-lg:hidden" aria-label="Main navigation">
         <RouterLink
           to="/"
           class="relative rounded-sm px-3.5 py-2 text-[13px] font-medium uppercase tracking-[0.04em] text-text-secondary no-underline transition-colors duration-150 hover:bg-surface-overlay hover:text-text-primary"
@@ -452,8 +441,7 @@ function closeMobileSearch() {
 
       <!-- Actions -->
       <div class="ml-auto flex items-center gap-2">
-        <!-- Mobile search trigger — the inline search bar is ≥1281px only, so narrower
-             screens get an icon that opens the full-width overlay below. -->
+        <!-- Mobile search trigger (inline bar is ≥1281px only). -->
         <button
           ref="mobileSearchTriggerRef"
           type="button"
@@ -464,22 +452,10 @@ function closeMobileSearch() {
           <IconSearch :size="16" />
         </button>
 
-        <!-- Theme controls — collapse into the drawer below the tablet breakpoint. -->
-        <div class="flex items-center gap-2 max-tablet:hidden">
-          <!-- Theme picker (Underground / Tactical / Arcade) -->
+        <!-- Theme controls — collapse into the drawer below 1024px. -->
+        <div class="flex items-center gap-2 max-lg:hidden">
           <ThemePicker />
-
-          <!-- Light/dark toggle -->
-          <button
-            class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-all duration-150 hover:border-border-hover hover:text-text-primary"
-            :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
-            :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
-            :aria-pressed="theme.isDark"
-            @click="theme.toggle()"
-          >
-            <IconSun v-if="theme.isDark" :size="16" />
-            <IconMoon v-else :size="16" />
-          </button>
+          <ThemeModeToggle />
         </div>
 
         <!-- Notifications bell (authenticated only) -->
@@ -506,7 +482,7 @@ function closeMobileSearch() {
         <RouterLink
           v-if="auth.isModerator"
           to="/admin"
-          class="inline-flex h-9 cursor-pointer items-center rounded-md border border-border bg-transparent px-3 font-heading text-[12px] font-bold uppercase tracking-wider text-text-secondary no-underline transition-colors duration-150 hover:border-border-hover hover:text-text-primary max-tablet:hidden"
+          class="inline-flex h-9 cursor-pointer items-center rounded-md border border-border bg-transparent px-3 font-heading text-[12px] font-bold uppercase tracking-wider text-text-secondary no-underline transition-colors duration-150 hover:border-border-hover hover:text-text-primary max-lg:hidden"
         >
           Admin
         </RouterLink>
@@ -543,9 +519,7 @@ function closeMobileSearch() {
       </div>
     </div>
 
-    <!-- Mobile search overlay — fills the bar when the search icon is tapped (inline search
-         is ≥1281px only). Reuses the same query + onSubmit, so there's one search path;
-         Enter opens the /search results view. -->
+    <!-- Mobile search overlay — fills the bar when the trigger is tapped; Enter opens /search. -->
     <div
       v-if="isMobileSearchOpen"
       class="absolute inset-0 z-20 flex items-center gap-2 bg-surface-base px-6 min-[1281px]:hidden"

--- a/web/src/components/KebabMenu.vue
+++ b/web/src/components/KebabMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, watch } from 'vue'
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import IconMoreVertical from '@/components/icons/IconMoreVertical.vue'
 import IconMoreHorizontal from '@/components/icons/IconMoreHorizontal.vue'
 
@@ -33,12 +33,26 @@ withDefaults(
 
 const open = ref(false)
 const rootRef = ref<HTMLDivElement | null>(null)
+const menuRef = ref<HTMLDivElement | null>(null)
+// Nudge the right-0 dropdown back on-screen when the trigger sits near a viewport edge.
+const shiftX = ref(0)
 
 function toggle() {
   open.value = !open.value
 }
 function close() {
   open.value = false
+}
+
+function clampToViewport() {
+  const el = menuRef.value
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  const margin = 8
+  if (rect.left < margin) shiftX.value = margin - rect.left
+  else if (rect.right > window.innerWidth - margin)
+    shiftX.value = window.innerWidth - margin - rect.right
+  else shiftX.value = 0
 }
 
 function onItemClick(item: KebabMenuItem) {
@@ -62,7 +76,9 @@ watch(open, (isOpen) => {
   if (isOpen) {
     window.addEventListener('keydown', onKeydown)
     window.addEventListener('click', onDocumentClick, true)
+    nextTick(clampToViewport)
   } else {
+    shiftX.value = 0
     window.removeEventListener('keydown', onKeydown)
     window.removeEventListener('click', onDocumentClick, true)
   }
@@ -97,7 +113,9 @@ onBeforeUnmount(() => {
 
     <div
       v-if="open"
+      ref="menuRef"
       role="menu"
+      :style="shiftX ? { transform: `translateX(${shiftX}px)` } : undefined"
       class="absolute right-0 top-full z-20 mt-1 min-w-36 rounded-md border border-border-strong bg-surface-overlay shadow-[0_4px_20px_rgba(0,0,0,0.4)]"
     >
       <button

--- a/web/src/components/MobileNavDrawer.vue
+++ b/web/src/components/MobileNavDrawer.vue
@@ -2,15 +2,11 @@
 import { nextTick, onMounted, onUnmounted, ref, useId, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { useThemeStore } from '@/stores/theme'
 import ThemePicker from './ThemePicker.vue'
-import IconSun from './icons/IconSun.vue'
-import IconMoon from './icons/IconMoon.vue'
+import ThemeModeToggle from './ThemeModeToggle.vue'
 
-// The drawer is the mobile home for everything the desktop bar exposes inline: the nav links
-// plus profile/admin and the theme controls (which collapse off the top bar on mobile).
+// Mobile home for everything the desktop bar exposes: nav links, profile/admin, theme controls.
 const auth = useAuthStore()
-const theme = useThemeStore()
 
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{ 'update:open': [boolean] }>()
@@ -141,8 +137,7 @@ const linkActive =
               </RouterLink>
             </nav>
 
-            <!-- Theme controls + sign-in pinned to the bottom: they collapse off the mobile
-                 top bar, so the drawer is the only place to reach them on small screens. -->
+            <!-- Theme controls + sign-in pinned to the bottom (off the mobile top bar). -->
             <div class="mt-auto flex flex-col gap-3 border-t border-border px-5 py-4">
               <div class="flex items-center justify-between gap-3">
                 <span class="font-mono text-[10px] uppercase tracking-widest text-text-muted">
@@ -150,17 +145,7 @@ const linkActive =
                 </span>
                 <div class="flex items-center gap-2">
                   <ThemePicker />
-                  <button
-                    type="button"
-                    class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-colors duration-150 hover:border-border-hover hover:text-text-primary"
-                    :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
-                    :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
-                    :aria-pressed="theme.isDark"
-                    @click="theme.toggle()"
-                  >
-                    <IconSun v-if="theme.isDark" :size="16" />
-                    <IconMoon v-else :size="16" />
-                  </button>
+                  <ThemeModeToggle />
                 </div>
               </div>
               <RouterLink

--- a/web/src/components/ThemeModeToggle.vue
+++ b/web/src/components/ThemeModeToggle.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { useThemeStore } from '@/stores/theme'
+import IconSun from './icons/IconSun.vue'
+import IconMoon from './icons/IconMoon.vue'
+
+const theme = useThemeStore()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-text-secondary transition-all duration-150 hover:border-border-hover hover:text-text-primary"
+    :title="theme.isDark ? 'Switch to light' : 'Switch to dark'"
+    :aria-label="theme.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+    :aria-pressed="theme.isDark"
+    @click="theme.toggle()"
+  >
+    <IconSun v-if="theme.isDark" :size="16" />
+    <IconMoon v-else :size="16" />
+  </button>
+</template>

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -304,6 +304,11 @@ onMounted(() => {
         </div>
       </div>
 
+      <!-- Mobile hero — the desktop hero is hidden < 900px and the list skips items[0]. -->
+      <div class="mt-7 mb-10 min-[900px]:hidden">
+        <ClipCard :clip="hero" @click="router.push({ name: 'clip', params: { id: hero.id } })" />
+      </div>
+
       <!-- Secondary row (4 cards) -->
       <div v-if="secondary.length" class="mt-7 mb-10">
         <div class="mb-5 flex items-baseline justify-between gap-4">


### PR DESCRIPTION
Bundles the Discord-bot crash fix with the #142 web responsive fixes (per request).

## fix(discord): migrator transaction on the reserved connection
The bot crash-looped on boot — `conn.begin is not a function`. `runMigrations` reserves a connection (`sql.reserve()`) to hold a session-scoped advisory lock, then called `conn.begin(...)` per migration; under Bun + postgres 3.4.9 the reserved connection exposes the query interface but **not `.begin()` at runtime** (types disagree, so it compiled). Replaced with explicit `BEGIN`/`COMMIT`/`ROLLBACK` on the same reserved session — same lock coverage, no `.begin()`. The migrator path is excluded from coverage (needs a real Postgres), so it wasn't caught.

## fix(web): responsive bugs
Closes #142.
- **Mobile feed:** the desktop hero is hidden < 900px and the list is `items.slice(1)`, so the hero clip (incl. a featured-only feed) never showed on mobile — add a mobile-only card.
- **Navbar at iPad/mid widths:** the full desktop bar overflowed; the nav row, theme controls, and admin now collapse into the drawer below **1024px** (`max-lg`, raised from 720px).
- **Profile kebab:** clamp the `right-0` dropdown to the viewport so it can't spill off a screen edge when the action cluster wraps left on narrow screens. Fix lives in the reusable `KebabMenu`, so it also covers ClipView.
- **DRY:** extracted the duplicated light/dark toggle into `ThemeModeToggle`; used the built-in `max-lg:` token instead of a repeated magic number.

Validated: full server + web suites green via pre-push (type-check, lint, build, 284 web tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-only hero section on the home view.

* **Bug Fixes**
  * Fixed dropdown menu positioning to stay within viewport bounds.

* **UI/UX Improvements**
  * Adjusted navigation responsive breakpoints for better layout on larger screens.
  * Extracted theme toggle into dedicated component for consistency across navigation and drawer.
  * Updated navigation comments clarifying mobile and desktop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->