### PR TITLE
fix(web): keep newest clip in homepage Latest Drops when a Clip of the Day is featured

### DIFF
--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -54,8 +54,18 @@ const hero = computed<ClipFeedItem | null>(() => featured.value ?? items.value[0
 // True only when the hero is actually today's featured pick — the badge must
 // not lie about provenance.
 const heroIsFeatured = computed(() => featured.value !== null)
-const secondary = computed(() => items.value.slice(1, 5))
-const grid = computed(() => items.value.slice(5))
+// Bands below the hero, with the hero's own clip removed. The hero isn't always
+// items[0] — when a featured "Clip of the Day" is shown it sits outside the feed
+// ordering — so slicing from a fixed offset would drop the newest clip (items[0])
+// and let the featured pick render twice. Filtering by hero id keeps the newest
+// clip visible and dedupes the featured pick; with no featured pick it collapses
+// back to the original items[1..] behaviour.
+const rest = computed(() => {
+  const heroId = hero.value?.id
+  return heroId ? items.value.filter((c) => c.id !== heroId) : items.value
+})
+const secondary = computed(() => rest.value.slice(0, 4))
+const grid = computed(() => rest.value.slice(4))
 
 const showFollowingEmpty = computed(
   () =>

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -54,12 +54,9 @@ const hero = computed<ClipFeedItem | null>(() => featured.value ?? items.value[0
 // True only when the hero is actually today's featured pick — the badge must
 // not lie about provenance.
 const heroIsFeatured = computed(() => featured.value !== null)
-// Bands below the hero, with the hero's own clip removed. The hero isn't always
-// items[0] — when a featured "Clip of the Day" is shown it sits outside the feed
-// ordering — so slicing from a fixed offset would drop the newest clip (items[0])
-// and let the featured pick render twice. Filtering by hero id keeps the newest
-// clip visible and dedupes the featured pick; with no featured pick it collapses
-// back to the original items[1..] behaviour.
+// The hero isn't always items[0] — a featured "Clip of the Day" sits outside the
+// feed ordering. Slicing the bands from a fixed offset would drop the newest clip
+// and double-render the featured pick, so exclude the hero clip by id instead.
 const rest = computed(() => {
   const heroId = hero.value?.id
   return heroId ? items.value.filter((c) => c.id !== heroId) : items.value

--- a/web/src/views/__tests__/HomeView.spec.ts
+++ b/web/src/views/__tests__/HomeView.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+import { createPinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import type { ClipFeedItem, ClipFeedPage } from '@/api/clips'
+
+const feed = vi.fn()
+const featured = vi.fn()
+vi.mock('@/api/clips', async () => {
+  const actual = await vi.importActual<typeof import('@/api/clips')>('@/api/clips')
+  return {
+    ...actual,
+    clips: {
+      ...actual.clips,
+      feed: (q?: unknown) => feed(q),
+      featured: () => featured(),
+    },
+  }
+})
+
+import HomeView from '../HomeView.vue'
+
+beforeEach(() => {
+  feed.mockReset()
+  featured.mockReset()
+})
+
+function makeClip(id: string, overrides: Partial<ClipFeedItem> = {}): ClipFeedItem {
+  return {
+    id,
+    title: `Clip ${id}`,
+    description: null,
+    thumbnailUrl: `https://cdn.test/${id}.jpg`,
+    durationSecs: 10,
+    viewCount: 0,
+    likeCount: 0,
+    createdAt: new Date().toISOString(),
+    author: { id: 'u1', username: 'creator', avatarUrl: null },
+    game: null,
+    tags: [],
+    likedByMe: false,
+    shareCode: id,
+    ...overrides,
+  }
+}
+
+function makePage(items: ClipFeedItem[], nextCursor: string | null = null): ClipFeedPage {
+  return { items, nextCursor }
+}
+
+function makeRouter(): Router {
+  const stub = defineComponent({ render: () => h('div') })
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: stub },
+      { path: '/login', name: 'login', component: stub },
+      { path: '/clip/:id', name: 'clip', component: stub },
+      { path: '/user/:username', name: 'user', component: stub },
+      { path: '/upload', name: 'upload', component: stub },
+      { path: '/trending', name: 'trending', component: stub },
+      { path: '/games', name: 'games', component: stub },
+      { path: '/feed/reels', name: 'reels', component: stub },
+    ],
+  })
+}
+
+async function mountHome(): Promise<VueWrapper> {
+  const router = makeRouter()
+  await router.push('/')
+  await router.isReady()
+  const wrapper = mount(HomeView, { global: { plugins: [router, createPinia()] } })
+  await flushPromises()
+  return wrapper
+}
+
+// Text of the two feed bands below the hero (Latest Drops + main grid). The hero
+// renders outside any .feed-grid (and is duplicated across the desktop/mobile
+// breakpoints), so scoping to .feed-grid isolates the non-hero items cleanly.
+function bandText(wrapper: VueWrapper): string {
+  return wrapper
+    .findAll('.feed-grid')
+    .map((g) => g.text())
+    .join(' ')
+}
+
+describe('HomeView — newest clip stays visible below the hero', () => {
+  it('keeps the newest clip in the bands when a Clip of the Day is featured', async () => {
+    // items[0] (the newest clip) is A; the featured pick X is a different, older
+    // clip chosen by engagement, so it does not sit at items[0].
+    feed.mockResolvedValue(
+      makePage([
+        makeClip('a', { title: 'Newest Clip' }),
+        makeClip('b'),
+        makeClip('c'),
+        makeClip('d'),
+        makeClip('e'),
+      ]),
+    )
+    featured.mockResolvedValue(makeClip('x', { title: 'Featured Pick' }))
+
+    const wrapper = await mountHome()
+
+    // Hero is the featured pick…
+    expect(wrapper.text()).toContain('Clip of the Day')
+    expect(wrapper.text()).toContain('Featured Pick')
+    // …and the newest clip must still render in the bands below it.
+    expect(bandText(wrapper)).toContain('Newest Clip')
+  })
+
+  it('does not render the featured clip twice when it is also in the feed page', async () => {
+    feed.mockResolvedValue(
+      makePage([
+        makeClip('a', { title: 'Newest Clip' }),
+        makeClip('x', { title: 'Featured Pick' }),
+        makeClip('c'),
+        makeClip('d'),
+      ]),
+    )
+    featured.mockResolvedValue(makeClip('x', { title: 'Featured Pick' }))
+
+    const wrapper = await mountHome()
+
+    expect(bandText(wrapper)).toContain('Newest Clip')
+    // The featured clip is the hero; it must not also appear in the bands below.
+    expect(bandText(wrapper)).not.toContain('Featured Pick')
+  })
+
+  it('falls back to the newest clip as hero and lists the rest when there is no featured pick', async () => {
+    feed.mockResolvedValue(
+      makePage([
+        makeClip('a', { title: 'Newest Clip' }),
+        makeClip('b', { title: 'Second Clip' }),
+        makeClip('c', { title: 'Third Clip' }),
+      ]),
+    )
+    featured.mockResolvedValue(null)
+
+    const wrapper = await mountHome()
+
+    // Hero falls back to the newest clip, labelled as a plain featured clip.
+    expect(wrapper.text()).toContain('Featured Clip')
+    expect(wrapper.text()).toContain('Newest Clip')
+    // The hero clip is not duplicated in the bands; the rest are listed there.
+    expect(bandText(wrapper)).not.toContain('Newest Clip')
+    expect(bandText(wrapper)).toContain('Second Clip')
+    expect(bandText(wrapper)).toContain('Third Clip')
+  })
+})

--- a/web/src/views/__tests__/HomeView.spec.ts
+++ b/web/src/views/__tests__/HomeView.spec.ts
@@ -4,6 +4,7 @@ import { createRouter, createMemoryHistory, type Router } from 'vue-router'
 import { createPinia } from 'pinia'
 import { defineComponent, h } from 'vue'
 import type { ClipFeedItem, ClipFeedPage } from '@/api/clips'
+import LoadMoreButton from '@/components/LoadMoreButton.vue'
 
 const feed = vi.fn()
 const featured = vi.fn()
@@ -125,6 +126,25 @@ describe('HomeView — newest clip stays visible below the hero', () => {
     expect(bandText(wrapper)).toContain('Newest Clip')
     // The featured clip is the hero; it must not also appear in the bands below.
     expect(bandText(wrapper)).not.toContain('Featured Pick')
+  })
+
+  it('keeps the newest clip in the bands after loading more older clips', async () => {
+    // First page is newest-first with a cursor so "Load more" is offered.
+    feed.mockResolvedValueOnce(
+      makePage([makeClip('a', { title: 'Newest Clip' }), makeClip('b'), makeClip('c')], 'cursor-1'),
+    )
+    featured.mockResolvedValue(makeClip('x', { title: 'Featured Pick' }))
+
+    const wrapper = await mountHome()
+    expect(bandText(wrapper)).toContain('Newest Clip')
+
+    // Loading more appends OLDER clips; the newest must stay in the bands.
+    feed.mockResolvedValueOnce(makePage([makeClip('d', { title: 'Older Clip' }), makeClip('e')]))
+    wrapper.findComponent(LoadMoreButton).vm.$emit('load')
+    await flushPromises()
+
+    expect(bandText(wrapper)).toContain('Newest Clip')
+    expect(bandText(wrapper)).toContain('Older Clip')
   })
 
   it('falls back to the newest clip as hero and lists the rest when there is no featured pick', async () => {


### PR DESCRIPTION
## Summary

The homepage "Latest Drops" / feed bands assumed the hero is always `items[0]` (the newest clip). When a featured "Clip of the Day" is shown, that assumption breaks and the newest clip silently disappears from the page.

## What's here
- Derive the bands below the hero from `items` minus the hero's own clip, instead of the fixed offsets `slice(1, 5)` / `slice(5)`.
- This keeps the newest clip visible when the hero is the featured pick, and stops the featured clip rendering twice (hero + a band).
- Adds `HomeView.spec.ts` covering the featured-set, featured-also-in-feed (dedupe), and no-featured (unchanged-path) cases.

Closes #144

## How to test
1. `cd web && bun run test:unit -- --run src/views/__tests__/HomeView.spec.ts`
2. Manual: with infra up (`make up`), ensure there's a featured clip (a clip with a like/view today) and a newer clip than it, then load the homepage — the newest clip now appears in "Latest Drops" and the featured clip is not duplicated below the hero.

<details>
<summary><b>Context for reviewers</b></summary>

### Files changed
- `web/src/views/HomeView.vue` — replaced the fixed-offset `secondary`/`grid` computeds with a `rest` computed (`items` minus `hero.id`); `secondary = rest.slice(0, 4)`, `grid = rest.slice(4)`.
- `web/src/views/__tests__/HomeView.spec.ts` — new spec; scopes assertions to `.feed-grid` so the hero (duplicated across the desktop/mobile breakpoints) is excluded from the band checks.

### Root cause
`hero = featured.value ?? items[0]`. `GET /clips/featured` returns a daily engagement-ranked pick whenever any public+ready clip has a like/view since 00:00 UTC, so it's non-null on any active day and almost never equals `items[0]`. With the old `slice(1, 5)` / `slice(5)` offsets, `items[0]` then landed in no band at all, and the featured clip (also present in the feed) rendered twice.

### Risk / blast radius
- Frontend-only, single view. The no-featured path is provably unchanged (`hero === items[0]` ⇒ `rest === items[1..]`), covered by the third test. Backend feed query untouched.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where clips could be dropped or duplicated in the feed. The hero clip and feed now render correctly without gaps or repeats.

* **Tests**
  * Added comprehensive test coverage for feed and hero clip rendering scenarios, including featured pick behavior and load-more functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->