### PR TITLE
fix(secrets): fetch Sentry DSNs + shared config from Vaultwarden (optional tier)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -46,6 +46,9 @@ JWT_AUDIENCE=gankedtv-web
 OAUTH_STATE_SECRET=                      # >= 32 bytes once any OAuth provider is configured
 WEB_ORIGIN=https://example.com           # REQUIRED, public origin of the web app
 CORS_ORIGINS=https://example.com         # REQUIRED, comma-separated (WEB_ORIGIN is always allowed)
+# Comma-separated emails promoted to admin at API boot (user must register/login once first).
+# Promote-only — see DEPLOYMENT.md "Admin bootstrap". May also live in the optional Vaultwarden manifest.
+ADMIN_EMAILS=
 
 # ── Host port mappings (your reverse proxy / firewall fronts these) ──
 WEB_HTTP_PORT=8080

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -28,11 +28,13 @@ S3_PUBLIC_URL=https://cdn.example.com    # REQUIRED
 MINIO_LICENSE_FILE=./secrets/minio.license
 
 # ── Web app (runtime config; injected into config.js at container start, not baked) ──
+# These are ALL public — they ship to every browser — and the web bundle has no vault client, so
+# they MUST live here (NOT in Vaultwarden), unlike the API/bot secrets below.
 # Browser-facing API URL (through your reverse proxy). REQUIRED for the web app to reach the API.
 VITE_API_BASE_URL=https://api.example.com
 VITE_USE_SECURE_COOKIES=true             # skip localStorage token persistence (HttpOnly-cookie strategy)
 VITE_GA_MEASUREMENT_ID=                  # GA4 id (empty = analytics off)
-VITE_SENTRY_DSN=                         # web GlitchTip DSN (empty = off)
+VITE_SENTRY_DSN=                         # web GlitchTip DSN (empty = off) — host-supplied, not vaulted
 VITE_SENTRY_ENVIRONMENT=Production
 VITE_SENTRY_RELEASE=                     # release/tag for Sentry (empty = package version)
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.01
@@ -68,6 +70,10 @@ IGDB_CLIENT_SECRET=
 
 # ── Error monitoring (optional; one GlitchTip project per app) ──
 # *_RELEASE tags are optional — unset, each app falls back to its assembly/package version.
+# The API/bot Sentry keys below are in each app's OPTIONAL Vaultwarden manifest: if you run
+# Vaultwarden, store them in the "Secrets - PROD" collection (named exactly as here) and leave these
+# blank — the app fetches them at boot, best-effort (a missing key never fails boot). A non-empty
+# value here wins over the vault. (Web's VITE_SENTRY_* is NOT vaulted — see the web block above.)
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=Production
 DISCORD_SENTRY_DSN=

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -222,22 +222,29 @@ Vault items are named exactly like the env keys, scoped by org + collection so t
 different values in DEV vs PROD without colliding.
 
 **Resilience.** Fetches are sequential (the API rate-limits 30 req/min/IP) and one-shot at
-startup/build — rotate a secret by restarting/rebuilding. In **Production** a required secret that
+startup/build — rotate a secret by restarting/rebuilding. In **Production** a **required** secret that
 can't be fetched **fails the boot** with a clear, Vaultwarden-specific error; in development a
 missing/unreachable vault falls back to `.env`. The API's fetch runs **before** the fail-fast
 validation above, so a prod boot supplied with only the two bootstrap vars has the vault populate
 `DATABASE_URL` / `JWT_SECRET` / `S3_*` / … and then passes validation.
 
+**Two tiers — required vs optional.** Each app fetches a *required* manifest (above behaviour) and an
+*optional* manifest that is **always best-effort**: a key missing/errored in the vault is silently
+skipped and never fails boot, in any environment. Opt-in features (Sentry/GlitchTip) and shared
+config live in the optional tier so the published image stays generic for deployers who don't use
+them. An empty env value (e.g. compose passing `SENTRY_DSN: ${SENTRY_DSN:-}`) counts as "unset", so
+the vault still fills it; a **non-empty** env value always wins over the vault.
+
 **Per-app manifest** (the keys each app fetches):
 
-| App | Keys |
-|---|---|
-| API | `DATABASE_URL`, `JWT_SECRET`, `OAUTH_STATE_SECRET`, `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_PUBLIC_URL`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`, `REDIS_URL`, `WEB_ORIGIN`, `CORS_ORIGINS` |
-| Discord bot | `DISCORD_BOT_TOKEN`, `DISCORD_BOT_APP_ID`, `DISCORD_DATABASE_URL` |
-| Web build | *(none)* — the web image is runtime-configured; `VITE_*` are supplied as container env at deploy (see [Web frontend](#web-frontend-runtime-config)), not fetched from the vault. |
+| App | Required keys | Optional keys (best-effort) |
+|---|---|---|
+| API | `DATABASE_URL`, `JWT_SECRET`, `OAUTH_STATE_SECRET`, `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_PUBLIC_URL`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`, `REDIS_URL`, `WEB_ORIGIN`, `CORS_ORIGINS` | `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`, `ADMIN_EMAILS`, `IGDB_SYNC_ENABLED` |
+| Discord bot | `DISCORD_BOT_TOKEN`, `DISCORD_BOT_APP_ID`, `DISCORD_DATABASE_URL` | `DISCORD_SENTRY_DSN`, `DISCORD_SENTRY_ENVIRONMENT`, `DISCORD_SENTRY_RELEASE`, `DISCORD_SENTRY_TRACES_SAMPLE_RATE`, `GANKEDTV_PUBLIC_BASE` |
+| Web build | *(none)* — the web image is runtime-configured; `VITE_*` are supplied as container env at deploy (see [Web frontend](#web-frontend-runtime-config)), not fetched from the vault. The web Sentry DSN is `VITE_SENTRY_DSN` in the host `.env`. |
 
-`SENTRY_DSN` is intentionally **absent** — there's no Sentry integration yet (tracked in #124); add
-it to the manifests when that lands.
+The web bundle has **no vault client**, and all its `VITE_*` values (API URL, GlitchTip DSN, GA id)
+are *public* — they ship to every browser — so they stay host-supplied via `.env`, not vaulted.
 
 **CI.** The web build (`web.yml`) only **compiles** — it does **not** fetch from Vaultwarden, so neither
 PR nor `main`/release CI depends on vault availability or runner-IP whitelisting. The published web

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -241,7 +241,7 @@ the vault still fills it; a **non-empty** env value always wins over the vault.
 |---|---|---|
 | API | `DATABASE_URL`, `JWT_SECRET`, `OAUTH_STATE_SECRET`, `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_PUBLIC_URL`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`, `REDIS_URL`, `WEB_ORIGIN`, `CORS_ORIGINS` | `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`, `ADMIN_EMAILS`, `IGDB_SYNC_ENABLED` |
 | Discord bot | `DISCORD_BOT_TOKEN`, `DISCORD_BOT_APP_ID`, `DISCORD_DATABASE_URL` | `DISCORD_SENTRY_DSN`, `DISCORD_SENTRY_ENVIRONMENT`, `DISCORD_SENTRY_RELEASE`, `DISCORD_SENTRY_TRACES_SAMPLE_RATE`, `GANKEDTV_PUBLIC_BASE` |
-| Web build | *(none)* — the web image is runtime-configured; `VITE_*` are supplied as container env at deploy (see [Web frontend](#web-frontend-runtime-config)), not fetched from the vault. The web Sentry DSN is `VITE_SENTRY_DSN` in the host `.env`. |
+| Web build | *(none)* — the web image is runtime-configured; `VITE_*` are supplied as container env at deploy (see [Web frontend](#web-frontend-runtime-config)), not fetched from the vault. | *(none)* — the web Sentry DSN is `VITE_SENTRY_DSN`, host-supplied in `.env`. |
 
 The web bundle has **no vault client**, and all its `VITE_*` values (API URL, GlitchTip DSN, GA id)
 are *public* — they ship to every browser — so they stay host-supplied via `.env`, not vaulted.
@@ -262,6 +262,34 @@ serialises migration runs via a `__EFMigrationsHistory` lock, so multiple replic
 flag enabled apply migrations safely (they wait, they don't race). For clarity you may still prefer
 to gate the flag to one replica or run migrations as a separate init step, but it isn't required for
 correctness. The flag accepts `true`/`1`/`yes`/`on`.
+
+## Admin bootstrap (`ADMIN_EMAILS`)
+
+There is no special "first user" — everyone registers as a normal user. To grant admin, set
+`ADMIN_EMAILS` (comma-separated) on the API. At each boot [AdminBootstrap](server/src/GankedTV.Api/HostedServices/AdminBootstrap.cs)
+promotes any **existing** user whose email matches (case-insensitive) to `role=admin`.
+
+- The user must have **registered/logged in at least once first** (the row has to exist); the
+  promotion then lands on the next API start. Re-runs are idempotent (already-admin rows are skipped).
+- **Promote-only:** removing an email does **not** demote. To revoke, run SQL directly —
+  `UPDATE users SET role='user' WHERE email='…'`.
+- Source order is env `ADMIN_EMAILS` → appsettings `AdminEmails`. It's also in the API's *optional*
+  Vaultwarden manifest, so it can live in `Secrets - PROD` instead of the host `.env` if you prefer.
+
+## Backups
+
+Durable state lives in three named volumes ([docker-compose.prod.yml](docker-compose.prod.yml)); back
+up the first two — losing them is unrecoverable:
+
+| Volume | Holds | Back up with |
+|---|---|---|
+| `postgres_data` | All app data (users, clips metadata, subscriptions). | `pg_dump` (logical) or a volume/filesystem snapshot with the DB quiesced. |
+| `minio_data` | The clip masters + covers/avatars (the object store). On a split deploy this is the storage host's dataset instead. | Volume/dataset snapshot (or `mc mirror` to off-box storage). |
+| `redis_data` | Cache **and** DataProtection keys. Not business data, but losing the DP keys invalidates every issued auth cookie/token, forcing all users to re-login. | Optional — persist if you want auth sessions to survive a Redis wipe. |
+
+Postgres and the object store must be restored **together** (a clip row whose master is missing, or
+vice-versa, is a broken clip). There's no built-in backup scheduler — wire `pg_dump` + a snapshot into
+your host's cron/backup tooling.
 
 ## Health endpoints
 

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -1,6 +1,6 @@
 // Importing loadEnv runs its side effect (merging the repo-root .env into process.env) and exposes
 // loadVaultwardenSecrets, which main() awaits before loadConfig().
-import { loadVaultwardenSecrets } from './loadEnv.ts';
+import { loadVaultwardenSecrets, optionalVaultwardenManifest } from './loadEnv.ts';
 
 import * as Sentry from '@sentry/bun';
 import { Client, GatewayIntentBits, REST, Routes, type Interaction } from 'discord.js';
@@ -32,6 +32,11 @@ const log: PollerLogger = {
 async function main(): Promise<void> {
   // Pull secrets from Vaultwarden (no-op unless the bootstrap vars are set) before reading config.
   await loadVaultwardenSecrets(process.env);
+  // Opt-in config (Sentry DSN, etc.): best-effort, never fails boot if absent from the vault.
+  await loadVaultwardenSecrets(process.env, {
+    manifest: optionalVaultwardenManifest,
+    optional: true,
+  });
   const config = loadConfig();
 
   // No-op unless DISCORD_SENTRY_DSN is set; before the enabled check so boot crashes still report.

--- a/discord/src/loadEnv.ts
+++ b/discord/src/loadEnv.ts
@@ -56,34 +56,51 @@ export function loadRootEnv(
   mergeFirstWins(target, parseEnvFile(readFileSync(envPath, 'utf8')));
 }
 
-// The bot's required secrets, fetched from Vaultwarden by these exact names. No SENTRY_DSN — no
-// Sentry integration yet.
+// The bot's required secrets, fetched from Vaultwarden by these exact names. In Production a missing
+// key fails boot — these must exist in the vault. Opt-in config goes in optionalVaultwardenManifest.
 export const vaultwardenManifest = [
   'DISCORD_BOT_TOKEN',
   'DISCORD_BOT_APP_ID',
   'DISCORD_DATABASE_URL',
 ] as const;
 
+// Best-effort secrets/config: fetched when present, silently skipped when absent (loaded with
+// `optional: true`), so the published image stays generic for deployers who don't use these opt-in
+// features (e.g. Sentry/GlitchTip).
+export const optionalVaultwardenManifest = [
+  'DISCORD_SENTRY_DSN',
+  'DISCORD_SENTRY_ENVIRONMENT',
+  'DISCORD_SENTRY_RELEASE',
+  'DISCORD_SENTRY_TRACES_SAMPLE_RATE',
+  'GANKEDTV_PUBLIC_BASE',
+] as const;
+
 // Fetches the bot's secrets from Vaultwarden and layers them into `target` via mergeFirstWins, so a
 // shell/.env value still beats the vault. No-op when the bootstrap vars are unset. Production fails
-// fast on a missing/errored secret; dev falls back to .env.
+// fast on a missing/errored secret; dev falls back to .env. With `optional: true` it's always
+// best-effort (never throws on a missing/errored key) regardless of environment.
 export async function loadVaultwardenSecrets(
   target: Record<string, string | undefined> = process.env,
-  opts: { manifest?: readonly string[]; fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+  opts: {
+    manifest?: readonly string[];
+    optional?: boolean;
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;
+  } = {},
 ): Promise<void> {
   const apiUrl = target.VAULTWARDEN_API_URL?.trim();
   const apiKey = target.VAULTWARDEN_API_KEY?.trim();
   if (!apiUrl || !apiKey) return; // opt-in: no bootstrap vars → no-op
 
   const environment = target.ASPNETCORE_ENVIRONMENT ?? target.NODE_ENV;
-  const failFast = environment?.toLowerCase() === 'production';
+  const failFast = !opts.optional && environment?.toLowerCase() === 'production';
   const fetched = await fetchSecrets({
     apiUrl,
     apiKey,
     collection: resolveCollection(target),
     manifest: opts.manifest ?? vaultwardenManifest,
     organization: target.VAULTWARDEN_ORG?.trim() || undefined,
-    // Production fails fast on anything missing or errored; dev falls back to .env on both.
+    // Production fails fast on anything missing or errored; dev (and the optional tier) fall back.
     throwIfMissing: failFast,
     throwOnError: failFast,
     alreadySet: (key) => Boolean(target[key]?.trim()),

--- a/discord/tests/loadEnv.test.ts
+++ b/discord/tests/loadEnv.test.ts
@@ -6,7 +6,9 @@ import {
   loadRootEnv,
   loadVaultwardenSecrets,
   mergeFirstWins,
+  optionalVaultwardenManifest,
   parseEnvFile,
+  vaultwardenManifest,
 } from '../src/loadEnv.ts';
 
 describe('parseEnvFile', () => {
@@ -157,5 +159,39 @@ describe('loadVaultwardenSecrets', () => {
     await expect(
       loadVaultwardenSecrets(target, { fetchImpl, manifest: ['DISCORD_BOT_TOKEN'] }),
     ).rejects.toThrow(/not found/);
+  });
+
+  test('optional tier is best-effort in production: missing key does not throw, present is filled', async () => {
+    const target: Record<string, string | undefined> = {
+      VAULTWARDEN_API_URL: 'https://vault.test',
+      VAULTWARDEN_API_KEY: 'k',
+      ASPNETCORE_ENVIRONMENT: 'Production', // would fail-fast on the required tier
+    };
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const key = decodeURIComponent(String(input).split('/secret/')[1]!.split('?')[0]!);
+      return key === 'DISCORD_SENTRY_DSN'
+        ? new Response(JSON.stringify({ name: key, value: 'https://k@glitchtip/2' }), {
+            status: 200,
+          })
+        : new Response('{"error":"secret not found"}', { status: 404 });
+    }) as typeof fetch;
+
+    await loadVaultwardenSecrets(target, {
+      fetchImpl,
+      manifest: optionalVaultwardenManifest,
+      optional: true,
+    });
+
+    expect(target.DISCORD_SENTRY_DSN).toBe('https://k@glitchtip/2'); // present → filled
+    expect(target.GANKEDTV_PUBLIC_BASE).toBeUndefined(); // missing → skipped, no throw
+  });
+});
+
+describe('manifests', () => {
+  test('Sentry is in the optional tier, not the required one, and the two are disjoint', () => {
+    expect(optionalVaultwardenManifest).toContain('DISCORD_SENTRY_DSN');
+    expect(vaultwardenManifest as readonly string[]).not.toContain('DISCORD_SENTRY_DSN');
+    const required = new Set<string>(vaultwardenManifest);
+    expect(optionalVaultwardenManifest.some((k) => required.has(k))).toBe(false);
   });
 });

--- a/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
+++ b/server/src/GankedTV.Api/Configuration/VaultwardenSecretsLoader.cs
@@ -13,8 +13,8 @@ namespace GankedTV.Api.Configuration;
 public sealed class VaultwardenSecretsLoader
 {
     /// <summary>
-    /// The server's required secrets, fetched by these exact names. No <c>SENTRY_DSN</c> — there's
-    /// no Sentry integration yet.
+    /// The server's required secrets, fetched by these exact names. In Production a missing key
+    /// fails boot — these must exist in the vault. Opt-in config goes in <see cref="OptionalManifest"/>.
     /// </summary>
     public static readonly IReadOnlyList<string> Manifest =
     [
@@ -36,6 +36,21 @@ public sealed class VaultwardenSecretsLoader
         "REDIS_URL",
         "WEB_ORIGIN",
         "CORS_ORIGINS",
+    ];
+
+    /// <summary>
+    /// Best-effort secrets/config: fetched from the vault when present, silently skipped when
+    /// absent (loaded with <c>failFast: false</c>), so the published image stays generic for
+    /// deployers who don't use these opt-in features (e.g. Sentry/GlitchTip).
+    /// </summary>
+    public static readonly IReadOnlyList<string> OptionalManifest =
+    [
+        "SENTRY_DSN",
+        "SENTRY_ENVIRONMENT",
+        "SENTRY_RELEASE",
+        "SENTRY_TRACES_SAMPLE_RATE",
+        "ADMIN_EMAILS",
+        "IGDB_SYNC_ENABLED",
     ];
 
     private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);

--- a/server/src/GankedTV.Api/Program.cs
+++ b/server/src/GankedTV.Api/Program.cs
@@ -80,6 +80,16 @@ if (vaultwardenOptions.IsConfigured)
             Environment.SetEnvironmentVariable)
         .GetAwaiter()
         .GetResult();
+    // Opt-in config (Sentry DSN, etc.): best-effort, never fails boot, so a deployer who doesn't
+    // provision these in the vault still starts. Runs before UseSentry so the DSN is visible.
+    vaultwardenLoader
+        .LoadAsync(
+            failFast: false,
+            Environment.GetEnvironmentVariable,
+            Environment.SetEnvironmentVariable,
+            VaultwardenSecretsLoader.OptionalManifest)
+        .GetAwaiter()
+        .GetResult();
 }
 
 // Error monitoring (Sentry → GlitchTip). Opt-in: the SDK throws on a null DSN and treats "" as

--- a/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
+++ b/server/tests/GankedTV.Api.Tests/Configuration/VaultwardenSecretsLoaderTests.cs
@@ -36,11 +36,31 @@ public class VaultwardenSecretsLoaderTests
     }
 
     [Fact]
-    public void Manifest_ContainsRequiredKeys_AndNoSentryDsn()
+    public void Manifest_ContainsRequiredKeys_AndSentryIsOptionalNotRequired()
     {
         VaultwardenSecretsLoader.Manifest.Should().HaveCount(18);
         VaultwardenSecretsLoader.Manifest.Should().Contain(["DATABASE_URL", "JWT_SECRET", "S3_SECRET_KEY", "CORS_ORIGINS"]);
+        // Sentry is opt-in: it must live in the optional (best-effort) tier, never the required one,
+        // so a deployer without a DSN still boots.
         VaultwardenSecretsLoader.Manifest.Should().NotContain("SENTRY_DSN");
+        VaultwardenSecretsLoader.OptionalManifest.Should().Contain("SENTRY_DSN");
+        VaultwardenSecretsLoader.OptionalManifest.Should().NotIntersectWith(VaultwardenSecretsLoader.Manifest);
+    }
+
+    [Fact]
+    public async Task LoadAsync_OptionalManifest_AppliesPresentKeys_AndSkipsMissingWithoutThrowing()
+    {
+        // Mixed: SENTRY_DSN resolves, the rest 404. failFast:false mirrors the Program.cs optional call.
+        var handler = new TestHttpMessageHandler()
+            .OnGet(SecretPrefix + "SENTRY_DSN", HttpStatusCode.OK, """{"name":"SENTRY_DSN","value":"https://k@glitchtip/1"}""")
+            .OnGet(SecretPrefix, HttpStatusCode.NotFound, """{"error":"secret not found"}""");
+        var (get, set, store) = FakeEnv();
+
+        var applied = await Build(handler).LoadAsync(
+            failFast: false, get, set, manifest: VaultwardenSecretsLoader.OptionalManifest);
+
+        applied.Should().ContainSingle().Which.Should().Be("SENTRY_DSN");
+        store["SENTRY_DSN"].Should().Be("https://k@glitchtip/1");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #147

## Problem
GlitchTip error monitoring was silent in production. All three apps fetch a *fixed* Vaultwarden manifest at boot and **none included any Sentry DSN** — the manifests still carried a stale `No SENTRY_DSN — no Sentry integration yet` comment (the Sentry integration #124 landed later). A DSN placed in the vault was never fetched; with no `SENTRY_DSN` in the container env either, the SDK treated `""` as disabled. Dev worked only because the dev `.env` carries the DSN directly.

Adding the keys to the *required* manifest would be wrong: in Production a missing required key **crashes boot**, but Sentry is opt-in/off-by-default and the published images must stay generic.

## Fix
A **best-effort optional manifest tier** alongside the required one — fetched when present, silently skipped when absent (never fails boot, any environment).

- **API** — `VaultwardenSecretsLoader.OptionalManifest` (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`, `ADMIN_EMAILS`, `IGDB_SYNC_ENABLED`); second `LoadAsync(failFast: false, …)` in `Program.cs` before `UseSentry`.
- **Bot** — `optionalVaultwardenManifest` (`DISCORD_SENTRY_*` + `GANKEDTV_PUBLIC_BASE`); `loadVaultwardenSecrets` gains an `optional` flag forcing best-effort.
- **Web** — unchanged. Its `VITE_*` are public (they ship to every browser) and host-supplied via `.env`; the bundle has no vault client. Documented as `.env`-only.
- Tests for the optional tier (server + discord), `DEPLOYMENT.md` two-tier manifest table, `.env.prod.example` annotations.

An empty env value (e.g. compose `SENTRY_DSN: ${SENTRY_DSN:-}`) counts as unset so the vault fills it; a non-empty env value always wins.

## Verification
- `make ci-server` — 1098 pass / 0 fail; coverage 95.23% line, 85.77% branch (gate 85/85); `dotnet format` clean.
- `make ci-discord` — 140 pass / 0 fail; coverage 99.36% line, 98.96% func (gate 85).

## Operator follow-up after deploy
- Name vault items **exactly** `SENTRY_DSN` / `DISCORD_SENTRY_DSN` in the **Secrets - PROD** collection. API + bot pick them up on next boot of the new image — no compose change needed.
- **Web Sentry is not vaulted:** add `VITE_SENTRY_DSN=…` (+ optional env/release) to the deploy-host `.env` and recreate the `web` container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated environment variable documentation to clarify public variable requirements and configuration best practices
  * Enhanced deployment guide detailing required vs. optional secret management and startup behavior

* **Chores**
  * Improved startup resilience: optional configuration now loads best-effort without causing boot failures when unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->