### PR TITLE
fix(discord): gate bot on api health to kill boot-race connection error

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -164,6 +164,11 @@ services:
       DISCORD_SENTRY_RELEASE: ${DISCORD_SENTRY_RELEASE:-}
     depends_on:
       postgres: { condition: service_healthy }
+      # Gate on api health too: startPoller fires its first poll immediately on
+      # boot, so without this the bot races the api container and the first round
+      # throws ECONNREFUSED (noisy GlitchTip boot error). api's healthcheck
+      # transitively waits on postgres/redis/minio.
+      api: { condition: service_healthy }
     restart: unless-stopped
     networks: [internal]
 


### PR DESCRIPTION
## What

Add \`api: { condition: service_healthy }\` to the \`discord\` service's \`depends_on\` in [docker-compose.prod.yml](docker-compose.prod.yml).

## Why

A GlitchTip error fired from the bot in Production:

\`\`\`
Error: Unable to connect. Is the computer able to access the url?
  at discord/src/api.ts:95   (fetch in get())
  at discord/src/poller.ts:85  (pollOnce → api.getFeed)
\`\`\`

It's a **boot-ordering race**, not a false positive. Breadcrumbs show the failure landed `1ms` after "Discord client ready" (`11:14:48.595` ready → `.596` poll threw). \`startPoller\` kicks off its first \`tick()\` immediately on boot, and the prod \`discord\` service only waited on **postgres** health — not the **api**. So the first poll raced the api container and threw ECONNREFUSED, captured by \`Sentry.captureException\` in the poll loop.

## Fix

The \`api\` service already defines a \`/health/live\` healthcheck (\`start_period: 40s\`) and itself gates on postgres/redis/minio, so gating \`discord\` on \`api: service_healthy\` transitively waits for the full stack before the bot polls.

- **Prod only** — dev runs the API as a host process (\`dotnet watch\`), which \`depends_on\` can't gate.
- **Boot race only** — \`service_healthy\` applies on \`up\`, not later restarts. A genuine mid-run API outage still throws and alerts (correct: real outage, not boot noise). The poller's 30s self-healing retry covers it.
- No bot code change.

## Verification

\`\`\`bash
docker compose -f docker-compose.prod.yml --profile discord config   # parses; discord depends_on api: service_healthy
\`\`\`

On next deploy: \`docker compose ps\` shows api \`healthy\` before the bot logs "Starting poller"; no new "Unable to connect" boot event in GlitchTip.